### PR TITLE
Fix types for `<Flyout>` + enable `<RenderInPortal>` tests

### DIFF
--- a/designer/client/src/components/Flyout/Flyout.enzyme.test.tsx
+++ b/designer/client/src/components/Flyout/Flyout.enzyme.test.tsx
@@ -1,20 +1,19 @@
-import { mount } from 'enzyme'
+import { type ReactWrapper, mount } from 'enzyme'
 import React from 'react'
 
 import { useFlyoutEffect } from '~/src/components/Flyout/Flyout.jsx'
 import { FlyoutContext } from '~/src/context/index.js'
 
-function HookWrapper(props) {
-  const hook = props.hook ? props.hook() : undefined
-  // @ts-expect-error
-  // eslint-disable-next-line react/no-unknown-property
-  return <div hook={hook} />
+function HookWrapper(props: {
+  hook: () => ReturnType<typeof useFlyoutEffect>
+}) {
+  return <div style={props.hook().style} />
 }
 
 describe('useFlyoutContext', () => {
   const increment = jest.fn()
   const decrement = jest.fn()
-  let wrapper
+  let wrapper: ReactWrapper | undefined
 
   afterEach(() => {
     wrapper?.exists() && wrapper.unmount()
@@ -22,17 +21,20 @@ describe('useFlyoutContext', () => {
 
   test('Increment is called on mount', () => {
     const flyoutContextProviderValue = { count: 0, increment, decrement }
+
     wrapper = mount(
       <FlyoutContext.Provider value={flyoutContextProviderValue}>
         <HookWrapper hook={() => useFlyoutEffect({ show: true })} />
       </FlyoutContext.Provider>
     )
+
     expect(increment).toHaveBeenCalledTimes(1)
     expect(decrement).not.toHaveBeenCalled()
   })
 
   test('Decrement is called on unmount', () => {
     const flyoutContextProviderValue = { count: 0, increment, decrement }
+
     wrapper = mount(
       <FlyoutContext.Provider value={flyoutContextProviderValue}>
         <HookWrapper hook={() => useFlyoutEffect({ show: true })} />
@@ -50,19 +52,17 @@ describe('useFlyoutContext', () => {
       increment,
       decrement
     }
+
     expect(increment).not.toHaveBeenCalled()
+
     wrapper = mount(
       <FlyoutContext.Provider value={flyoutContextProviderValue}>
         <HookWrapper hook={() => useFlyoutEffect({ show: true })} />
       </FlyoutContext.Provider>
     )
 
-    const { hook } = wrapper.find('div').props()
-    wrapper.mount()
-    const { style } = hook
     expect(increment).toHaveBeenCalledTimes(1)
-
-    expect(style).toEqual({
+    expect(wrapper.find('div').props().style).toEqual({
       paddingLeft: '50px',
       transform: 'translateX(-50px)',
       position: 'relative'

--- a/designer/client/src/components/Flyout/Flyout.tsx
+++ b/designer/client/src/components/Flyout/Flyout.tsx
@@ -1,6 +1,8 @@
 import FocusTrap from 'focus-trap-react'
 import React, {
   type CSSProperties,
+  type KeyboardEvent,
+  type MouseEvent,
   type ReactChildren,
   useContext,
   useLayoutEffect,
@@ -13,12 +15,14 @@ import { i18n } from '~/src/i18n/index.js'
 import './Flyout.scss'
 
 interface Props {
-  style: string
+  style?: string
   width?: string
-  onHide: () => void
-  closeOnEnter: (e) => void
-  show: boolean
-  offset: number
+  onHide?: (
+    e?: KeyboardEvent<HTMLAnchorElement> | MouseEvent<HTMLAnchorElement>
+  ) => void
+  closeOnEnter?: (e: KeyboardEvent<HTMLAnchorElement>) => void
+  show?: boolean
+  offset?: number
   title?: string
   children?: ReactChildren
   NEVER_UNMOUNTS?: boolean
@@ -31,7 +35,7 @@ export function useFlyoutEffect(props: Props) {
   const show = props.show ?? true
 
   /**
-   * @code on component mount
+   * Run on component mount
    */
   useLayoutEffect(() => {
     flyoutContext.increment()
@@ -54,7 +58,7 @@ export function useFlyoutEffect(props: Props) {
     }
   }, [offset])
 
-  const onHide = (e) => {
+  const onHide: Props['onHide'] = (e) => {
     e?.preventDefault()
 
     if (props.onHide) {
@@ -66,7 +70,7 @@ export function useFlyoutEffect(props: Props) {
     }
   }
 
-  const closeOnEnter = (e) => {
+  const closeOnEnter: Props['closeOnEnter'] = (e) => {
     if (e.key === 'Enter') {
       onHide(e)
     }

--- a/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
+++ b/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
@@ -1,54 +1,54 @@
-test.todo('RenderInPortal renders a single component in portal')
-test.todo('RenderInPortal renders a multiple components in parallel')
-/**
- suite("Component RenderInPortal", () => {
-  test("renders paragraph inside portal", () => {
-    let portalRoot = document.querySelector("#portal-root");
- 
-    expect(portalRoot.innerHTML).to.equal("");
- 
+import { mount } from 'enzyme'
+import React from 'react'
+
+import { RenderInPortal } from '~/src/components/RenderInPortal/index.js'
+
+describe('RenderInPortal component', () => {
+  test('renders paragraph inside portal', () => {
+    let portalRoot = document.getElementById('portal-root')
+
+    expect(portalRoot?.innerHTML).toBe('')
+
     const wrapper = mount(
       <RenderInPortal>
         <p id="test-paragraph">Test</p>
       </RenderInPortal>
-    );
-    portalRoot = document.querySelector("#portal-root");
-    expect(portalRoot.innerHTML).to.equal(
+    )
+    portalRoot = document.getElementById('portal-root')
+    expect(portalRoot?.innerHTML).toBe(
       '<div><p id="test-paragraph">Test</p></div>'
-    );
- 
-    wrapper.unmount();
-    portalRoot = document.querySelector("#portal-root");
-    expect(portalRoot.innerHTML).to.equal("");
-  });
- 
-  test("renders multiple portals in parallel", () => {
+    )
+
+    wrapper.unmount()
+    portalRoot = document.getElementById('portal-root')
+    expect(portalRoot?.innerHTML).toBe('')
+  })
+
+  test('renders multiple portals in parallel', () => {
     const wrapper1 = mount(
       <RenderInPortal>
         <p id="test-paragraph1">Test 1</p>
       </RenderInPortal>
-    );
+    )
     const wrapper2 = mount(
       <RenderInPortal>
         <p id="test-paragraph2">Test 2</p>
       </RenderInPortal>
-    );
- 
-    let portalRoot = document.querySelector("#portal-root");
-    expect(portalRoot.innerHTML).to.equal(
+    )
+
+    let portalRoot = document.getElementById('portal-root')
+    expect(portalRoot?.innerHTML).toBe(
       '<div><p id="test-paragraph1">Test 1</p></div><div><p id="test-paragraph2">Test 2</p></div>'
-    );
- 
-    wrapper1.unmount();
-    portalRoot = document.querySelector("#portal-root");
-    expect(portalRoot.innerHTML).to.equal(
+    )
+
+    wrapper1.unmount()
+    portalRoot = document.getElementById('portal-root')
+    expect(portalRoot?.innerHTML).toBe(
       '<div><p id="test-paragraph2">Test 2</p></div>'
-    );
- 
-    wrapper2.unmount();
-    portalRoot = document.querySelector("#portal-root");
-    expect(portalRoot.innerHTML).to.equal("");
-  });
-});
- 
- */
+    )
+
+    wrapper2.unmount()
+    portalRoot = document.getElementById('portal-root')
+    expect(portalRoot?.innerHTML).toBe('')
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
       },
       "optionalDependencies": {
         "@types/dagre": "^0.7.52",
+        "@types/enzyme": "^3.10.18",
         "@types/hapi__catbox-memory": "^4.1.8",
         "@types/hapi__cookie": "^12.0.5",
         "@types/hapi__crumb": "^7.3.7",
@@ -4740,11 +4741,41 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cheerio": {
+      "version": "0.22.35",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
+      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/dagre": {
       "version": "0.7.52",
       "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.52.tgz",
       "integrity": "sha512-XKJdy+OClLk3hketHi9Qg6gTfe1F3y+UFnHxKA2rn9Dw+oXa4Gb378Ztz9HlMgZKSxpPmn4BNVh9wgkpvrK1uw==",
       "optional": true
+    },
+    "node_modules/@types/enzyme": {
+      "version": "3.10.18",
+      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.18.tgz",
+      "integrity": "sha512-RaO/TyyHZvXkpzinbMTZmd/S5biU4zxkvDsn22ujC29t9FMSzq8tnn8f2MxQ2P8GVhFRG5jTAL05DXKyTtpEQQ==",
+      "optional": true,
+      "dependencies": {
+        "@types/cheerio": "*",
+        "@types/react": "^16"
+      }
+    },
+    "node_modules/@types/enzyme/node_modules/@types/react": {
+      "version": "16.14.60",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.60.tgz",
+      "integrity": "sha512-wIFmnczGsTcgwCBeIYOuy2mdXEiKZ5znU/jNOnMZPQyCcIxauMGWlX0TNG4lZ7NxRKj7YUIZRneJQSSdB2jKgg==",
+      "optional": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "8.56.4",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "optionalDependencies": {
     "@types/dagre": "^0.7.52",
+    "@types/enzyme": "^3.10.18",
     "@types/hapi__catbox-memory": "^4.1.8",
     "@types/hapi__cookie": "^12.0.5",
     "@types/hapi__crumb": "^7.3.7",


### PR DESCRIPTION
This PR fixes a few type issues in the `<Flyout>` component and enables `<RenderInPortal>` tests

Good to fix them ahead of any work on the form editor