### PR TITLE
Remove dotenv, replace with --env-var

### DIFF
--- a/designer/nodemon.json
+++ b/designer/nodemon.json
@@ -3,5 +3,6 @@
   "env": {
     "NODE_ENV": "development"
   },
-  "ext": "js,json,ts"
+  "ext": "js,json,ts",
+  "exec": "tsx --env-file=.env --enable-source-maps ./server/src"
 }

--- a/designer/nodemon.json
+++ b/designer/nodemon.json
@@ -3,6 +3,9 @@
   "env": {
     "NODE_ENV": "development"
   },
-  "ext": "js,json,ts",
-  "exec": "tsx --env-file=.env --enable-source-maps ./server/src"
+  "execMap": {
+    "js": "node --enable-source-maps --env-file=.env",
+    "ts": "node --enable-source-maps --env-file=.env --import tsx"
+  },
+  "ext": "js,json,ts"
 }

--- a/designer/package.json
+++ b/designer/package.json
@@ -22,8 +22,8 @@
     "test": "jest --color --coverage --verbose",
     "test:watch": "jest --color --watch",
     "client:watch": "NODE_ENV=development npm run build:client -- --watch",
-    "server:watch": "nodemon --exec tsx --env-file=../.env --enable-source-maps ./server/src",
-    "server:debug": "nodemon --exec tsx --env-file=../.env --enable-source-maps --inspect ./server/src",
+    "server:watch": "nodemon",
+    "server:debug": "nodemon --inspect",
     "prestart": "npm run build",
     "start": "NODE_ENV=${NODE_ENV:-production} node --enable-source-maps ./server/dist/index.js"
   },

--- a/designer/package.json
+++ b/designer/package.json
@@ -22,8 +22,8 @@
     "test": "jest --color --coverage --verbose",
     "test:watch": "jest --color --watch",
     "client:watch": "NODE_ENV=development npm run build:client -- --watch",
-    "server:watch": "nodemon --exec tsx --enable-source-maps ./server/src",
-    "server:debug": "nodemon --exec tsx --enable-source-maps --inspect ./server/src",
+    "server:watch": "nodemon --exec tsx --env-file=../.env --enable-source-maps ./server/src",
+    "server:debug": "nodemon --exec tsx --env-file=../.env --enable-source-maps --inspect ./server/src",
     "prestart": "npm run build",
     "start": "NODE_ENV=${NODE_ENV:-production} node --enable-source-maps ./server/dist/index.js"
   },
@@ -47,7 +47,6 @@
     "classnames": "^2.5.1",
     "date-fns": "^2.30.0",
     "depth-first": "^4.0.0",
-    "dotenv": "^16.4.5",
     "focus-trap-react": "^8.11.3",
     "govuk-frontend": "^4.8.0",
     "hapi-pino": "^12.1.0",

--- a/designer/package.json
+++ b/designer/package.json
@@ -22,8 +22,8 @@
     "test": "jest --color --coverage --verbose",
     "test:watch": "jest --color --watch",
     "client:watch": "NODE_ENV=development npm run build:client -- --watch",
-    "server:watch": "nodemon",
-    "server:debug": "nodemon --inspect",
+    "server:watch": "nodemon ./server/src/index.ts",
+    "server:debug": "nodemon --inspect ./server/src/index.ts",
     "prestart": "npm run build",
     "start": "NODE_ENV=${NODE_ENV:-production} node --enable-source-maps ./server/dist/index.js"
   },

--- a/designer/server/src/config.ts
+++ b/designer/server/src/config.ts
@@ -1,15 +1,10 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { configDotenv } from 'dotenv'
 import joi from 'joi'
 import { Duration } from 'luxon'
 
 const configPath = fileURLToPath(import.meta.url)
-
-configDotenv({
-  path: [resolve(dirname(configPath), '../../.env')]
-})
 
 export interface Config {
   env: 'development' | 'test' | 'production'

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
         "classnames": "^2.5.1",
         "date-fns": "^2.30.0",
         "depth-first": "^4.0.0",
-        "dotenv": "^16.4.5",
         "focus-trap-react": "^8.11.3",
         "govuk-frontend": "^4.8.0",
         "hapi-pino": "^12.1.0",
@@ -7912,17 +7911,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer": {


### PR DESCRIPTION
This is only required for development, not in the live environment, therefore I've not modified `npm run start`.