### PR TITLE
Split out GitHub Actions lint tasks to run before build

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -125,6 +125,36 @@ jobs:
           - description: TypeScript compiler
             run: npm run lint:types
 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore dependencies
+        uses: actions/cache/restore@v4
+        with:
+          enableCrossOsArchive: true
+          key: npm-install-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          path: |
+            designer/node_modules
+            model/node_modules
+            node_modules
+
+      - name: Run lint task
+        run: ${{ matrix.task.run }}
+
+  tasks:
+    name: ${{ matrix.task.description }} (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    needs: [install, build]
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        runner:
+          - ubuntu-latest
+
+        task:
           - description: Unit tests
             run: npm run test
 
@@ -142,7 +172,17 @@ jobs:
             model/node_modules
             node_modules
 
-      - name: Run lint task
+      - name: Restore build
+        uses: actions/cache/restore@v4
+        with:
+          enableCrossOsArchive: true
+          key: npm-build-${{ runner.os }}-${{ github.sha }}
+          path: |
+            designer/client/dist
+            designer/server/dist
+            model/dist
+
+      - name: Run task
         run: ${{ matrix.task.run }}
 
   publish:

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -95,10 +95,10 @@ jobs:
       - name: Run build
         run: npm run build
 
-  tasks:
+  lint:
     name: ${{ matrix.task.description }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
-    needs: [install, build]
+    needs: [install]
 
     env:
       # Authorise GitHub API requests for EditorConfig checker binary
@@ -142,17 +142,7 @@ jobs:
             model/node_modules
             node_modules
 
-      - name: Restore build
-        uses: actions/cache/restore@v4
-        with:
-          enableCrossOsArchive: true
-          key: npm-build-${{ runner.os }}-${{ github.sha }}
-          path: |
-            designer/client/dist
-            designer/server/dist
-            model/dist
-
-      - name: Run task
+      - name: Run lint task
         run: ${{ matrix.task.run }}
 
   publish:


### PR DESCRIPTION
We shouldn't need to wait for `npm run build --workspace model` (and have it restored) for every lint task

See commit https://github.com/DEFRA/forms-designer/pull/116/commits/8c96cbb1e166c96e167ea680aa0e6aed1c88e467 for earlier changes made to support this

This frees up the "post build" step to spin up integration tests (maybe) etc

<br>

<img width="1032" alt="Split out lint tasks" src="https://github.com/DEFRA/forms-designer/assets/415517/8b25b0ee-a591-418b-8c6c-51b9e1196dd5">