### PR TITLE
Always use mock auth in tests

### DIFF
--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -84,11 +84,11 @@ export async function createServer() {
   await server.register(inert, registrationOptions)
   await server.register(sessionManager)
 
-  if (config.oidcWellKnownConfigurationUrl) {
-    await server.register(azureOidc)
-  } else {
-    await server.register(azureOidcNoop)
-  }
+  await server.register(
+    config.isTest
+      ? azureOidcNoop // Mock auth for tests
+      : azureOidc // OpenID Connect (OIDC) auth
+  )
 
   await server.register(sessionCookie)
 

--- a/designer/server/src/login/controller.js
+++ b/designer/server/src/login/controller.js
@@ -4,14 +4,8 @@ const loginController = {
   options: {
     auth: 'azure-oidc'
   },
-  handler: (request, h) => {
-    // TODO re-vert to just h.redirect(config.appPathPrefix) once feature flag removed
-    // re-visit 2024-02-26
-    if (config.oidcWellKnownConfigurationUrl) {
-      return h.redirect(config.appPathPrefix)
-    } else {
-      return h.redirect(`${config.appPathPrefix}/auth/callback`)
-    }
+  handler(request, h) {
+    return h.redirect(config.appPathPrefix)
   }
 }
 


### PR DESCRIPTION
This PR ensures tests always use mock authentication

This wasn't the case (locally) when `OIDC_WELL_KNOWN_CONFIGURATION_URL` was set