### PR TITLE
Add UK allow-list for email TLDs

### DIFF
--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -11,6 +11,9 @@ export const formMetadataSchema = Joi.object<FormMetadata>()
     title: Joi.string().max(250).trim().required(),
     organisation: Joi.string().max(100).trim().required(),
     teamName: Joi.string().max(100).trim().required(),
-    teamEmail: Joi.string().email().trim().required()
+    teamEmail: Joi.string()
+      .email({ tlds: { allow: ['uk'] } })
+      .trim()
+      .required()
   })
   .required()


### PR DESCRIPTION
Fixes the 'Built-in TLD list disabled' error.

Unfortunately there's no quick domain filter, else I'd have gone a step further.
