### PR TITLE
Fix missing Slack emoji

### DIFF
--- a/.github/workflows/pr-notifier.yml
+++ b/.github/workflows/pr-notifier.yml
@@ -17,27 +17,27 @@ env:
   CONFIG: |
     {
       "opened": {
-        "icon": "${{ github.event.pull_request.draft && ':pencil:' || ':new:' }}",
+        "icon": "${{ github.event.pull_request.draft && '📝' || '🆕' }}",
         "status": "${{ github.event.pull_request.draft && 'opened as draft' || 'opened' }}"
       },
       "converted_to_draft": {
-        "icon": ":pencil:",
+        "icon": "📝",
         "status": "converted to draft"
       },
       "ready_for_review": {
-        "icon": ":eyes:",
+        "icon": "👀",
         "status": "ready for review"
       },
       "reopened": {
-        "icon": ":recycle:",
+        "icon": "🔄",
         "status": "reopened"
       },
       "submitted": {
-        "icon": "${{ github.event.review.state == 'approved' && ':white_check_mark:' || ':speech_bubble:' }}",
-        "status": "${{ github.event.review.state == 'approved' && 'code review approved' || 'code review changes requested' }}"
+        "icon": "${{ github.event.review.state == 'approved' && '✅' || '💬' }}",
+        "status": "${{ github.event.review.state == 'approved' && 'code review approved' || 'code review comments' }}"
       },
       "closed": {
-        "icon": "${{ github.event.pull_request.merged && ':rocket:' || ':wastebasket:' }}",
+        "icon": "${{ github.event.pull_request.merged && '🚀' || '🗑️' }}",
         "status": "${{ github.event.pull_request.merged && 'merged' || 'closed' }}"
       }
     }


### PR DESCRIPTION
This PR swaps all codes to Emoji characters because it looks like `:speech_bubble:` didn't work via the API

From the [**Formatting: Emoji** documentation](https://api.slack.com/reference/surfaces/formatting#emoji) Slack says:

>If you're publishing text with emoji, you don't need to worry about converting them, just include them as-is.

