### PR TITLE
Fix helper `isMultipleApiKey()` exported as type

### DIFF
--- a/model/src/data-model/helpers.ts
+++ b/model/src/data-model/helpers.ts
@@ -1,0 +1,8 @@
+import { type MultipleApiKeys } from '~/src/data-model/types.js'
+
+export function isMultipleApiKey(
+  payApiKey: string | MultipleApiKeys | undefined
+): payApiKey is MultipleApiKeys {
+  const obj = payApiKey as MultipleApiKeys
+  return obj.test !== undefined || obj.production !== undefined
+}

--- a/model/src/data-model/index.ts
+++ b/model/src/data-model/index.ts
@@ -1,3 +1,4 @@
 export { InputWrapper } from '~/src/data-model/input-wrapper.js'
 export { ConditionsWrapper } from '~/src/data-model/conditions-wrapper.js'
 export { OutputType } from '~/src/data-model/enums.js'
+export { isMultipleApiKey } from '~/src/data-model/helpers.js'

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -124,13 +124,6 @@ export interface SpecialPages {
   paymentSkippedWarningPage?: PaymentSkippedWarningPage
 }
 
-export function isMultipleApiKey(
-  payApiKey: string | MultipleApiKeys | undefined
-): payApiKey is MultipleApiKeys {
-  const obj = payApiKey as MultipleApiKeys
-  return obj.test !== undefined || obj.production !== undefined
-}
-
 export interface Fee {
   description: string
   amount: number
@@ -177,7 +170,7 @@ export interface FormDefinition {
   skipSummary?: boolean | undefined
   outputs: Output[]
   declaration?: string | undefined
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
   payApiKey?: string | MultipleApiKeys | undefined
   specialPages?: SpecialPages
   paymentReferenceFormat?: string


### PR DESCRIPTION
This resolves an issue in `@defra/forms-runner` when importing from `@defra/forms-model`