### PR TITLE
Use `appHeading()` and `appPageBody()` for page content

### DIFF
--- a/designer/server/src/common/components/heading/template.njk
+++ b/designer/server/src/common/components/heading/template.njk
@@ -1,11 +1,13 @@
 <div class="govuk-grid-row app-heading" data-testid="app-heading">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2"
-        data-testid="app-heading-title">{{ params.text }}</h1>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-2" data-testid="app-heading-title">
+      {{ params.text }}
+    </h1>
 
-    {% if params.caption %}
-      <span class="govuk-caption-m"
-            data-testid="app-heading-caption">{{ params.caption }}</span>
-    {% endif %}
+  {% if params.caption %}
+    <span class="govuk-caption-m" data-testid="app-heading-caption">
+      {{ params.caption }}
+    </span>
+  {% endif %}
   </div>
 </div>

--- a/designer/server/src/plugins/routes/app.test.ts
+++ b/designer/server/src/plugins/routes/app.test.ts
@@ -1,6 +1,7 @@
 import { type Server } from '@hapi/hapi'
 
 import { auth } from '~/test/fixtures/auth.js'
+import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 describe('App routes test', () => {
   const startServer = async (): Promise<Server> => {
@@ -38,10 +39,8 @@ describe('App routes test', () => {
       auth
     }
 
-    const res = await server.inject(options)
-
-    expect(res.statusCode).toBe(200)
-    expect(res.result).toContain(
+    const { document } = await renderResponse(server, options)
+    expect(document.body).toContainHTML(
       '<div class="govuk-grid-column-full app-editor"></div>'
     )
   })

--- a/designer/server/src/routes/library.test.js
+++ b/designer/server/src/routes/library.test.js
@@ -1,6 +1,7 @@
 import { createServer } from '~/src/createServer.js'
 import * as forms from '~/src/lib/forms.js'
 import { auth } from '~/test/fixtures/auth.js'
+import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 jest.mock('~/src/lib/forms.js')
 
@@ -13,10 +14,7 @@ describe('Forms library routes', () => {
     await server.initialize()
   })
 
-  const okStatusCode = 200
-  const htmlContentType = 'text/html'
-
-  test('Testing Forms library list page', async () => {
+  test('Forms library list page', async () => {
     const title = 'Form 1'
 
     // Mock the api call to forms-manager
@@ -30,18 +28,19 @@ describe('Forms library routes', () => {
       }
     ])
 
-    const res = await server.inject({
+    const options = {
       method: 'GET',
       url: '/forms-designer/library',
       auth
-    })
+    }
 
-    expect(res.statusCode).toBe(okStatusCode)
-    expect(res.headers['content-type']).toContain(htmlContentType)
-    expect(res.result).toContain(
-      `<h1 class="govuk-heading-xl govuk-!-margin-bottom-2"
-        data-testid="app-heading-title">Forms library</h1>`
-    )
-    expect(res.result).toContain(`<td class="govuk-table__cell">${title}</td>`)
+    const { document } = await renderResponse(server, options)
+
+    const $heading = document.querySelector('h1')
+    expect($heading).toHaveClass('govuk-heading-xl')
+    expect($heading).toHaveTextContent('Forms library')
+
+    const $table = document.querySelector('table')
+    expect($table).toContainHTML(`<td class="govuk-table__cell">${title}</td>`)
   })
 })

--- a/designer/server/src/views/help/accessibility-statement.njk
+++ b/designer/server/src/views/help/accessibility-statement.njk
@@ -3,344 +3,342 @@
 {% set pageTitle = "Accessibility statement" %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        Accessibility statement for [website name]
-      </h1>
+  {{ appHeading({
+    text: "Accessibility statement for [website name]"
+  }) }}
 
-      <p class="govuk-body">
-        This accessibility statement applies to [scope of statement, for
-        example, website or domain to which the statement applies].
-      </p>
+  {% call appPageBody() %}
+    <p class="govuk-body">
+      This accessibility statement applies to [scope of statement, for
+      example, website or domain to which the statement applies].
+    </p>
 
-      <p class="govuk-body">
-        This website is run by [name of organisation]. We want as many people as
-        possible to be able to use this website. For example, that means you
-        should be able to:
-      </p>
+    <p class="govuk-body">
+      This website is run by [name of organisation]. We want as many people as
+      possible to be able to use this website. For example, that means you
+      should be able to:
+    </p>
 
-      <ul class="govuk-list">
-        <li>
-          change colours, contrast levels and fonts using browser or device
-          settings
-        </li>
-        <li>zoom in up to 400% without the text spilling off the screen</li>
-        <li>
-          navigate most of the website using a keyboard or speech recognition
-          software
-        </li>
-        <li>
-          listen to most of the website using a screen reader (including the
-          most recent versions of JAWS, NVDA and VoiceOver)
-        </li>
-      </ul>
+    <ul class="govuk-list">
+      <li>
+        change colours, contrast levels and fonts using browser or device
+        settings
+      </li>
+      <li>zoom in up to 400% without the text spilling off the screen</li>
+      <li>
+        navigate most of the website using a keyboard or speech recognition
+        software
+      </li>
+      <li>
+        listen to most of the website using a screen reader (including the
+        most recent versions of JAWS, NVDA and VoiceOver)
+      </li>
+    </ul>
 
-      <p class="govuk-body">
-        We’ve also made the website text as simple as possible to understand.
-      </p>
+    <p class="govuk-body">
+      We’ve also made the website text as simple as possible to understand.
+    </p>
 
-      <p class="govuk-body">
-        <a
-          rel="external"
-          href="https://mcmw.abilitynet.org.uk/"
-          class="govuk-link">
-          AbilityNet
-        </a>
-        has advice on making your device easier to use if you have a disability.
-      </p>
+    <p class="govuk-body">
+      <a
+        rel="external"
+        href="https://mcmw.abilitynet.org.uk/"
+        class="govuk-link">
+        AbilityNet
+      </a>
+      has advice on making your device easier to use if you have a disability.
+    </p>
 
-      <h3 id="how-accessible-this-website-is" class="govuk-heading-m">
-        How accessible this website is
-      </h3>
+    <h3 id="how-accessible-this-website-is" class="govuk-heading-m">
+      How accessible this website is
+    </h3>
 
-      <p class="govuk-body">
-        We know some parts of this website are not fully accessible:
-      </p>
+    <p class="govuk-body">
+      We know some parts of this website are not fully accessible:
+    </p>
 
-      <ul class="govuk-list">
-        <li>you cannot modify the line height or spacing of text</li>
-        <li>
-          most older PDF documents are not fully accessible to screen reader
-          software
-        </li>
-        <li>live video streams do not have captions</li>
-        <li>you cannot skip to the main content when using a screen reader</li>
-        <li>
-          there’s a limit to how far you can magnify the map on our ‘contact us’
-          page
-        </li>
-      </ul>
+    <ul class="govuk-list">
+      <li>you cannot modify the line height or spacing of text</li>
+      <li>
+        most older PDF documents are not fully accessible to screen reader
+        software
+      </li>
+      <li>live video streams do not have captions</li>
+      <li>you cannot skip to the main content when using a screen reader</li>
+      <li>
+        there’s a limit to how far you can magnify the map on our ‘contact us’
+        page
+      </li>
+    </ul>
 
-      <h3 id="feedback-and-contact-information" class="govuk-heading-m">
-        Feedback and contact information
-      </h3>
+    <h3 id="feedback-and-contact-information" class="govuk-heading-m">
+      Feedback and contact information
+    </h3>
 
-      <p class="govuk-body">
-        If you find any problems not listed on this page or think we’re not
-        meeting accessibility requirements, contact: [provide both details of
-        how to report these issues to your organisation, and contact details for
-        the unit or person responsible for dealing with these reports].
-      </p>
+    <p class="govuk-body">
+      If you find any problems not listed on this page or think we’re not
+      meeting accessibility requirements, contact: [provide both details of
+      how to report these issues to your organisation, and contact details for
+      the unit or person responsible for dealing with these reports].
+    </p>
 
-      <p class="govuk-body">
-        If you need information on this website in a different format like
-        accessible PDF, large print, easy read, audio recording or braille:
-      </p>
+    <p class="govuk-body">
+      If you need information on this website in a different format like
+      accessible PDF, large print, easy read, audio recording or braille:
+    </p>
 
-      <ul class="govuk-list">
-        <li>email [email address]</li>
-        <li>call [phone number]</li>
-        <li>[add any other contact details]</li>
-      </ul>
+    <ul class="govuk-list">
+      <li>email [email address]</li>
+      <li>call [phone number]</li>
+      <li>[add any other contact details]</li>
+    </ul>
 
-      <p class="govuk-body">
-        We’ll consider your request and get back to you in [number] days.
-      </p>
+    <p class="govuk-body">
+      We’ll consider your request and get back to you in [number] days.
+    </p>
 
-      <p class="govuk-body">
-        If you cannot view the map on our ‘contact us’ page, call or email us
-        [add link to contact details page] for directions.
-      </p>
+    <p class="govuk-body">
+      If you cannot view the map on our ‘contact us’ page, call or email us
+      [add link to contact details page] for directions.
+    </p>
 
-      <h3 id="enforcement-procedure" class="govuk-heading-m">
-        Enforcement procedure
-      </h3>
+    <h3 id="enforcement-procedure" class="govuk-heading-m">
+      Enforcement procedure
+    </h3>
 
-      <p class="govuk-body">
-        [Note: this wording is legally required and must not be changed.]
-      </p>
+    <p class="govuk-body">
+      [Note: this wording is legally required and must not be changed.]
+    </p>
 
-      <p class="govuk-body">
-        The Equality and Human Rights Commission (EHRC) is responsible for
-        enforcing the Public Sector Bodies (Websites and Mobile Applications)
-        (No. 2) Accessibility Regulations 2018 (the ‘accessibility
-        regulations’). If you’re not happy with how we respond to your
-        complaint,
-        <a
-          rel="external"
-          href="https://www.equalityadvisoryservice.com/"
-          class="govuk-link">
-          contact the Equality Advisory and Support Service (EASS)
-        </a>
-        .
-      </p>
+    <p class="govuk-body">
+      The Equality and Human Rights Commission (EHRC) is responsible for
+      enforcing the Public Sector Bodies (Websites and Mobile Applications)
+      (No. 2) Accessibility Regulations 2018 (the ‘accessibility
+      regulations’). If you’re not happy with how we respond to your
+      complaint,
+      <a
+        rel="external"
+        href="https://www.equalityadvisoryservice.com/"
+        class="govuk-link">
+        contact the Equality Advisory and Support Service (EASS)
+      </a>
+      .
+    </p>
 
-      <h2
-        id="technical-information-about-this-websites-accessibility"
-        class="govuk-heading-l">
-        Technical information about this website’s accessibility
-      </h2>
+    <h2
+      id="technical-information-about-this-websites-accessibility"
+      class="govuk-heading-l">
+      Technical information about this website’s accessibility
+    </h2>
 
-      <p class="govuk-body">
-        [Name of organisation] is committed to making its website accessible, in
-        accordance with the Public Sector Bodies (Websites and Mobile
-        Applications) (No. 2) Accessibility Regulations 2018.
-      </p>
+    <p class="govuk-body">
+      [Name of organisation] is committed to making its website accessible, in
+      accordance with the Public Sector Bodies (Websites and Mobile
+      Applications) (No. 2) Accessibility Regulations 2018.
+    </p>
 
-      <h3 id="compliance-status" class="govuk-heading-m">Compliance status</h3>
+    <h3 id="compliance-status" class="govuk-heading-m">Compliance status</h3>
 
-      <p class="govuk-body">
-        The website has been tested against the Web Content Accessibility
-        Guidelines (WCAG) [2.1 or 2.2] AA standard.
-      </p>
+    <p class="govuk-body">
+      The website has been tested against the Web Content Accessibility
+      Guidelines (WCAG) [2.1 or 2.2] AA standard.
+    </p>
 
-      <p class="govuk-body">
-        [Select (a) only if all requirements of the technical specification are
-        fully met without exceptions for WCAG 2.1 or WCAG 2.2.]
-      </p>
+    <p class="govuk-body">
+      [Select (a) only if all requirements of the technical specification are
+      fully met without exceptions for WCAG 2.1 or WCAG 2.2.]
+    </p>
 
-      <p class="govuk-body">
-        (a) This website is fully compliant with the [
-        <a
-          rel="external"
-          href="https://www.w3.org/TR/WCAG21/"
-          class="govuk-link">
-          Web Content Accessibility Guidelines version 2.1
-        </a>
-        AA standard or
-        <a
-          rel="external"
-          href="https://www.w3.org/TR/WCAG22/"
-          class="govuk-link">
-          Web Content Accessibility Guidelines version 2.2
-        </a>
-        AA standard].
-      </p>
+    <p class="govuk-body">
+      (a) This website is fully compliant with the [
+      <a
+        rel="external"
+        href="https://www.w3.org/TR/WCAG21/"
+        class="govuk-link">
+        Web Content Accessibility Guidelines version 2.1
+      </a>
+      AA standard or
+      <a
+        rel="external"
+        href="https://www.w3.org/TR/WCAG22/"
+        class="govuk-link">
+        Web Content Accessibility Guidelines version 2.2
+      </a>
+      AA standard].
+    </p>
 
-      <p class="govuk-body">
-        [Select (b) if most requirements of the technical specification are met,
-        but with some exceptions. This means not yet fully compliant and that
-        the necessary measures are to be taken in order to reach full
-        compliance.]
-      </p>
+    <p class="govuk-body">
+      [Select (b) if most requirements of the technical specification are met,
+      but with some exceptions. This means not yet fully compliant and that
+      the necessary measures are to be taken in order to reach full
+      compliance.]
+    </p>
 
-      <p class="govuk-body">
-        (b) This website is partially compliant with the [
-        <a
-          rel="external"
-          href="https://www.w3.org/TR/WCAG21/"
-          class="govuk-link">
-          Web Content Accessibility Guidelines version 2.1
-        </a>
-        AA standard or
-        <a
-          rel="external"
-          href="https://www.w3.org/TR/WCAG22/"
-          class="govuk-link">
-          Web Content Accessibility Guidelines version 2.2
-        </a>
-        AA standard], due to [insert one of the following: ‘the
-        non-compliances’, ‘the exemptions’ or ‘the non-compliances and
-        exemptions’] listed below.
-      </p>
+    <p class="govuk-body">
+      (b) This website is partially compliant with the [
+      <a
+        rel="external"
+        href="https://www.w3.org/TR/WCAG21/"
+        class="govuk-link">
+        Web Content Accessibility Guidelines version 2.1
+      </a>
+      AA standard or
+      <a
+        rel="external"
+        href="https://www.w3.org/TR/WCAG22/"
+        class="govuk-link">
+        Web Content Accessibility Guidelines version 2.2
+      </a>
+      AA standard], due to [insert one of the following: ‘the
+      non-compliances’, ‘the exemptions’ or ‘the non-compliances and
+      exemptions’] listed below.
+    </p>
 
-      <p class="govuk-body">
-        [Select (c) if most requirements of the technical specification are not
-        met.]
-      </p>
+    <p class="govuk-body">
+      [Select (c) if most requirements of the technical specification are not
+      met.]
+    </p>
 
-      <p class="govuk-body">
-        (c) This website is not compliant with the [
-        <a
-          rel="external"
-          href="https://www.w3.org/TR/WCAG21/"
-          class="govuk-link">
-          Web Content Accessibility Guidelines version 2.1
-        </a>
-        AA standard or
-        <a
-          rel="external"
-          href="https://www.w3.org/TR/WCAG22/"
-          class="govuk-link">
-          Web Content Accessibility Guidelines version 2.2
-        </a>
-        AA standard]. The [insert one of the following: ‘non-compliances’,
-        ‘exemptions’ or ‘non-compliances and exemptions’] are listed below.
-      </p>
+    <p class="govuk-body">
+      (c) This website is not compliant with the [
+      <a
+        rel="external"
+        href="https://www.w3.org/TR/WCAG21/"
+        class="govuk-link">
+        Web Content Accessibility Guidelines version 2.1
+      </a>
+      AA standard or
+      <a
+        rel="external"
+        href="https://www.w3.org/TR/WCAG22/"
+        class="govuk-link">
+        Web Content Accessibility Guidelines version 2.2
+      </a>
+      AA standard]. The [insert one of the following: ‘non-compliances’,
+      ‘exemptions’ or ‘non-compliances and exemptions’] are listed below.
+    </p>
 
-      <h2 id="non-accessible-content" class="govuk-heading-l">
-        Non-accessible content
-      </h2>
+    <h2 id="non-accessible-content" class="govuk-heading-l">
+      Non-accessible content
+    </h2>
 
-      <p class="govuk-body">
-        The content listed below is non-accessible for the following reasons.
-      </p>
+    <p class="govuk-body">
+      The content listed below is non-accessible for the following reasons.
+    </p>
 
-      <h3
-        id="non-compliance-with-the-accessibility-regulations"
-        class="govuk-heading-m">
-        Non-compliance with the accessibility regulations
-      </h3>
+    <h3
+      id="non-compliance-with-the-accessibility-regulations"
+      class="govuk-heading-m">
+      Non-compliance with the accessibility regulations
+    </h3>
 
-      <p class="govuk-body">
-        Some images do not have a text alternative, so people using a screen
-        reader cannot access the information. This fails WCAG 2.2 success
-        criterion 1.1.1 (non-text content).
-      </p>
+    <p class="govuk-body">
+      Some images do not have a text alternative, so people using a screen
+      reader cannot access the information. This fails WCAG 2.2 success
+      criterion 1.1.1 (non-text content).
+    </p>
 
-      <p class="govuk-body">
-        We plan to add text alternatives for all images by September 2022. When
-        we publish new content we’ll make sure our use of images meets
-        accessibility standards.
-      </p>
+    <p class="govuk-body">
+      We plan to add text alternatives for all images by September 2022. When
+      we publish new content we’ll make sure our use of images meets
+      accessibility standards.
+    </p>
 
-      <h3 id="disproportionate-burden" class="govuk-heading-m">
-        Disproportionate burden
-      </h3>
+    <h3 id="disproportionate-burden" class="govuk-heading-m">
+      Disproportionate burden
+    </h3>
 
-      <h4 id="navigation-and-accessing-information" class="govuk-heading-s">
-        Navigation and accessing information
-      </h4>
+    <h4 id="navigation-and-accessing-information" class="govuk-heading-s">
+      Navigation and accessing information
+    </h4>
 
-      <p class="govuk-body">
-        There’s no way to skip the repeated content in the page header (for
-        example, a ‘skip to main content’ option).
-      </p>
+    <p class="govuk-body">
+      There’s no way to skip the repeated content in the page header (for
+      example, a ‘skip to main content’ option).
+    </p>
 
-      <p class="govuk-body">
-        It’s not always possible to change the device orientation from
-        horizontal to vertical without making it more difficult to view the
-        content.
-      </p>
+    <p class="govuk-body">
+      It’s not always possible to change the device orientation from
+      horizontal to vertical without making it more difficult to view the
+      content.
+    </p>
 
-      <p class="govuk-body">
-        It’s not possible for users to change text size without some of the
-        content overlapping.
-      </p>
+    <p class="govuk-body">
+      It’s not possible for users to change text size without some of the
+      content overlapping.
+    </p>
 
-      <p class="govuk-body">
-        We’ve assessed the cost of fixing the issues with navigation and
-        accessing information. We believe that doing so now would be a
-        disproportionate burden within the meaning of the accessibility
-        regulations. We will make another assessment when the supplier contract
-        is up for renewal, likely to be in [rough timing].
-      </p>
+    <p class="govuk-body">
+      We’ve assessed the cost of fixing the issues with navigation and
+      accessing information. We believe that doing so now would be a
+      disproportionate burden within the meaning of the accessibility
+      regulations. We will make another assessment when the supplier contract
+      is up for renewal, likely to be in [rough timing].
+    </p>
 
-      <h3
-        id="content-thats-not-within-the-scope-of-the-accessibility-regulations"
-        class="govuk-heading-m">
-        Content that’s not within the scope of the accessibility regulations
-      </h3>
+    <h3
+      id="content-thats-not-within-the-scope-of-the-accessibility-regulations"
+      class="govuk-heading-m">
+      Content that’s not within the scope of the accessibility regulations
+    </h3>
 
-      <h4 id="pdfs-and-other-documents" class="govuk-heading-s">
-        PDFs and other documents
-      </h4>
+    <h4 id="pdfs-and-other-documents" class="govuk-heading-s">
+      PDFs and other documents
+    </h4>
 
-      <p class="govuk-body">
-        The accessibility regulations do not require us to fix PDFs or other
-        documents published before 23 September 2018 if they’re not essential to
-        providing our services. For example, we do not plan to fix [example of
-        non-essential document].
-      </p>
+    <p class="govuk-body">
+      The accessibility regulations do not require us to fix PDFs or other
+      documents published before 23 September 2018 if they’re not essential to
+      providing our services. For example, we do not plan to fix [example of
+      non-essential document].
+    </p>
 
-      <p class="govuk-body">
-        Any new PDFs or Word documents we publish will meet accessibility
-        standards.
-      </p>
+    <p class="govuk-body">
+      Any new PDFs or Word documents we publish will meet accessibility
+      standards.
+    </p>
 
-      <h4 id="live-video" class="govuk-heading-s">Live video</h4>
+    <h4 id="live-video" class="govuk-heading-s">Live video</h4>
 
-      <p class="govuk-body">
-        We do not plan to add captions to live video streams because live video
-        is exempt from meeting the accessibility regulations.
-      </p>
+    <p class="govuk-body">
+      We do not plan to add captions to live video streams because live video
+      is exempt from meeting the accessibility regulations.
+    </p>
 
-      <h2 id="what-were-doing-to-improve-accessibility" class="govuk-heading-l">
-        What we’re doing to improve accessibility
-      </h2>
+    <h2 id="what-were-doing-to-improve-accessibility" class="govuk-heading-l">
+      What we’re doing to improve accessibility
+    </h2>
 
-      <p class="govuk-body">
-        Our accessibility roadmap [add link to roadmap] shows how and when we
-        plan to improve accessibility on this website.
-      </p>
+    <p class="govuk-body">
+      Our accessibility roadmap [add link to roadmap] shows how and when we
+      plan to improve accessibility on this website.
+    </p>
 
-      <h2
-        id="preparation-of-this-accessibility-statement"
-        class="govuk-heading-l">
-        Preparation of this accessibility statement
-      </h2>
+    <h2
+      id="preparation-of-this-accessibility-statement"
+      class="govuk-heading-l">
+      Preparation of this accessibility statement
+    </h2>
 
-      <p class="govuk-body">
-        This statement was prepared on [date when it was first published]. It
-        was last reviewed on [date when it was last reviewed].
-      </p>
+    <p class="govuk-body">
+      This statement was prepared on [date when it was first published]. It
+      was last reviewed on [date when it was last reviewed].
+    </p>
 
-      <p class="govuk-body">
-        This website was last tested on [date] against the WCAG [2.1 or 2.2] AA
-        standard.
-      </p>
+    <p class="govuk-body">
+      This website was last tested on [date] against the WCAG [2.1 or 2.2] AA
+      standard.
+    </p>
 
-      <p class="govuk-body">
-        The test was carried out by [add name of organisation that carried out
-        test, or indicate that you did your own testing]. The most viewed pages
-        were tested using automated testing tools by our website team. A further
-        audit of the website was carried out to the WCAG 2.2 AA standard.
-      </p>
+    <p class="govuk-body">
+      The test was carried out by [add name of organisation that carried out
+      test, or indicate that you did your own testing]. The most viewed pages
+      were tested using automated testing tools by our website team. A further
+      audit of the website was carried out to the WCAG 2.2 AA standard.
+    </p>
 
-      <p class="govuk-body">
-        You can read the full accessibility test report [add link to report].
-      </p>
-    </div>
-  </div>
+    <p class="govuk-body">
+      You can read the full accessibility test report [add link to report].
+    </p>
+  {% endcall %}
 {% endblock %}

--- a/designer/server/src/views/help/cookies.njk
+++ b/designer/server/src/views/help/cookies.njk
@@ -5,66 +5,67 @@
 {% set pageTitle = "Cookies" %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Cookies</h1>
-      <p class="govuk-body">
-        <a href="{{ config.appPathPrefix }}" class="govuk-link">{{ config.serviceName }}</a>
-        puts small files (known as ‘cookies’) on your computer.
-      </p>
+  {{ appHeading({
+    text: pageTitle
+  }) }}
 
-      <p class="govuk-body">
-        These cookies are used across the {{ config.serviceName }} website.
-      </p>
+  {% call appPageBody() %}
+    <p class="govuk-body">
+      <a href="{{ config.appPathPrefix }}" class="govuk-link">{{ config.serviceName }}</a>
+      puts small files (known as ‘cookies’) on your computer.
+    </p>
 
-      <p class="govuk-body">
-        We only set cookies when JavaScript is running in your browser and
-        you’ve accepted them. If you choose not to run Javascript, the
-        information on this page will not apply to you.
-      </p>
+    <p class="govuk-body">
+      These cookies are used across the {{ config.serviceName }} website.
+    </p>
 
-      <p class="govuk-body">
-        Find out
-        <a
-          rel="external"
-          href="https://ico.org.uk/for-the-public/online/cookies"
-          class="govuk-link">
-          how to manage cookies
-        </a>
-        from the Information Commissioner's Office.
-      </p>
+    <p class="govuk-body">
+      We only set cookies when JavaScript is running in your browser and
+      you’ve accepted them. If you choose not to run Javascript, the
+      information on this page will not apply to you.
+    </p>
 
-      <h2 class="govuk-heading-l govuk-!-margin-top-6">
-        Essential cookies (strictly necessary)
-      </h2>
+    <p class="govuk-body">
+      Find out
+      <a
+        rel="external"
+        href="https://ico.org.uk/for-the-public/online/cookies"
+        class="govuk-link">
+        how to manage cookies
+      </a>
+      from the Information Commissioner's Office.
+    </p>
 
-      <p class="govuk-body">
-        We use an essential cookie to remember your progress through the forms.
-        These cookies do not store your personal data and are deleted once
-        you’ve completed the transaction.
-      </p>
+    <h2 class="govuk-heading-l govuk-!-margin-top-6">
+      Essential cookies (strictly necessary)
+    </h2>
 
-      {{ govukTable({
-        firstCellIsHeader: true,
-        caption: "Essential cookies we use",
-        head: [
-          { text: "Name" },
-          { text: "Purpose"},
-          { text: "Expires"}
+    <p class="govuk-body">
+      We use an essential cookie to remember your progress through the forms.
+      These cookies do not store your personal data and are deleted once
+      you’ve completed the transaction.
+    </p>
+
+    {{ govukTable({
+      firstCellIsHeader: true,
+      caption: "Essential cookies we use",
+      head: [
+        { text: "Name" },
+        { text: "Purpose"},
+        { text: "Expires"}
+      ],
+      rows: [
+        [
+          { text: "seen_cookie" },
+          { text: "Saves your cookie consent settings" },
+          { text: "28 days" }
         ],
-        rows: [
-          [
-            { text: "seen_cookie" },
-            { text: "Saves your cookie consent settings" },
-            { text: "28 days" }
-          ],
-          [
-            { text: "crumb" },
-            { text: "Helps us to prevent cross site scripting attacks" },
-            { text: "When you close your browser" }
-          ]
+        [
+          { text: "crumb" },
+          { text: "Helps us to prevent cross site scripting attacks" },
+          { text: "When you close your browser" }
         ]
-      }) }}
-    </div>
-  </div>
+      ]
+    }) }}
+  {% endcall %}
 {% endblock %}

--- a/designer/server/src/views/help/feedback.njk
+++ b/designer/server/src/views/help/feedback.njk
@@ -3,41 +3,39 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
-{% set pageTitle = "Feedback" %}
+{% set pageTitle = "Give feedback" %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        Give feedback
-      </h1>
+  {{ appHeading({
+    text: pageTitle
+  }) }}
 
-      <form method="post" novalidate>
-        {{ govukCharacterCount({
-          name: "feedback",
-          id: "feedback",
-          maxlength: 500,
-          label: {
-            text: "How can we improve this service?",
-            classes: "govuk-label--l"
-          },
-          hint: {
-            text: "Do not include personal or financial information like your National Insurance number or credit card details."
-          }
+  {% call appPageBody() %}
+    <form method="post" novalidate>
+      {{ govukCharacterCount({
+        name: "feedback",
+        id: "feedback",
+        maxlength: 500,
+        label: {
+          text: "How can we improve this service?",
+          classes: "govuk-label--l"
+        },
+        hint: {
+          text: "Do not include personal or financial information like your National Insurance number or credit card details."
+        }
+      }) }}
+
+      <div class="govuk-button-group">
+        {{ govukButton({
+          text: "Send feedback"
         }) }}
 
-        <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Send feedback"
-          }) }}
-
-          {{ govukButton({
-            text: "Cancel",
-            href: config.appPathPrefix + "/",
-            classes: "govuk-button--secondary"
-          }) }}
-        </div>
-      </form>
-    </div>
-  </div>
+        {{ govukButton({
+          text: "Cancel",
+          href: config.appPathPrefix + "/",
+          classes: "govuk-button--secondary"
+        }) }}
+      </div>
+    </form>
+  {% endcall %}
 {% endblock %}

--- a/designer/server/src/views/library.njk
+++ b/designer/server/src/views/library.njk
@@ -12,6 +12,6 @@
     {{ govukTable({
       head: head,
       rows: rows
-    }) }}    
+    }) }}
   {% endcall %}
 {% endblock %}


### PR DESCRIPTION
Updates our new static pages from https://github.com/DEFRA/forms-designer/pull/69 to use the built in page content macros