### PR TITLE
Prevent unspecified `..` import in `@xgovformbuilder/govuk-react-jsx` resolving server

### DIFF
--- a/designer/client/babel.config.cjs
+++ b/designer/client/babel.config.cjs
@@ -33,7 +33,6 @@ module.exports = {
         browserslistEnv: 'javascripts',
         bugfixes: true,
         corejs: pkg.devDependencies['core-js'],
-        modules: NODE_ENV === 'test' ? 'auto' : 'umd',
         useBuiltIns: 'usage'
       }
     ]

--- a/designer/nodemon.json
+++ b/designer/nodemon.json
@@ -3,8 +3,5 @@
   "env": {
     "NODE_ENV": "development"
   },
-  "execMap": {
-    "js": "node --enable-source-maps --no-warnings"
-  },
   "ext": "js,json"
 }

--- a/designer/nodemon.json
+++ b/designer/nodemon.json
@@ -1,5 +1,8 @@
 {
   "watch": ["./server/dist"],
+  "env": {
+    "NODE_ENV": "development"
+  },
   "execMap": {
     "js": "node --enable-source-maps --no-warnings"
   },

--- a/designer/package.json
+++ b/designer/package.json
@@ -9,7 +9,6 @@
     "directory": "designer"
   },
   "license": "OGL-UK-3.0",
-  "main": "server/dist/index.js",
   "type": "module",
   "scripts": {
     "audit": "npm audit --audit-level=high",

--- a/designer/package.json
+++ b/designer/package.json
@@ -14,16 +14,16 @@
   "scripts": {
     "audit": "npm audit --audit-level=high",
     "build": "npm run build:server && npm run build:client",
-    "build:client": "NODE_ENV=production webpack",
+    "build:client": "NODE_ENV=${NODE_ENV:-production} webpack",
     "build:server": "BABEL_ENV=node babel --delete-dir-on-start --extensions \".js\",\".ts\" --ignore \"**/*.test.*\" --ignore \"**/layouts/legacy-layout.njk\" --copy-files --no-copy-ignored --source-maps --out-dir ./server/dist ./server/src",
     "dev": "concurrently \"npm run build:server -- --watch\" \"npm run client:watch\" \"npm run server:watch\"",
     "symlink-env": "./bin/symlink-config",
     "test": "jest --color --coverage --verbose",
     "test:watch": "jest --color --watch",
-    "client:watch": "NODE_ENV=development webpack --watch",
+    "client:watch": "NODE_ENV=development npm run build:client --watch",
     "server:watch": "PERSISTENT_BACKEND=preview wait-on --delay 2000 ./client/dist/assets/manifest.json && nodemon",
     "prestart": "npm run build",
-    "start": "NODE_ENV=production node --enable-source-maps ./server/dist/index.js"
+    "start": "NODE_ENV=${NODE_ENV:-production} node --enable-source-maps ./server/dist/index.js"
   },
   "dependencies": {
     "@defra/forms-model": "^3.0.11",

--- a/designer/webpack.config.cjs
+++ b/designer/webpack.config.cjs
@@ -194,5 +194,5 @@ module.exports = {
       '.mjs': ['.mts', '.mjs']
     }
   },
-  target: 'web'
+  target: 'browserslist:javascripts'
 }

--- a/model/.browserslistrc
+++ b/model/.browserslistrc
@@ -1,16 +1,2 @@
-[javascripts]
-supports es6-module
-
-[stylesheets]
-> 0.1% in GB and not dead
-last 6 Chrome versions
-last 6 Firefox versions
-last 6 Edge versions
-last 2 Samsung versions
-Firefox ESR
-Safari >= 11
-iOS >= 11
-ie 11
-
 [node]
 node 20

--- a/model/package.json
+++ b/model/package.json
@@ -10,12 +10,10 @@
   },
   "license": "OGL-UK-3.0",
   "main": "dist/module/index.js",
-  "browser": "dist/browser/index.js",
   "types": "dist/types/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "npm run build:types && npm run build:node && npm run build:browser",
-    "build:browser": "BABEL_ENV=javascripts babel --delete-dir-on-start --extensions \".ts\" --ignore \"**/*.test.*\" --copy-files --no-copy-ignored --source-maps --out-dir ./dist/browser ./src",
+    "build": "npm run build:types && npm run build:node",
     "build:node": "BABEL_ENV=node babel --delete-dir-on-start --extensions \".ts\" --ignore \"**/*.test.*\" --copy-files --no-copy-ignored --source-maps --out-dir ./dist/module ./src",
     "build:types": "tsc --build --force tsconfig.build.json && tsc-alias --project tsconfig.build.json",
     "test": "jest --color --coverage --verbose",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces",
+    "predev": "npm run build --workspace model",
     "dev": "npm run dev --workspace designer",
     "format": "prettier --write \"**/*.{cjs,js,jsx,json,md,mjs,scss,ts,tsx}\"",
     "format:check": "prettier --check \"**/*.{cjs,js,jsx,json,md,mjs,scss,ts,tsx}\"",


### PR DESCRIPTION
All ES module imports should be fully specified like `..` → `../index.js`

As a workaround for `@xgovformbuilder/govuk-react-jsx` we use Babel with webpack `{ fullySpecified: false }`

https://github.com/DEFRA/forms-designer/blob/6d71d55d7b0ef052793d2a71304c9f84d7ca817a/designer/webpack.config.cjs#L50-L59

But unfortunately webpack hits an [unknown `..` import in `govuk/template/index.js`](https://github.com/XGovFormBuilder/govuk-react-jsx/blob/main/src/govuk/template/index.js#L11)

This PR removes the `main` export in `@defra/forms-designer` so `govuk/index.js` is matched instead