### PR TITLE
Move `joi` and `nanoid` to peer dependencies

### DIFF
--- a/model/package.json
+++ b/model/package.json
@@ -19,9 +19,13 @@
     "test": "jest --color --coverage --verbose",
     "test:watch": "jest --color --watch"
   },
-  "dependencies": {
-    "joi": "17.13.0",
-    "nanoid": "^3.3.4"
+  "devDependencies": {
+    "joi": "^17.13.0",
+    "nanoid": "^3.3.7"
+  },
+  "peerDependencies": {
+    "joi": "^17.0.0",
+    "nanoid": "^3.0.0"
   },
   "engines": {
     "node": "^20.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,13 +299,17 @@
       "name": "@defra/forms-model",
       "version": "3.0.56",
       "license": "OGL-UK-3.0",
-      "dependencies": {
-        "joi": "17.13.0",
-        "nanoid": "^3.3.4"
+      "devDependencies": {
+        "joi": "^17.13.0",
+        "nanoid": "^3.3.7"
       },
       "engines": {
         "node": "^20.9.0",
         "npm": "^10.1.0"
+      },
+      "peerDependencies": {
+        "joi": "^17.0.0",
+        "nanoid": "^3.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
Allow `npm install` to share a compatible `joi` and `nanoid` as `@defra/forms-model` **peerDependencies**

Otherwise each package can depend on their own mismatched versions:

```console
    Cannot mix different versions of joi schemas (0)

      80 |       })
      81 |       .optional(),
    > 82 |     components: joi.array().items(componentSchema)
```

I've included `nanoid` because `nanoid@4` and above is "ESM only" and won't work with Jest

This should prevent Dependabot PR checks from intentionally completing an `npm install` with an incompatible version