### PR TITLE
Review and fix React specific test issues

### DIFF
--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import ComponentTypeEdit from './ComponentTypeEdit'
 import {
   ComponentContext,
@@ -10,6 +11,8 @@ import { DataContext } from './context'
 import { Data } from '@defra/forms-model'
 
 describe('ComponentTypeEdit', () => {
+  const { getByText } = screen
+
   let mockData: Data
 
   const RenderWithContext = ({ children, stateProps = {} }) => {
@@ -44,6 +47,8 @@ describe('ComponentTypeEdit', () => {
     }
   })
 
+  afterEach(cleanup)
+
   describe('Checkbox', () => {
     let stateProps
 
@@ -58,7 +63,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('title input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -69,7 +74,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('help text input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -80,7 +85,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('hide title checkbox hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -92,7 +97,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('component name input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -104,7 +109,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('make checkbox field optional hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -119,7 +124,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('select list hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -145,7 +150,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('title input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -156,7 +161,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('help text input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -167,7 +172,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('hide title checkbox hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -179,7 +184,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('component name input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -191,7 +196,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('make checkbox field optional hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -206,7 +211,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('select list hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -232,7 +237,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('title input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -243,7 +248,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('help text input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -254,7 +259,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('hide title checkbox hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -266,7 +271,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('component name input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -278,7 +283,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('make checkbox field optional hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -293,7 +298,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('select list hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -319,7 +324,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('title input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -330,7 +335,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('help text input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -341,7 +346,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('hide title checkbox hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>
@@ -353,7 +358,7 @@ describe('ComponentTypeEdit', () => {
     })
 
     test('component name input hint text is rendered correctly', () => {
-      const { getByText } = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <ComponentTypeEdit page={mockData.pages[0]} />
         </RenderWithContext>

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import { DataContext } from './context'
 import {
   ComponentContext,
@@ -9,6 +10,8 @@ import {
 import { FieldEdit } from './field-edit'
 
 describe('Field Edit', () => {
+  const { getByText } = screen
+
   const data = {
     pages: [
       {
@@ -28,6 +31,7 @@ describe('Field Edit', () => {
       }
     ]
   }
+
   const dataValue = { data, save: jest.fn() }
 
   const TestComponentContextProvider = ({
@@ -52,8 +56,10 @@ describe('Field Edit', () => {
     )
   }
 
+  afterEach(cleanup)
+
   test('Help text changes', () => {
-    const { container, getByText } = render(
+    const { container } = render(
       <TestComponentContextProvider
         dataValue={dataValue}
         componentValue={false}
@@ -61,6 +67,7 @@ describe('Field Edit', () => {
         <FieldEdit />
       </TestComponentContextProvider>
     )
+
     expect(container).toHaveTextContent('Enter the name to show for this field')
 
     expect(container).toHaveTextContent(

--- a/designer/client/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/designer/client/src/components/Autocomplete/Autocomplete.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import { Autocomplete } from './Autocomplete'
 import { RenderWithContext } from '../../../../test/helpers/renderers'
 
 describe('AutocompleteField', () => {
+  const { getByText } = screen
+
   let stateProps
-  let page
 
   beforeEach(() => {
     stateProps = {
@@ -16,21 +18,23 @@ describe('AutocompleteField', () => {
       }
     }
 
-    page = render(
+    render(
       <RenderWithContext stateProps={stateProps}>
         <Autocomplete />
       </RenderWithContext>
     )
   })
 
+  afterEach(cleanup)
+
   test('should display display correct title', () => {
     const text = 'Autocomplete'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('should display display correct helptext', () => {
     const text =
       "Add the autocomplete attribute to this field. For example, 'on' or 'given-name'."
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 })

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.test.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { cleanup, render } from '@testing-library/react'
 import { ComponentCreateList } from './ComponentCreateList'
 
 describe('ComponentCreateList', () => {
+  afterEach(cleanup)
+
   test('should match snapshot', async () => {
     const onSelectComponent = jest.fn()
     const { asFragment } = render(

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
@@ -1,5 +1,6 @@
 import React, { useReducer } from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { act, cleanup, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { DataContext } from '../../context'
 import { Data } from '@defra/forms-model'
@@ -13,6 +14,8 @@ import { ListsEditorContextProvider } from '../../reducers/list/listsEditorReduc
 import { ListContextProvider } from '../../reducers/listReducer'
 
 describe('ComponentListSelect', () => {
+  const { getByText } = screen
+
   const data = {
     pages: [
       {
@@ -47,6 +50,7 @@ describe('ComponentListSelect', () => {
       }
     ]
   }
+
   const dataValue = { data, save: jest.fn() }
 
   interface IContextProvider {
@@ -82,6 +86,8 @@ describe('ComponentListSelect', () => {
     )
   }
 
+  afterEach(cleanup)
+
   test('Lists all available lists', () => {
     // - when
     const { container } = render(
@@ -111,7 +117,7 @@ describe('ComponentListSelect', () => {
 
   test('Selecting a different list changes the edit link', async () => {
     // - when
-    const { container, getByText } = render(
+    const { container } = render(
       <TestComponentContextProvider
         dataValue={dataValue}
         componentValue={false}
@@ -121,14 +127,14 @@ describe('ComponentListSelect', () => {
     )
 
     const select = container.querySelector('select')!
-    await userEvent.selectOptions(select, 'myList')
+    await act(() => userEvent.selectOptions(select, 'myList'))
 
     // - then
     expect(getByText('Edit My list')).toBeInTheDocument()
   })
 
   test('should render strings correctly', () => {
-    const { getByText } = render(
+    render(
       <TestComponentContextProvider
         dataValue={dataValue}
         componentValue={false}
@@ -160,7 +166,7 @@ describe('ComponentListSelect', () => {
     )
 
     const select = container.querySelector('select')!
-    await userEvent.selectOptions(select, 'Select a list')
+    await act(() => userEvent.selectOptions(select, 'Select a list'))
 
     // - then
     expect(

--- a/designer/client/src/components/CssClasses/CssClasses.test.tsx
+++ b/designer/client/src/components/CssClasses/CssClasses.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import { CssClasses } from './CssClasses'
 import { RenderWithContext } from '../../../../test/helpers/renderers'
 
 describe('CssClasses', () => {
+  afterEach(cleanup)
+
   describe('CssClassField', () => {
+    const { getByText } = screen
+
     let stateProps
-    let page
 
     beforeEach(() => {
       stateProps = {
@@ -17,7 +21,7 @@ describe('CssClasses', () => {
         }
       }
 
-      page = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <CssClasses />
         </RenderWithContext>
@@ -26,13 +30,13 @@ describe('CssClasses', () => {
 
     test('should display display correct title', () => {
       const text = 'Classes'
-      expect(page.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display display correct helptext', () => {
       const text =
         'Apply CSS classes to this field. For example, govuk-input govuk-!-width-full'
-      expect(page.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
   })
 })

--- a/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.test.tsx
+++ b/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.test.tsx
@@ -1,12 +1,17 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { act, cleanup, render } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { CustomValidationMessage } from './CustomValidationMessage'
 import { RenderWithContext } from '../../../../test/helpers/renderers'
 
 describe('CssClasses', () => {
+  afterEach(cleanup)
+
   describe('CssClassField', () => {
+    const { getByLabelText, getByText } = screen
+
     let stateProps
-    let page
 
     beforeEach(() => {
       stateProps = {
@@ -17,7 +22,7 @@ describe('CssClasses', () => {
         }
       }
 
-      page = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <CustomValidationMessage />
         </RenderWithContext>
@@ -28,18 +33,18 @@ describe('CssClasses', () => {
       const title = 'Validation message'
       const hint =
         'Enter the validation message to show when a validation error occurs'
-      expect(page.getByText(title)).toBeInTheDocument()
-      expect(page.getByText(hint)).toBeInTheDocument()
+      expect(getByText(title)).toBeInTheDocument()
+      expect(getByText(hint)).toBeInTheDocument()
     })
 
     test('value should change and be displayed correctly', async () => {
-      const { getByLabelText } = page
-      const input = getByLabelText('Validation message')
-      expect(input.value).toBe('')
-      await fireEvent.change(input, {
-        target: { value: "It's wrong!" }
-      })
-      expect(input.value).toBe("It's wrong!")
+      const $input = getByLabelText('Validation message') as HTMLInputElement
+      expect($input.value).toBe('')
+
+      await act(() => userEvent.clear($input))
+      await act(() => userEvent.type($input, "It's wrong!"))
+
+      expect($input.value).toBe("It's wrong!")
     })
   })
 })

--- a/designer/client/src/components/ErrorMessage/ErrorMessage.test.tsx
+++ b/designer/client/src/components/ErrorMessage/ErrorMessage.test.tsx
@@ -1,13 +1,16 @@
 import React from 'react'
-import { render, cleanup, screen } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { render, cleanup } from '@testing-library/react'
 import { ErrorMessage } from '.'
 
 describe('ErrorMessage component', () => {
   afterEach(cleanup)
 
+  const { getByText } = screen
+
   it('renders children text', async () => {
     render(<ErrorMessage className="123">Error 123</ErrorMessage>)
-    expect(screen.findByText('Error 123')).toBeDefined()
+    expect(getByText('Error 123')).toBeDefined()
   })
 
   it('passed down className', async () => {
@@ -19,6 +22,6 @@ describe('ErrorMessage component', () => {
 
   it('renders hidden accessibility error span', () => {
     render(<ErrorMessage className="123">Error 123</ErrorMessage>)
-    expect(screen.getByText('Error:')).toHaveClass('govuk-visually-hidden')
+    expect(getByText('Error:')).toHaveClass('govuk-visually-hidden')
   })
 })

--- a/designer/client/src/components/FieldEditors/date-field-edit.test.tsx
+++ b/designer/client/src/components/FieldEditors/date-field-edit.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import { DateFieldEdit } from './date-field-edit'
 import { RenderWithContext } from '../../../../test/helpers/renderers'
 
 describe('date field edit', () => {
+  afterEach(cleanup)
+
+  const { getByText } = screen
+
   describe('date field edit fields', () => {
     let stateProps
-    let textFieldEditPage
 
     beforeEach(() => {
       stateProps = {
@@ -17,7 +21,7 @@ describe('date field edit', () => {
         }
       }
 
-      textFieldEditPage = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <DateFieldEdit />
         </RenderWithContext>
@@ -26,27 +30,27 @@ describe('date field edit', () => {
 
     test('should display details link title', () => {
       const text = 'Additional settings'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display future title', () => {
       const text = 'Max days in the future'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display future help text ', () => {
       const text = 'Determines the latest date users can enter'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display past title', () => {
       const text = 'Max days in the past'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display past help text ', () => {
       const text = 'Determines the earliest date users can enter'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
   })
 })

--- a/designer/client/src/components/FieldEditors/details-edit.test.tsx
+++ b/designer/client/src/components/FieldEditors/details-edit.test.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { cleanup, render } from '@testing-library/react'
 import { ComponentContext } from '../../reducers/component/componentReducer'
 import DetailsEdit from './details-edit'
 
 describe('details-edit', () => {
+  afterEach(cleanup)
+
   function TestComponentWithContext({ children }) {
     return (
       <ComponentContext.Provider

--- a/designer/client/src/components/FieldEditors/number-field-edit.test.tsx
+++ b/designer/client/src/components/FieldEditors/number-field-edit.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import { NumberFieldEdit } from './number-field-edit'
 import { RenderWithContext } from '../../../../test/helpers/renderers'
 
 describe('Number field edit', () => {
+  afterEach(cleanup)
+
   describe('Number field edit fields', () => {
+    const { getByText } = screen
+
     let stateProps
-    let textFieldEditPage
 
     beforeEach(() => {
       stateProps = {
@@ -17,7 +21,7 @@ describe('Number field edit', () => {
         }
       }
 
-      textFieldEditPage = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <NumberFieldEdit />
         </RenderWithContext>
@@ -26,48 +30,48 @@ describe('Number field edit', () => {
 
     test('should display details link title', () => {
       const text = 'Additional settings'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display min title', () => {
       const text = 'Min'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display min help text ', () => {
       const text = 'Specifies the lowest number users can enter'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display max title', () => {
       const text = 'Max'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display max help text ', () => {
       const text = 'Specifies the highest number users can enter'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display precision title', () => {
       const text = 'Precision'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display precision help text ', () => {
       const text =
         'Specifies the number of decimal places users can enter. For example, to allow users to enter numbers with up to two decimal places, set this to 2'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display prefix help text ', () => {
       const text = 'Specifies the prefix of the field.'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display suffix help text ', () => {
       const text = 'Specifies the suffix of the field.'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
   })
 })

--- a/designer/client/src/components/FieldEditors/text-field-edit.test.tsx
+++ b/designer/client/src/components/FieldEditors/text-field-edit.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
+import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { TextFieldEdit } from './text-field-edit'
 import { RenderWithContext } from '../../../../test/helpers/renderers'
 
 describe('Text field edit', () => {
+  const { getByText } = screen
+
   describe('Text field edit fields', () => {
     let stateProps
-    let textFieldEditPage
 
     beforeEach(() => {
       stateProps = {
@@ -17,7 +19,7 @@ describe('Text field edit', () => {
         }
       }
 
-      textFieldEditPage = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <TextFieldEdit />
         </RenderWithContext>
@@ -26,60 +28,60 @@ describe('Text field edit', () => {
 
     test('should display details link title', () => {
       const text = 'Additional settings'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display min length title', () => {
       const text = 'Min length'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display min length help text ', () => {
       const text = 'Specifies the minimum number of characters users can enter'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display max length title', () => {
       const text = 'Max length'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display max length help text ', () => {
       const text = 'Specifies the maximum number of characters users can enter'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display length title', () => {
       const text = 'Length'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display length help text ', () => {
       const text =
         'Specifies the exact character length users must enter. Using this setting negates any values you set for Min length or Max length.'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display regex title', () => {
       const text = 'Regex'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display regex help text ', () => {
       const text =
         "Specifies a regular expression to validate users' inputs. Use JavaScript syntax."
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display autocomplete title', () => {
       const text = 'Autocomplete'
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display autocomplete help text ', () => {
       const text =
         "Add the autocomplete attribute to this field. For example, 'on' or 'given-name'."
-      expect(textFieldEditPage.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
   })
 })

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -1,5 +1,11 @@
 import { screen } from '@testing-library/dom'
-import { act, render, waitFor } from '@testing-library/react'
+import {
+  act,
+  cleanup,
+  render,
+  type RenderResult,
+  waitFor
+} from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { DataContext } from '../../context'
 import { Router } from 'react-router-dom'
@@ -9,18 +15,14 @@ import { Page } from '.'
 const history = createMemoryHistory()
 history.push('')
 
-const customRender = (ui, { providerProps, ...renderOptions }) => {
-  const rendered = render(
+function customRender(element: React.JSX.Element, providerProps): RenderResult {
+  return render(
     <Router history={history}>
-      <DataContext.Provider value={providerProps}>{ui}</DataContext.Provider>
-    </Router>,
-    renderOptions
+      <DataContext.Provider value={providerProps}>
+        {element}
+      </DataContext.Provider>
+    </Router>
   )
-  return {
-    ...rendered,
-    rerender: (ui, options) =>
-      customRender(ui, { container: rendered.container, ...options })
-  }
 }
 
 const data = {
@@ -71,6 +73,8 @@ const providerProps = {
 }
 
 describe('Page', () => {
+  afterEach(cleanup)
+
   const { findByTestId, getByText, queryByTestId } = screen
 
   test('PageEdit can be shown/hidden successfully', async () => {
@@ -81,9 +85,7 @@ describe('Page', () => {
         id={'aa'}
         layout={{}}
       />,
-      {
-        providerProps
-      }
+      providerProps
     )
 
     await act(() => userEvent.click(getByText('Edit page')))
@@ -107,9 +109,7 @@ describe('Page', () => {
         id={'aa'}
         layout={{}}
       />,
-      {
-        providerProps
-      }
+      providerProps
     )
 
     await act(() => userEvent.click(getByText('Create component')))
@@ -127,10 +127,9 @@ describe('Page', () => {
         id={'aa'}
         layout={{}}
       />,
-      {
-        providerProps
-      }
+      providerProps
     )
+
     expect(getByText('Edit page')).toBeTruthy()
     expect(getByText('Create component')).toBeTruthy()
     expect(getByText('Preview')).toBeTruthy()
@@ -144,9 +143,7 @@ describe('Page', () => {
         id={'aa'}
         layout={{}}
       />,
-      {
-        providerProps
-      }
+      providerProps
     )
 
     await act(() => userEvent.click(getByText('Create component')))

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render } from '@testing-library/react'
 import { screen } from '@testing-library/dom'
+import { act, render, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { DataContext } from '../../context'
 import { Router } from 'react-router-dom'
 import { createMemoryHistory } from 'history'
@@ -70,8 +71,10 @@ const providerProps = {
 }
 
 describe('Page', () => {
+  const { findByTestId, getByText, queryByTestId } = screen
+
   test('PageEdit can be shown/hidden successfully', async () => {
-    const { findByText, getByText } = customRender(
+    customRender(
       <Page
         page={data.pages[0]}
         previewUrl={'https://localhost:3009'}
@@ -82,21 +85,22 @@ describe('Page', () => {
         providerProps
       }
     )
-    await fireEvent.click(getByText('Edit page'))
-    expect(screen.findByTestId('page-edit')).toBeTruthy()
 
-    await fireEvent.click(screen.getByText('Save'))
-    expect(screen.queryByTestId('page-edit')).toBeFalsy()
+    await act(() => userEvent.click(getByText('Edit page')))
+    await waitFor(() => findByTestId('page-edit'))
 
-    await fireEvent.click(await findByText('Edit page'))
-    expect(screen.findByTestId('Flyout-0')).toBeTruthy()
+    await act(() => userEvent.click(getByText('Save')))
+    expect(queryByTestId('page-edit')).not.toBeInTheDocument()
 
-    await fireEvent.click(screen.getByText('Close'))
-    expect(screen.queryByTestId('Flyout-0')).toBeFalsy()
+    await act(() => userEvent.click(getByText('Edit page')))
+    await waitFor(() => findByTestId('flyout-0'))
+
+    await act(() => userEvent.click(getByText('Close')))
+    expect(queryByTestId('flyout-0')).not.toBeInTheDocument()
   })
 
   test('AddComponent can be shown/hidden successfully', async () => {
-    const { getByText } = customRender(
+    customRender(
       <Page
         page={data.pages[0]}
         previewUrl={'https://localhost:3009'}
@@ -107,15 +111,16 @@ describe('Page', () => {
         providerProps
       }
     )
-    await fireEvent.click(getByText('Create component'))
-    expect(screen.findByTestId('component-create')).toBeTruthy()
 
-    await fireEvent.click(screen.getByText('Close'))
-    expect(screen.queryByTestId('Flyout-0')).toBeFalsy()
+    await act(() => userEvent.click(getByText('Create component')))
+    await waitFor(() => findByTestId('component-create'))
+
+    await act(() => userEvent.click(getByText('Close')))
+    expect(queryByTestId('flyout-0')).not.toBeInTheDocument()
   })
 
   test('Page actions contain expected call to actions', () => {
-    const { getByText } = customRender(
+    customRender(
       <Page
         page={data.pages[0]}
         previewUrl={'https://localhost:3009'}
@@ -132,7 +137,7 @@ describe('Page', () => {
   })
 
   test('Dragging component order saves successfully', async () => {
-    const { getByText } = customRender(
+    customRender(
       <Page
         page={data.pages[0]}
         previewUrl={'https://localhost:3009'}
@@ -143,10 +148,11 @@ describe('Page', () => {
         providerProps
       }
     )
-    await fireEvent.click(getByText('Create component'))
-    expect(screen.findByTestId('component-create')).toBeTruthy()
 
-    await fireEvent.click(screen.getByText('Close'))
-    expect(screen.queryByTestId('Flyout-0')).toBeFalsy()
+    await act(() => userEvent.click(getByText('Create component')))
+    await waitFor(() => findByTestId('component-create'))
+
+    await act(() => userEvent.click(getByText('Close')))
+    expect(queryByTestId('flyout-0')).not.toBeInTheDocument()
   })
 })

--- a/designer/client/src/conditions/AbsoluteDateTimeValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteDateTimeValues.test.tsx
@@ -1,18 +1,21 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { AbsoluteDateTimeValues } from './AbsoluteDateTimeValues'
 
 describe('AbsoluteDateTimeValues', () => {
+  afterEach(cleanup)
+
   const { findByLabelText } = screen
 
   it("renders out a date that's passed to it", async () => {
     const d = new Date('2020-01-31T12:10:35Z')
     render(<AbsoluteDateTimeValues updateValue={jest.fn()} value={d} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
 
     expect($year?.getAttribute('value')).toEqual('2020')
     expect($month?.getAttribute('value')).toEqual('01')
@@ -23,8 +26,8 @@ describe('AbsoluteDateTimeValues', () => {
     const d = new Date('2020-01-31T12:10:35Z')
     render(<AbsoluteDateTimeValues updateValue={jest.fn()} value={d} />)
 
-    const $hours = await findByLabelText('HH')
-    const $minutes = await findByLabelText('mm')
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    const $minutes = await waitFor(() => findByLabelText('mm'))
 
     expect($hours?.getAttribute('value')).toEqual('12')
     expect($minutes?.getAttribute('value')).toEqual('10')
@@ -34,17 +37,17 @@ describe('AbsoluteDateTimeValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateTimeValues updateValue={updateValue} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
-    const $hours = await findByLabelText('HH')
-    const $minutes = await findByLabelText('mm')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    const $minutes = await waitFor(() => findByLabelText('mm'))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '26')
-    await userEvent.type($hours, '10')
-    await userEvent.type($minutes, '57')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '26'))
+    await act(() => userEvent.type($hours, '10'))
+    await act(() => userEvent.type($minutes, '57'))
 
     const d = updateValue.mock.calls.pop()[0]
     expect(d.toISOString()).toEqual('2020-04-26T10:57:00.000Z')
@@ -55,22 +58,22 @@ describe('AbsoluteDateTimeValues', () => {
     const d = new Date('2020-01-31T12:10:35Z')
     render(<AbsoluteDateTimeValues updateValue={updateValue} value={d} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
-    const $hours = await findByLabelText('HH')
-    const $minutes = await findByLabelText('mm')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    const $minutes = await waitFor(() => findByLabelText('mm'))
 
     // Clear existing values
     await Promise.all(
       [$year, $month, $day, $hours, $minutes].map(userEvent.clear)
     )
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '26')
-    await userEvent.type($hours, '10')
-    await userEvent.type($minutes, '57')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '26'))
+    await act(() => userEvent.type($hours, '10'))
+    await act(() => userEvent.type($minutes, '57'))
 
     const newDate = updateValue.mock.calls.pop()[0]
     expect(newDate.toISOString()).toEqual('2020-04-26T10:57:00.000Z')
@@ -80,15 +83,15 @@ describe('AbsoluteDateTimeValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateTimeValues updateValue={updateValue} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
-    const $hours = await findByLabelText('HH')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
+    const $hours = await waitFor(() => findByLabelText('HH'))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '26')
-    await userEvent.type($hours, '40')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '26'))
+    await act(() => userEvent.type($hours, '40'))
 
     expect(updateValue).not.toHaveBeenCalled()
   })
@@ -97,17 +100,17 @@ describe('AbsoluteDateTimeValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateTimeValues updateValue={updateValue} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
-    const $hours = await findByLabelText('HH')
-    const $minutes = await findByLabelText('mm')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    const $minutes = await waitFor(() => findByLabelText('mm'))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '26')
-    await userEvent.type($hours, '0')
-    await userEvent.type($minutes, '57')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '26'))
+    await act(() => userEvent.type($hours, '0'))
+    await act(() => userEvent.type($minutes, '57'))
 
     const d = updateValue.mock.calls.pop()[0]
     expect(d.toISOString()).toEqual('2020-04-26T00:57:00.000Z')
@@ -117,17 +120,17 @@ describe('AbsoluteDateTimeValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateTimeValues updateValue={updateValue} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
-    const $hours = await findByLabelText('HH')
-    const $minutes = await findByLabelText('mm')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    const $minutes = await waitFor(() => findByLabelText('mm'))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '26')
-    await userEvent.type($hours, '14')
-    await userEvent.type($minutes, '0')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '26'))
+    await act(() => userEvent.type($hours, '14'))
+    await act(() => userEvent.type($minutes, '0'))
 
     const d = updateValue.mock.calls.pop()[0]
     expect(d.toISOString()).toEqual('2020-04-26T14:00:00.000Z')

--- a/designer/client/src/conditions/AbsoluteDateValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { AbsoluteDateValues } from './AbsoluteDateValues'
 
 describe('AbsoluteDateValues', () => {
+  afterEach(cleanup)
+
   const { findByLabelText } = screen
 
   it("renders out a date that's passed to it", async () => {
@@ -14,9 +17,9 @@ describe('AbsoluteDateValues', () => {
       />
     )
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
 
     expect($year?.getAttribute('value')).toEqual('1999')
     expect($month?.getAttribute('value')).toEqual('12')
@@ -27,15 +30,21 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '26')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '26'))
 
-    expect(updateValue).toHaveBeenCalledWith({ year: 2020, month: 4, day: 26 })
+    await waitFor(() =>
+      expect(updateValue).toHaveBeenCalledWith({
+        year: 2020,
+        month: 4,
+        day: 26
+      })
+    )
   })
 
   it('calls the updateValue prop if an existing date is edited', async () => {
@@ -47,31 +56,37 @@ describe('AbsoluteDateValues', () => {
       />
     )
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
 
     // Clear existing values
     await Promise.all([$year, $month, $day].map(userEvent.clear))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '26')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '26'))
 
-    expect(updateValue).toHaveBeenCalledWith({ year: 2020, month: 4, day: 26 })
+    await waitFor(() =>
+      expect(updateValue).toHaveBeenCalledWith({
+        year: 2020,
+        month: 4,
+        day: 26
+      })
+    )
   })
 
   it("doesn't call the updateValue prop if an valid day is not entered", async () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '0')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '0'))
 
     expect(updateValue).not.toHaveBeenCalled()
   })
@@ -80,11 +95,11 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $year = await findByLabelText('Year')
-    const $month = await findByLabelText('Month')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $month = await waitFor(() => findByLabelText('Month'))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($month, '4')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($month, '4'))
 
     expect(updateValue).not.toHaveBeenCalled()
   })
@@ -93,11 +108,11 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $year = await findByLabelText('Year')
-    const $day = await findByLabelText('Day')
+    const $year = await waitFor(() => findByLabelText('Year'))
+    const $day = await waitFor(() => findByLabelText('Day'))
 
-    await userEvent.type($year, '2020')
-    await userEvent.type($day, '7')
+    await act(() => userEvent.type($year, '2020'))
+    await act(() => userEvent.type($day, '7'))
 
     expect(updateValue).not.toHaveBeenCalled()
   })
@@ -106,11 +121,11 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $month = await findByLabelText('Month')
-    const $day = await findByLabelText('Day')
+    const $month = await waitFor(() => findByLabelText('Month'))
+    const $day = await waitFor(() => findByLabelText('Day'))
 
-    await userEvent.type($month, '4')
-    await userEvent.type($day, '23')
+    await act(() => userEvent.type($month, '4'))
+    await act(() => userEvent.type($day, '23'))
 
     expect(updateValue).not.toHaveBeenCalled()
   })

--- a/designer/client/src/conditions/AbsoluteTimeValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteTimeValues.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { AbsoluteTimeValues } from './AbsoluteTimeValues'
 
 describe('AbsoluteTimeValues', () => {
+  afterEach(cleanup)
+
   const { findByLabelText } = screen
 
   it("renders out a time that's passed to it", async () => {
@@ -14,8 +17,8 @@ describe('AbsoluteTimeValues', () => {
       />
     )
 
-    const $hours = await findByLabelText('HH')
-    const $minutes = await findByLabelText('mm')
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    const $minutes = await waitFor(() => findByLabelText('mm'))
 
     expect($hours?.getAttribute('value')).toEqual('0')
     expect($minutes?.getAttribute('value')).toEqual('34')
@@ -24,13 +27,18 @@ describe('AbsoluteTimeValues', () => {
   it('calls the updateValue prop if a valid time is entered', async () => {
     const updateValue = jest.fn()
     render(<AbsoluteTimeValues updateValue={updateValue} value={{}} />)
-    const $hours = await findByLabelText('HH')
-    const $minutes = await findByLabelText('mm')
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    const $minutes = await waitFor(() => findByLabelText('mm'))
 
-    await userEvent.type($hours, '14')
-    await userEvent.type($minutes, '20')
+    await act(() => userEvent.type($hours, '14'))
+    await act(() => userEvent.type($minutes, '20'))
 
-    expect(updateValue).toHaveBeenCalledWith({ hour: 14, minute: 20 })
+    await waitFor(() =>
+      expect(updateValue).toHaveBeenCalledWith({
+        hour: 14,
+        minute: 20
+      })
+    )
   })
 
   it('calls the updateValue prop if an existing valid time is edited', async () => {
@@ -42,31 +50,36 @@ describe('AbsoluteTimeValues', () => {
       />
     )
 
-    const $hours = await findByLabelText('HH')
-    const $minutes = await findByLabelText('mm')
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    const $minutes = await waitFor(() => findByLabelText('mm'))
 
     // Clear existing values
     await Promise.all([$hours, $minutes].map(userEvent.clear))
 
-    await userEvent.type($hours, '14')
-    await userEvent.type($minutes, '20')
+    await act(() => userEvent.type($hours, '14'))
+    await act(() => userEvent.type($minutes, '20'))
 
-    expect(updateValue).toHaveBeenCalledWith({ hour: 14, minute: 20 })
+    await waitFor(() =>
+      expect(updateValue).toHaveBeenCalledWith({
+        hour: 14,
+        minute: 20
+      })
+    )
   })
 
   it("doesn't call the updateValue prop if a minutes value is not entered", async () => {
     const updateValue = jest.fn()
     render(<AbsoluteTimeValues updateValue={updateValue} value={{}} />)
-    const $hours = await findByLabelText('HH')
-    await userEvent.type($hours, '3')
+    const $hours = await waitFor(() => findByLabelText('HH'))
+    await act(() => userEvent.type($hours, '3'))
     expect(updateValue).not.toHaveBeenCalled()
   })
 
   it("doesn't call the updateValue prop if an hours value is not entered", async () => {
     const updateValue = jest.fn()
     render(<AbsoluteTimeValues updateValue={updateValue} value={{}} />)
-    const $minutes = await findByLabelText('mm')
-    await userEvent.type($minutes, '20')
+    const $minutes = await waitFor(() => findByLabelText('mm'))
+    await act(() => userEvent.type($minutes, '20'))
     expect(updateValue).not.toHaveBeenCalled()
   })
 })

--- a/designer/client/src/conditions/InlineConditions.test.tsx
+++ b/designer/client/src/conditions/InlineConditions.test.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import InlineConditions from './InlineConditions'
 import { DataContext } from '../context/DataContext'
 
 describe('InlineConditions', () => {
+  afterEach(cleanup)
+
+  const { getByText } = screen
+
   test('Strings are rendered correctly', () => {
     const props = {
       path: '/some-path',
@@ -32,7 +37,7 @@ describe('InlineConditions', () => {
       conditions: []
     }
 
-    const { getByText } = render(
+    render(
       <DataContext.Provider value={{ data, save: jest.fn() }}>
         <InlineConditions {...props} />
       </DataContext.Provider>

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -1,4 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { InlineConditionsDefinitionValue } from './InlineConditionsDefinitionValue'
 import {
@@ -8,9 +10,12 @@ import {
   relativeDateOrTimeOperatorNames,
   timeUnits
 } from '@defra/forms-model'
-import { userEvent } from '@testing-library/user-event'
 
 describe.skip('InlineConditionsDefinitionValue', () => {
+  afterEach(cleanup)
+
+  const { findByDisplayValue, findByTestId, findByText } = screen
+
   it('should display a text input for fields without custom mappings or options', async () => {
     const fieldDef = {
       label: 'Something',
@@ -25,9 +30,10 @@ describe.skip('InlineConditionsDefinitionValue', () => {
         operator="is"
       />
     )
-    const input = await screen.findByDisplayValue('my-value')
-    expect(input).toBeInTheDocument()
-    expect(input).toHaveAttribute('type', 'text')
+
+    const $input = await waitFor(() => findByDisplayValue('my-value'))
+    expect($input).toBeInTheDocument()
+    expect($input).toHaveAttribute('type', 'text')
   })
 
   it('inputting a text value should call update value', async () => {
@@ -45,9 +51,10 @@ describe.skip('InlineConditionsDefinitionValue', () => {
         operator="is"
       />
     )
-    const input = await screen.findByDisplayValue('my-value')
-    await userEvent.clear(input)
-    await userEvent.type(input, 'new-value')
+
+    const $input = await waitFor(() => findByDisplayValue('my-value'))
+    await act(() => userEvent.clear($input))
+    await act(() => userEvent.type($input, 'new-value'))
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: 'new-value',
       type: 'Value',
@@ -70,9 +77,10 @@ describe.skip('InlineConditionsDefinitionValue', () => {
         operator="is"
       />
     )
-    const input = await screen.findByDisplayValue('my-value')
-    await userEvent.clear(input)
-    await userEvent.type(input, '')
+
+    const $input = await waitFor(() => findByDisplayValue('my-value'))
+    await act(() => userEvent.clear($input))
+    await act(() => userEvent.type($input, ''))
     expect(updateValueCallback).toHaveBeenLastCalledWith(undefined)
   })
 
@@ -95,10 +103,15 @@ describe.skip('InlineConditionsDefinitionValue', () => {
         operator="is"
       />
     )
-    const select = await screen.findByTestId('cond-value')
-    expect(select).toBeInTheDocument()
-    expect(await screen.findByText('Value 1')).toBeInTheDocument()
-    expect(await screen.findByText('Value 2')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(findByTestId('cond-value')).resolves.toBeInTheDocument()
+    )
+    await waitFor(() =>
+      expect(findByText('Value 1')).resolves.toBeInTheDocument()
+    )
+    await waitFor(() =>
+      expect(findByText('Value 2')).resolves.toBeInTheDocument()
+    )
   })
 
   it('selecting a value from the select list should call update value', async () => {
@@ -121,8 +134,10 @@ describe.skip('InlineConditionsDefinitionValue', () => {
         operator="is"
       />
     )
-    const select = await screen.findByTestId('cond-value')
-    await userEvent.selectOptions(select, 'value1')
+
+    const select = await waitFor(() => findByTestId('cond-value'))
+    await act(() => userEvent.selectOptions(select, 'value1'))
+
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: 'Value 1',
       type: 'Value',
@@ -150,8 +165,10 @@ describe.skip('InlineConditionsDefinitionValue', () => {
         operator="is"
       />
     )
-    const select = await screen.findByTestId('cond-value')
-    await userEvent.selectOptions(select, 'true')
+
+    const select = await waitFor(() => findByTestId('cond-value'))
+    await act(() => userEvent.selectOptions(select, 'true'))
+
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: 'Value 1',
       type: 'Value',
@@ -179,8 +196,10 @@ describe.skip('InlineConditionsDefinitionValue', () => {
         operator="is"
       />
     )
-    const select = await screen.findByTestId('cond-value')
-    await userEvent.selectOptions(select, '42')
+
+    const select = await waitFor(() => findByTestId('cond-value'))
+    await act(() => userEvent.selectOptions(select, '42'))
+
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: 'Value 1',
       type: 'Value',
@@ -208,8 +227,10 @@ describe.skip('InlineConditionsDefinitionValue', () => {
         operator="is"
       />
     )
-    const select = await screen.findByTestId('cond-value')
-    await userEvent.selectOptions(select, '')
+
+    const select = await waitFor(() => findByTestId('cond-value'))
+    await act(() => userEvent.selectOptions(select, ''))
+
     expect(updateValueCallback).toHaveBeenLastCalledWith(undefined)
   })
 
@@ -230,28 +251,34 @@ describe.skip('InlineConditionsDefinitionValue', () => {
           type: mapping.type
         }
         const updateValueCallback = jest.fn()
-        const { findByDisplayValue } = render(
+        render(
           <InlineConditionsDefinitionValue
             updateValue={updateValueCallback}
             fieldDef={fieldDef}
             operator={operator}
           />
         )
-        expect(
-          await screen.findByTestId('cond-value-period')
-        ).toBeInTheDocument()
-        const units = await screen.findByTestId('cond-value-units')
+        await waitFor(() =>
+          expect(findByTestId('cond-value-period')).resolves.toBeInTheDocument()
+        )
+        const units = await waitFor(() => findByTestId('cond-value-units'))
         expect(units).toBeInTheDocument()
         waitFor(() =>
           Promise.all(
             Object.values(mapping.units).map(async (unit) =>
-              expect(await findByDisplayValue(unit.display)).toBeInTheDocument()
+              waitFor(() =>
+                expect(
+                  findByDisplayValue(unit.display)
+                ).resolves.toBeInTheDocument()
+              )
             )
           )
         )
-        expect(
-          await screen.findByTestId('cond-value-direction')
-        ).toBeInTheDocument()
+        await waitFor(() =>
+          expect(
+            findByTestId('cond-value-direction')
+          ).resolves.toBeInTheDocument()
+        )
       })
     })
   })

--- a/designer/client/src/conditions/SelectConditions.test.tsx
+++ b/designer/client/src/conditions/SelectConditions.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { type RenderResult, render } from '@testing-library/react'
+import { cleanup, render, type RenderResult } from '@testing-library/react'
 import SelectConditions from './SelectConditions'
 import { DataContext } from '../context'
 
 describe('SelectConditions', () => {
-  const { getByText, queryByText, getByTestId } = screen
+  afterEach(cleanup)
+
+  const { getByText, getByTestId, queryByText } = screen
 
   const data: FormDefinition = {
     lists: [],
@@ -21,12 +23,12 @@ describe('SelectConditions', () => {
   let props
 
   function customRender(
-    children: React.JSX.Element,
-    providerProps: DataContextProps = dataValue
+    element: React.JSX.Element,
+    providerProps = dataValue
   ): RenderResult {
     return render(
       <DataContext.Provider value={providerProps}>
-        {children}
+        {element}
         <div id="portal-root" />
       </DataContext.Provider>
     )
@@ -156,7 +158,9 @@ describe('SelectConditions', () => {
       (condition) => condition.displayName
     )
 
-    expect(queryByText('You cannot add any conditions as')).toBeNull()
+    expect(
+      queryByText('You cannot add any conditions as')
+    ).not.toBeInTheDocument()
     expect(getByTestId('select-conditions')).toBeInTheDocument()
 
     expectedConditions.forEach((condition) => {

--- a/designer/client/src/field-edit.test.tsx
+++ b/designer/client/src/field-edit.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import { FieldEdit } from './field-edit'
 import { RenderWithContextAndDataContext } from '../../test/helpers/renderers'
 
 describe('Field edit', () => {
-  let stateProps
-  let page
+  const { getByText } = screen
 
   const mockData = {
     pages: [
@@ -20,6 +20,8 @@ describe('Field edit', () => {
     lists: []
   }
 
+  let stateProps
+
   beforeEach(() => {
     stateProps = {
       component: {
@@ -29,7 +31,7 @@ describe('Field edit', () => {
       }
     }
 
-    page = render(
+    render(
       <RenderWithContextAndDataContext
         stateProps={stateProps}
         mockData={mockData}
@@ -39,67 +41,69 @@ describe('Field edit', () => {
     )
   })
 
+  afterEach(cleanup)
+
   test('helpTextField should display display correct title', () => {
     const text = 'Help text (optional)'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('helpTextField should display display correct helpText', () => {
     const text = 'Enter the description to show for this field'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('hideOptionalTextOption should display display correct title', () => {
     const text = "Hide '(optional)' text"
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('hideOptionalTextOption should display display correct helpText', () => {
     const text =
       'Tick this box if you do not want the title to indicate that this field is optional'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('hideTitleOption should display display correct title', () => {
     const text = 'Hide title'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('hideTitleOption should display display correct helpText', () => {
     const text =
       'Tick this box if you do not want the title to show on the page'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('titleField should display display correct title', () => {
     const text = 'Title'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('titleField should display display correct helpText', () => {
     const text = 'Enter the name to show for this field'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('componentOptionalOption should display display correct title', () => {
     const text = 'Make UK address field optional'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('componentOptionalOption should display display correct helpText', () => {
     const text =
       'Tick this box if users do not need to complete this field to progress through the form'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('componentNameField should display display correct title', () => {
     const text = 'Component name'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 
   test('componentNameField should display display correct helpText', () => {
     const text =
       'This is generated automatically and does not show on the page. Only change it if you are using an integration that requires you to, for example GOV.UK Notify. It must not contain spaces.'
-    expect(page.getByText(text)).toBeInTheDocument()
+    expect(getByText(text)).toBeInTheDocument()
   })
 })

--- a/designer/client/src/file-upload-field-edit.test.tsx
+++ b/designer/client/src/file-upload-field-edit.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import { FileUploadFieldEdit } from './file-upload-field-edit'
 import { RenderWithContext } from '../../test/helpers/renderers'
 
 describe('File upload', () => {
+  const { getByText } = screen
+
   describe('File upload Field', () => {
     let stateProps
-    let page
 
     beforeEach(() => {
       stateProps = {
@@ -17,21 +19,23 @@ describe('File upload', () => {
         }
       }
 
-      page = render(
+      render(
         <RenderWithContext stateProps={stateProps}>
           <FileUploadFieldEdit />
         </RenderWithContext>
       )
     })
 
+    afterEach(cleanup)
+
     test('should display display correct title', () => {
       const text = 'Allow multiple file upload'
-      expect(page.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
 
     test('should display display correct help text', () => {
       const text = 'Tick this box to enable users to upload multiple files'
-      expect(page.getByText(text)).toBeInTheDocument()
+      expect(getByText(text)).toBeInTheDocument()
     })
   })
 })

--- a/designer/client/src/link-create.test.tsx
+++ b/designer/client/src/link-create.test.tsx
@@ -229,7 +229,7 @@ describe('LinkCreate', () => {
       target: { value: '/first-page' }
     })
     await fireEvent.change(getByTestId('select-condition'), {
-      target: { value: 'hasUKPassport' }
+      target: { value: '' }
     })
     await fireEvent.click(getByRole('button'))
     expect(save).toHaveBeenCalledTimes(2)

--- a/designer/client/src/link-edit.test.tsx
+++ b/designer/client/src/link-edit.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { screen, within } from '@testing-library/dom'
+import { act, cleanup, render, type RenderResult } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import LinkCreate from './link-create'
 import { DataContext } from './context'
-import { within } from '@testing-library/dom'
 
 const data = {
   pages: [
@@ -15,28 +16,31 @@ const data = {
   ]
 }
 
-const dataValue = {
-  data,
-  save: jest.fn()
-}
-export const customRender = (children, providerProps = dataValue) => {
+const dataValue = { data, save: jest.fn() }
+
+function customRender(
+  element: React.JSX.Element,
+  providerProps = dataValue
+): RenderResult {
   return render(
     <DataContext.Provider value={providerProps}>
-      {children}
+      {element}
       <div id="portal-root" />
     </DataContext.Provider>
   )
 }
 
+afterEach(cleanup)
+
 describe('LinkEdit', () => {
+  const { getByRole } = screen
+
   test('Submitting with a condition updates the link', async () => {
-    const save = jest.fn()
-    const { getByRole } = customRender(<LinkCreate />, {
-      data,
-      save
-    })
-    await fireEvent.click(getByRole('button'))
+    customRender(<LinkCreate />)
+
+    await act(() => userEvent.click(getByRole('button')))
     const summary = within(getByRole('alert'))
+
     expect(summary.getByText('Enter from')).toBeInTheDocument()
     expect(summary.getByText('Enter to')).toBeInTheDocument()
   })

--- a/designer/client/src/list/ListEdit.test.tsx
+++ b/designer/client/src/list/ListEdit.test.tsx
@@ -1,5 +1,6 @@
 import { customRenderForLists } from '../../../test/helpers/renderers-lists'
 import { Data } from '@defra/forms-model'
+import { screen } from '@testing-library/dom'
 import React from 'react'
 import { ListEdit } from './ListEdit'
 import { ListContext } from '../reducers/listReducer'
@@ -25,9 +26,12 @@ const data = {
   ]
 }
 
+const dataValue = { data, save: jest.fn() }
+
 describe('ListEdit', () => {
+  const { getByText, queryByText } = screen
+
   test('strings are rendered correctly', async () => {
-    const dataValue = { data, save: jest.fn() }
     const listValue = {
       state: { selectedList: data.lists[0] },
       dispatch: jest.fn()
@@ -37,14 +41,11 @@ describe('ListEdit', () => {
       dispatch: jest.fn()
     }
 
-    const { getByText, queryByText, rerender } = customRenderForLists(
-      <ListEdit />,
-      {
-        dataValue,
-        listsValue,
-        listValue
-      }
-    )
+    const { rerender } = customRenderForLists(<ListEdit />, {
+      dataValue,
+      listsValue,
+      listValue
+    })
 
     expect(getByText('List items')).toBeInTheDocument()
     expect(getByText('Enter a unique name for your list')).toBeInTheDocument()
@@ -52,18 +53,23 @@ describe('ListEdit', () => {
       getByText('Use the drag handles to reorder your list')
     ).toBeInTheDocument()
     expect(getByText('Add list item')).toBeInTheDocument()
-    expect(queryByText('This list does not have any list items')).toBeNull()
+    expect(
+      queryByText('This list does not have any list items')
+    ).not.toBeInTheDocument()
 
     const emptyList = {
       state: { selectedList: data.lists[1], isNew: true },
       dispatch: jest.fn()
     }
 
-    await rerender(<ListEdit />, {
-      dataValue,
-      listsValue,
-      listValue: emptyList
-    })
+    await rerender.call(
+      {
+        dataValue,
+        listsValue,
+        listValue: emptyList
+      },
+      <ListEdit />
+    )
     expect(
       getByText('This list does not have any list items')
     ).toBeInTheDocument()

--- a/designer/client/src/list/ListItemEdit.test.tsx
+++ b/designer/client/src/list/ListItemEdit.test.tsx
@@ -1,7 +1,9 @@
-import { customRenderForLists } from '../../../test/helpers/renderers-lists'
+import { screen } from '@testing-library/dom'
+import { act } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
+import { customRenderForLists } from '../../../test/helpers/renderers-lists'
 import { ListItemEdit } from './ListItemEdit'
-import { fireEvent } from '@testing-library/react'
 
 const data = {
   pages: [
@@ -80,13 +82,13 @@ const data = {
   ]
 }
 
-describe('ListItemEdit', () => {
-  test('strings are rendered correctly', async () => {
-    const dataValue = { data, save: jest.fn() }
+const dataValue = { data, save: jest.fn() }
 
-    const { getByText } = customRenderForLists(<ListItemEdit />, {
-      dataValue
-    })
+describe('ListItemEdit', () => {
+  const { getByText, getByTestId, getAllByTestId } = screen
+
+  test('strings are rendered correctly', async () => {
+    customRenderForLists(<ListItemEdit />, { dataValue })
 
     expect(getByText('Item text')).toBeInTheDocument()
     expect(getByText('Enter the text you want to show')).toBeInTheDocument()
@@ -103,23 +105,20 @@ describe('ListItemEdit', () => {
   })
 
   test('Condition selection works correctly', async () => {
-    const dataValue = { data, save: jest.fn() }
+    customRenderForLists(<ListItemEdit />, { dataValue })
 
-    const { getByTestId, getAllByTestId } = customRenderForLists(
-      <ListItemEdit />,
-      {
-        dataValue
-      }
+    const $select = getByTestId('list-condition-select')
+    const $options: HTMLOptionElement[] = getAllByTestId(
+      'list-condition-option'
     )
-    const options: HTMLOptionElement[] = getAllByTestId('list-condition-option')
-    expect(options[0].selected).toBeTruthy()
-    expect(options[1].selected).toBeFalsy()
-    await fireEvent.change(getByTestId('list-condition-select'), {
-      target: { value: 'MYWwRN' }
-    })
 
-    expect(options[0].selected).toBeFalsy()
-    expect(options[1].selected).toBeTruthy()
-    expect(options[1].textContent).toBe('my condition')
+    expect($options[0].selected).toBeTruthy()
+    expect($options[1].selected).toBeFalsy()
+
+    await act(() => userEvent.selectOptions($select, 'MYWwRN'))
+
+    expect($options[0].selected).toBeFalsy()
+    expect($options[1].selected).toBeTruthy()
+    expect($options[1].textContent).toBe('my condition')
   })
 })

--- a/designer/client/src/list/ListSelect.test.tsx
+++ b/designer/client/src/list/ListSelect.test.tsx
@@ -1,5 +1,6 @@
-import { customRenderForLists } from '../../../test/helpers/renderers-lists'
 import { Data } from '@defra/forms-model'
+import { screen } from '@testing-library/dom'
+import { customRenderForLists } from '../../../test/helpers/renderers-lists'
 
 import React from 'react'
 import { ListSelect } from './ListSelect'
@@ -21,27 +22,20 @@ const data = {
   ]
 }
 
-describe('ListSelect', () => {
-  test('Lists all available lists and add list', async () => {
-    const dataValue = { data, save: jest.fn() }
+const dataValue = { data, save: jest.fn() }
 
-    const { queryAllByTestId, getByTestId } = customRenderForLists(
-      <ListSelect />,
-      {
-        dataValue
-      }
-    )
-    const editLinks = await queryAllByTestId('edit-list')
-    expect(editLinks.length).toBe(2)
+describe('ListSelect', () => {
+  const { getByTestId, getByText, queryAllByTestId } = screen
+
+  test('Lists all available lists and add list', () => {
+    customRenderForLists(<ListSelect />, { dataValue })
+    const $links = queryAllByTestId('edit-list')
+    expect($links).toHaveLength(2)
     expect(getByTestId('add-list')).toBeInTheDocument()
   })
 
   test('strings are rendered correctly', async () => {
-    const dataValue = { data, save: jest.fn() }
-
-    const { getByText } = customRenderForLists(<ListSelect />, {
-      dataValue
-    })
+    customRenderForLists(<ListSelect />, { dataValue })
 
     expect(
       getByText(

--- a/designer/client/src/list/Warning.test.tsx
+++ b/designer/client/src/list/Warning.test.tsx
@@ -1,6 +1,7 @@
-import { customRenderForLists } from '../../../test/helpers/renderers-lists'
 import { Data } from '@defra/forms-model'
+import { screen } from '@testing-library/dom'
 import React from 'react'
+import { customRenderForLists } from '../../../test/helpers/renderers-lists'
 import { Warning } from './Warning'
 
 const data = {
@@ -19,13 +20,13 @@ const data = {
   ]
 }
 
-describe('Warning', () => {
-  test('strings are rendered correctly', async () => {
-    const dataValue = { data, save: jest.fn() }
+const dataValue = { data, save: jest.fn() }
 
-    const { getByText } = customRenderForLists(<Warning />, {
-      dataValue
-    })
+describe('Warning', () => {
+  const { getByText } = screen
+
+  test('strings are rendered correctly', async () => {
+    customRenderForLists(<Warning />, { dataValue })
 
     expect(getByText('Delete list')).toBeInTheDocument()
     expect(

--- a/designer/client/src/outputs/output-edit.test.tsx
+++ b/designer/client/src/outputs/output-edit.test.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
-import { render, fireEvent, waitFor } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { RenderWithContextAndDataContext } from '../../../test/helpers/renderers'
 import { Data } from '@defra/forms-model'
 
 import OutputEdit from './output-edit'
 
 describe('OutputEdit', () => {
+  afterEach(cleanup)
+
+  const { getByText, getByLabelText } = screen
+
   let mockData: Data
   let mockSave: any
 
@@ -52,7 +58,7 @@ describe('OutputEdit', () => {
         }
       }
 
-      const { getByText, getByLabelText } = render(
+      render(
         <RenderWithContextAndDataContext
           mockData={mockData}
           mockSave={mockSave}
@@ -61,37 +67,38 @@ describe('OutputEdit', () => {
         </RenderWithContextAndDataContext>
       )
 
+      const $title = getByLabelText('Title')
+      const $name = getByLabelText('Name')
+      const $templateId = getByLabelText('Template ID')
+      const $apiKey = getByLabelText('API Key')
+      const $selectEmail = getByLabelText('Email field')
+      const $checkbox = getByText('Include webhook and payment references')
+      const $button = getByText('Save')
+
       // change title
-      await fireEvent.change(getByLabelText('Title'), {
-        target: { value: 'NewTitle' }
-      })
+      await act(() => userEvent.clear($title))
+      await act(() => userEvent.type($title, 'NewTitle'))
 
       // change name
-      await fireEvent.change(getByLabelText('Name'), {
-        target: { value: 'NewName' }
-      })
+      await act(() => userEvent.clear($name))
+      await act(() => userEvent.type($name, 'NewName'))
 
       // change templateId
-      await fireEvent.change(getByLabelText('Template ID'), {
-        target: { value: 'NewTemplateId' }
-      })
+      await act(() => userEvent.clear($templateId))
+      await act(() => userEvent.type($templateId, 'NewTemplateId'))
 
       // change apiKey
-      await fireEvent.change(getByLabelText('API Key'), {
-        target: { value: 'NewAPIKey' }
-      })
+      await act(() => userEvent.clear($apiKey))
+      await act(() => userEvent.type($apiKey, 'NewAPIKey'))
 
       // change email field
-      await fireEvent.change(getByLabelText('Email field'), {
-        target: { value: '9WH4EX' }
-      })
+      await act(() => userEvent.selectOptions($selectEmail, '9WH4EX'))
 
       // include references
-      await fireEvent.click(getByText('Include webhook and payment references'))
+      await act(() => userEvent.click($checkbox))
 
       // save
-      await fireEvent.click(getByText('Save'))
-
+      await act(() => userEvent.click($button))
       await waitFor(() => expect(mockSave).toHaveBeenCalledTimes(1))
 
       expect(mockSave.mock.calls[0][0].outputs).toEqual([

--- a/designer/client/src/page-create.test.tsx
+++ b/designer/client/src/page-create.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import PageCreate from './page-create'
 
 describe('page create fields text', () => {
+  afterEach(cleanup)
+
+  const { getByText } = screen
+
   test('displays field titles and help texts', () => {
     const props = {
       path: '/some-path',
@@ -12,7 +17,7 @@ describe('page create fields text', () => {
       }
     }
 
-    const { getByText } = render(<PageCreate {...props} />)
+    render(<PageCreate {...props} />)
     expect(getByText('Page type')).toBeInTheDocument()
     expect(
       getByText(

--- a/designer/client/src/pages/ErrorPages/SaveError.test.tsx
+++ b/designer/client/src/pages/ErrorPages/SaveError.test.tsx
@@ -1,51 +1,64 @@
 import React from 'react'
 import { SaveError } from './SaveError'
-import {
-  render,
-  cleanup,
-  fireEvent,
-  screen,
-  waitFor
-} from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { act, render, cleanup, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 
 describe('SaveErrorPage', () => {
   afterEach(cleanup)
+
+  const { findByText, getByText } = screen
 
   test('should render correctly', async () => {
     const push = jest.fn()
     const history = { push }
     const location = { state: { id: 'testid' } }
-    const { asFragment } = render(
-      <SaveError history={history} location={location} />
+
+    render(<SaveError history={history} location={location} />)
+
+    await waitFor(() =>
+      expect(findByText('Back to Designer')).resolves.toBeInTheDocument()
     )
-    expect(await screen.findByText('Back to Designer')).toBeInTheDocument()
-    expect(
-      await screen.findByText('Sorry, there is a problem with the service')
-    ).toBeInTheDocument()
-    expect(
-      await screen.findByText('An error occurred while saving.')
-    ).toBeInTheDocument()
-    expect(
-      await screen.findByText(
-        'We saved the last valid version of your form. Return to the Designer to continue.'
-      )
-    ).toBeInTheDocument()
-    expect(
-      await screen.findByText(
-        'So we can check what went wrong, complete the following:'
-      )
-    ).toBeInTheDocument()
-    expect(
-      await screen.findByText('download your crash report')
-    ).toBeInTheDocument()
 
-    expect(
-      await screen.findByText('create an issue on GitHub')
-    ).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        findByText('Sorry, there is a problem with the service')
+      ).resolves.toBeInTheDocument()
+    )
 
-    expect(
-      screen.getByText('create an issue on GitHub').closest('a')
-    ).toHaveAttribute(
+    await waitFor(() =>
+      expect(
+        findByText('An error occurred while saving.')
+      ).resolves.toBeInTheDocument()
+    )
+
+    await waitFor(() =>
+      expect(
+        findByText(
+          'We saved the last valid version of your form. Return to the Designer to continue.'
+        )
+      ).resolves.toBeInTheDocument()
+    )
+
+    await waitFor(() =>
+      expect(
+        findByText('So we can check what went wrong, complete the following:')
+      ).resolves.toBeInTheDocument()
+    )
+
+    await waitFor(() =>
+      expect(
+        findByText('download your crash report')
+      ).resolves.toBeInTheDocument()
+    )
+
+    await waitFor(() =>
+      expect(
+        findByText('create an issue on GitHub')
+      ).resolves.toBeInTheDocument()
+    )
+
+    expect(getByText('create an issue on GitHub').closest('a')).toHaveAttribute(
       'href',
       'https://github.com/XGovFormBuilder/digital-form-builder/issues/new?template=bug_report.md'
     )
@@ -56,10 +69,10 @@ describe('SaveErrorPage', () => {
     const history = { push }
     const location = { state: { id: 'testid' } }
     render(<SaveError history={history} location={location} />)
-    expect(await screen.findByText(/Back to Designer/i)).toBeInTheDocument()
 
-    await fireEvent.click(screen.getByText('Back to Designer'))
-    await waitFor(() => expect(push).toHaveBeenCalledTimes(1))
-    expect(push).toHaveBeenCalledWith('designer/testid')
+    const $backLink = await waitFor(() => findByText('Back to Designer'))
+
+    await act(() => userEvent.click($backLink!))
+    await waitFor(() => expect(push).toHaveBeenCalledWith('designer/testid'))
   })
 })

--- a/designer/client/src/pages/LandingPage/Choice.test.tsx
+++ b/designer/client/src/pages/LandingPage/Choice.test.tsx
@@ -1,9 +1,13 @@
+import { screen } from '@testing-library/dom'
+import { act, render, cleanup, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { LandingChoice } from './Choice'
-import { render, cleanup, fireEvent, screen } from '@testing-library/react'
 
 describe('LandingChoice', () => {
   afterEach(cleanup)
+
+  const { getByLabelText, getByTitle } = screen
 
   it('snapshot matches', () => {
     const push = jest.fn()
@@ -16,16 +20,16 @@ describe('LandingChoice', () => {
     const push = jest.fn()
     const history = { push }
     render(<LandingChoice history={history} />)
-    await fireEvent.click(screen.getByTitle('Next'))
-    expect(push).toHaveBeenCalledWith('/new')
+    await act(() => userEvent.click(getByTitle('Next')))
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/new'))
   })
 
   it("should push /choose-existing to history if 'Open an existing form' is selected", async () => {
     const push = jest.fn()
     const history = { push }
     render(<LandingChoice history={history} />)
-    await fireEvent.click(screen.getByLabelText('Open an existing form'))
-    await fireEvent.click(screen.getByTitle('Next'))
-    expect(push).toHaveBeenCalledWith('/choose-existing')
+    await act(() => userEvent.click(getByLabelText('Open an existing form')))
+    await act(() => userEvent.click(getByTitle('Next')))
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/choose-existing'))
   })
 })

--- a/designer/client/src/pages/LandingPage/ChooseExisting.test.tsx
+++ b/designer/client/src/pages/LandingPage/ChooseExisting.test.tsx
@@ -1,6 +1,8 @@
+import { screen } from '@testing-library/dom'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { ChooseExisting } from './ChooseExisting'
-import { render, fireEvent, screen, waitFor } from '@testing-library/react'
 import {
   server,
   http,
@@ -11,7 +13,10 @@ import {
 describe('ChooseExisting', () => {
   beforeAll(() => server.listen())
   beforeEach(() => server.resetHandlers(...mockedFormHandlers))
+  afterEach(cleanup)
   afterAll(() => server.close())
+
+  const { findByText, getByText } = screen
 
   test('no existing configurations', async () => {
     server.resetHandlers(
@@ -25,7 +30,9 @@ describe('ChooseExisting', () => {
     const push = jest.fn()
     const history = { push }
     const { asFragment } = render(<ChooseExisting history={history} />)
-    expect(await screen.findByText(/Form name/i)).toBeInTheDocument()
+    await waitFor(() =>
+      expect(findByText(/Form name/i)).resolves.toBeInTheDocument()
+    )
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -33,7 +40,9 @@ describe('ChooseExisting', () => {
     const push = jest.fn()
     const history = { push }
     const { asFragment } = render(<ChooseExisting history={history} />)
-    expect(await screen.findByText(/Form name/i)).toBeInTheDocument()
+    await waitFor(() =>
+      expect(findByText(/Form name/i)).resolves.toBeInTheDocument()
+    )
     expect(asFragment()).toMatchSnapshot()
   })
 
@@ -49,12 +58,14 @@ describe('ChooseExisting', () => {
     const history = { push }
 
     render(<ChooseExisting history={history} />)
-    expect(await screen.findByText(/Form name/i)).toBeInTheDocument()
-
-    await fireEvent.click(
-      screen.getByText(mockedFormConfigurations[0].DisplayName)
+    await waitFor(() =>
+      expect(findByText(/Form name/i)).resolves.toBeInTheDocument()
     )
-    await waitFor(() => expect(push).toHaveBeenCalledTimes(1))
-    expect(push).toHaveBeenCalledWith('/designer/somekey')
+
+    await act(() =>
+      userEvent.click(getByText(mockedFormConfigurations[0].DisplayName))
+    )
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith('/designer/somekey'))
   })
 })

--- a/designer/client/src/section/section-edit.test.tsx
+++ b/designer/client/src/section/section-edit.test.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { cleanup, render } from '@testing-library/react'
 import { RenderWithContext } from '../../../test/helpers/renderers'
 import SectionEdit from './section-edit'
 
 describe('Section edit fields', () => {
+  afterEach(cleanup)
+
+  const { getByText } = screen
+
   test('should display titles and help texts', () => {
     const stateProps = {
       component: {
@@ -13,7 +18,7 @@ describe('Section edit fields', () => {
       }
     }
 
-    const { getByText } = render(
+    render(
       <RenderWithContext stateProps={stateProps}>
         <SectionEdit />
       </RenderWithContext>

--- a/designer/package.json
+++ b/designer/package.json
@@ -62,6 +62,7 @@
     "schmervice": "^1.6.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^14.5.2",
@@ -77,7 +78,6 @@
     "enzyme-adapter-react-16": "^1.15.8",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.6.0",
-    "jsdom": "^19.0.0",
     "lcov-result-merger": "^3.3.0",
     "mini-css-extract-plugin": "^2.8.1",
     "msw": "^2.2.3",

--- a/designer/test/helpers/renderers-lists.tsx
+++ b/designer/test/helpers/renderers-lists.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import { DataContext, FlyoutContext } from '../../client/src/context'
 import React from 'react'
 import { ListContext } from '../../client/src/reducers/listReducer'
@@ -19,8 +19,8 @@ const defaultListsValue = {
 }
 const defaultListValue = { state: {}, dispatch: jest.fn() }
 
-export const customRenderForLists = (
-  children,
+export function customRenderForLists(
+  element: React.JSX.Element,
   {
     dataValue = defaultDataValue,
     flyoutValue = defaultFlyoutValue,
@@ -28,13 +28,13 @@ export const customRenderForLists = (
     listValue = defaultListValue,
     ...renderOptions
   }
-) => {
+): RenderResult {
   const rendered = render(
     <DataContext.Provider value={dataValue}>
       <FlyoutContext.Provider value={flyoutValue}>
         <ListsEditorContext.Provider value={listsValue}>
           <ListContext.Provider value={listValue}>
-            {children}
+            {element}
           </ListContext.Provider>
         </ListsEditorContext.Provider>
       </FlyoutContext.Provider>
@@ -44,7 +44,8 @@ export const customRenderForLists = (
   )
   return {
     ...rendered,
-    rerender: (ui, options) =>
-      customRenderForLists(ui, { container: rendered.container, ...options })
+    rerender(this: Parameters<typeof customRenderForLists>[1], element) {
+      customRenderForLists(element, this)
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "schmervice": "^1.6.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^14.5.2",
@@ -110,7 +111,6 @@
         "enzyme-adapter-react-16": "^1.15.8",
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.6.0",
-        "jsdom": "^19.0.0",
         "lcov-result-merger": "^3.3.0",
         "mini-css-extract-plugin": "^2.8.1",
         "msw": "^2.2.3",
@@ -4612,7 +4612,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
       "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4632,7 +4631,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4648,7 +4646,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4665,7 +4662,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4677,15 +4673,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4695,7 +4689,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5749,28 +5742,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-globals": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
-      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^7.1.1",
-        "acorn-walk": "^7.1.1"
-      }
-    },
-    "node_modules/acorn-globals/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/acorn-import-assertions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
@@ -5787,15 +5758,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
-      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -6619,12 +6581,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
-      "dev": true
     },
     "node_modules/browserslist": {
       "version": "4.23.0",
@@ -13828,58 +13784,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsdom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-19.0.0.tgz",
-      "integrity": "sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==",
-      "dev": true,
-      "dependencies": {
-        "abab": "^2.0.5",
-        "acorn": "^8.5.0",
-        "acorn-globals": "^6.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.1",
-        "decimal.js": "^10.3.1",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.0",
-        "parse5": "6.0.1",
-        "saxes": "^5.0.1",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.0.0",
-        "w3c-hr-time": "^1.0.2",
-        "w3c-xmlserializer": "^3.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^10.0.0",
-        "ws": "^8.2.3",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -17425,18 +17329,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
-    "node_modules/saxes": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
-      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
-      "dev": true,
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/scheduler": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
@@ -18978,28 +18870,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/w3c-hr-time": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
-      "dev": true,
-      "dependencies": {
-        "browser-process-hrtime": "^1.0.0"
-      }
-    },
-    "node_modules/w3c-xmlserializer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
-      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
-      "dev": true,
-      "dependencies": {
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -19407,19 +19277,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-10.0.0.tgz",
-      "integrity": "sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
       "engines": {
         "node": ">=12"
       }


### PR DESCRIPTION
This PR fixes assertions that incorrectly passed due to un-awaited promises etc

I've also swapped [`fireEvent`](https://testing-library.com/docs/dom-testing-library/api-events/#fireevent) with [`userEvent`](https://testing-library.com/docs/user-event/intro/) where possible to catch various HTML element issues

For example, selecting `<option>` in `<select>` menus versus simulating a `change` event that may not be possible

>**Differences from fireEvent**
>`fireEvent` dispatches _DOM events_, whereas `user-event` simulates full _interactions_, which may fire multiple events and do additional checks along the way.

You'll see these tools are now used more frequently:

```mjs
import { screen } from '@testing-library/dom'
import { act, cleanup, render, waitFor } from '@testing-library/react'
import { userEvent } from '@testing-library/user-event'
```

We should consider running Jest without `silent: true` by default to reveal various hidden React warnings