### PR TITLE
Update session management to use end-user ID + types

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -65,8 +65,7 @@
     "react-router-dom": "^5.3.4",
     "react-simple-code-editor": "^0.11.3",
     "react-sortable-hoc": "^1.11.0",
-    "resolve": "^1.22.8",
-    "uuid": "^9.0.1"
+    "resolve": "^1.22.8"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.3.4",

--- a/designer/server/src/common/helpers/auth/azure-oidc.js
+++ b/designer/server/src/common/helpers/auth/azure-oidc.js
@@ -81,10 +81,7 @@ export const azureOidc = {
             redirect_uri: authCallbackUrl.href
           },
           cookie: 'bell-azure-oidc',
-          isSecure: false,
-          config: {
-            tenant: config.azureTenantId
-          }
+          isSecure: false
         })
       )
     }

--- a/designer/server/src/common/helpers/auth/azure-oidc.js
+++ b/designer/server/src/common/helpers/auth/azure-oidc.js
@@ -28,9 +28,6 @@ export const azureOidc = {
         (response) => /** @type {Promise<OidcMetadata>} */ (response.json())
       )
 
-      // making the OIDC config available to server
-      server.app.oidc = oidc
-
       server.auth.strategy(
         'azure-oidc',
         'bell',

--- a/designer/server/src/common/helpers/auth/drop-user-session.js
+++ b/designer/server/src/common/helpers/auth/drop-user-session.js
@@ -1,7 +1,22 @@
-async function dropUserSession() {
-  if (this?.state?.userSession?.sessionId) {
-    await this.server.methods.session.drop(this.state.userSession.sessionId)
+import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
+
+/**
+ * @param {Request} request
+ */
+export async function dropUserSession(request) {
+  const { cookieAuth, server } = request
+
+  const credentials = await getUserSession(request)
+
+  // Remove user session from Redis
+  if (credentials?.user?.id) {
+    await server.methods.session.drop(credentials.user.id)
   }
+
+  // Clear authentication cookie
+  cookieAuth.clear()
 }
 
-export { dropUserSession }
+/**
+ * @typedef {import('@hapi/hapi').Request} Request
+ */

--- a/designer/server/src/common/helpers/auth/drop-user-session.js
+++ b/designer/server/src/common/helpers/auth/drop-user-session.js
@@ -1,6 +1,6 @@
-function dropUserSession() {
+async function dropUserSession() {
   if (this?.state?.userSession?.sessionId) {
-    this.server.app.cache.drop(this.state.userSession.sessionId)
+    await this.server.methods.session.drop(this.state.userSession.sessionId)
   }
 }
 

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -4,7 +4,7 @@
  */
 async function getUserSession() {
   return this.state?.userSession?.sessionId
-    ? await this.server.app.cache.get(this.state.userSession.sessionId)
+    ? await this.server.methods.session.get(this.state.userSession.sessionId)
     : {}
 }
 

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -1,24 +1,69 @@
+import { token } from '@hapi/jwt'
+
 /**
- * @this {{ server: import('@hapi/hapi').Server, state?: { userSession?: { sessionId?: string } } }}
- * @returns {Promise<UserSession | undefined>}
+ * @param {Request} request
+ * @param {{ sessionId: string, user: UserCredentials }} [session] - Session cookie state
  */
-async function getUserSession() {
-  return this.state?.userSession?.sessionId
-    ? await this.server.methods.session.get(this.state.userSession.sessionId)
-    : {}
+export async function getUserSession(request, session) {
+  const { auth, server } = request
+
+  // Check for existing user
+  if (getUser(auth.credentials)) {
+    return auth.credentials
+  }
+
+  // Prefer Session ID from cookie state
+  let sessionId = session?.sessionId
+
+  // Fall back to OpenID Connect (OIDC) claim
+  if (!sessionId) {
+    const claims = getUserClaims(auth.credentials)
+
+    if (claims?.sub) {
+      sessionId = claims.sub
+    }
+  }
+
+  // Retrieve user session from Redis
+  if (sessionId) {
+    return server.methods.session.get(sessionId)
+  }
 }
 
-export { getUserSession }
+/**
+ * @param {AuthCredentials | null} [credentials]
+ */
+export function getUserClaims(credentials) {
+  if (!credentials?.token) {
+    return
+  }
+
+  const { decoded } = /** @type {UserToken<UserProfile>} */ (
+    token.decode(credentials.token)
+  )
+
+  return decoded.payload
+}
 
 /**
- * @typedef {object} UserSession
- * @property {string} id - User ID
- * @property {string} email - User email address
- * @property {string} displayName - User display name
- * @property {string} loginHint - User login hint
- * @property {boolean} isAuthenticated - User is authenticated
- * @property {string} token - User token
- * @property {string} refreshToken - User refresh token
- * @property {number} expiresIn - User session expiry time remaining
- * @property {Date} expiresAt - User session expiry time
+ * @param {AuthCredentials | null} [credentials]
+ */
+export function getUser(credentials) {
+  if (!credentials?.user) {
+    return
+  }
+
+  return credentials.user
+}
+
+/**
+ * @typedef {import('@hapi/hapi').Request} Request
+ * @typedef {import('@hapi/hapi').AuthCredentials} AuthCredentials
+ * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials
+ * @typedef {import('~/src/common/helpers/auth/azure-oidc.js').UserProfile} UserProfile
+ */
+
+/**
+ * @template {object} Payload
+ * @typedef {import('@hapi/jwt').HapiJwt.Artifacts<{ JwtPayload?: Payload }>} UserToken
  */

--- a/designer/server/src/common/helpers/auth/pre/provide-authed-user.js
+++ b/designer/server/src/common/helpers/auth/pre/provide-authed-user.js
@@ -1,6 +1,0 @@
-const provideAuthedUser = {
-  method: async (request) => (await request.getUserSession()) ?? null,
-  assign: 'authedUser'
-}
-
-export { provideAuthedUser }

--- a/designer/server/src/common/helpers/auth/refresh-token.js
+++ b/designer/server/src/common/helpers/auth/refresh-token.js
@@ -20,7 +20,11 @@ async function refreshAccessToken(request) {
 
   request.logger.info('Azure OIDC access token expired, refreshing...')
 
-  return await fetch(request.server.app.oidc.token_endpoint, {
+  const oidc = await fetch(config.oidcWellKnownConfigurationUrl).then(
+    (response) => /** @type {Promise<OidcMetadata>} */ (response.json())
+  )
+
+  return fetch(oidc.token_endpoint, {
     method: 'post',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/designer/server/src/common/helpers/auth/refresh-token.js
+++ b/designer/server/src/common/helpers/auth/refresh-token.js
@@ -1,26 +1,41 @@
+import Boom from '@hapi/boom'
 import fetch from 'node-fetch'
 
+import { dropUserSession } from '~/src/common/helpers/auth/drop-user-session.js'
 import config from '~/src/config.js'
 
-async function refreshAccessToken(request) {
-  const authedUser = await request.getUserSession()
-  const refreshToken = authedUser?.refreshToken ?? null
-  const azureClientId = config.azureClientId
-  const azureClientSecret = config.azureClientSecret
+/**
+ * @param {Request} request
+ */
+export async function refreshAccessToken(request) {
+  const { auth, logger } = request
+
+  const { azureClientId, azureClientSecret, oidcWellKnownConfigurationUrl } =
+    config
+
+  if (
+    !azureClientId ||
+    !azureClientSecret ||
+    !oidcWellKnownConfigurationUrl ||
+    !auth.credentials.refreshToken
+  ) {
+    throw Boom.unauthorized()
+  }
+
   const params = new URLSearchParams()
 
   params.append('client_id', azureClientId)
   params.append('client_secret', azureClientSecret)
   params.append('grant_type', 'refresh_token')
-  params.append('refresh_token', refreshToken)
+  params.append('refresh_token', auth.credentials.refreshToken)
   params.append(
     'scope',
     `api://${azureClientId}/forms.user openid profile email offline_access user.read`
   )
 
-  request.logger.info('Azure OIDC access token expired, refreshing...')
+  logger.info('Azure OIDC access token expired, refreshing...')
 
-  const oidc = await fetch(config.oidcWellKnownConfigurationUrl).then(
+  const oidc = await fetch(oidcWellKnownConfigurationUrl).then(
     (response) => /** @type {Promise<OidcMetadata>} */ (response.json())
   )
 
@@ -31,7 +46,15 @@ async function refreshAccessToken(request) {
       'Cache-Control': 'no-cache'
     },
     body: params
-  })
+  }).then(async (response) =>
+    response.ok
+      ? /** @type {Promise<SigninResponse>} */ (response.json())
+      : await dropUserSession(request)
+  )
 }
 
-export { refreshAccessToken }
+/**
+ * @typedef {import('@hapi/hapi').Request} Request
+ * @typedef {import('~/src/common/helpers/auth/azure-oidc.js').OidcMetadata} OidcMetadata
+ * @typedef {import('~/src/common/helpers/auth/azure-oidc.js').SigninResponse} SigninResponse
+ */

--- a/designer/server/src/common/helpers/auth/session-cookie.js
+++ b/designer/server/src/common/helpers/auth/session-cookie.js
@@ -47,7 +47,9 @@ const sessionCookie = {
         }
       })
 
-      server.auth.default('session')
+      server.auth.default({
+        strategies: ['azure-oidc', 'session']
+      })
     }
   }
 }

--- a/designer/server/src/common/helpers/auth/session-cookie.js
+++ b/designer/server/src/common/helpers/auth/session-cookie.js
@@ -1,11 +1,5 @@
 import authCookie from '@hapi/cookie'
-import { isPast, parseISO, subMinutes } from 'date-fns'
 
-import { refreshAccessToken } from '~/src/common/helpers/auth/refresh-token.js'
-import {
-  removeUserSession,
-  updateUserSession
-} from '~/src/common/helpers/auth/user-session.js'
 import config from '~/src/config.js'
 
 /**
@@ -39,31 +33,6 @@ const sessionCookie = {
          */
         async validate(request, session) {
           const authedUser = await request.getUserSession()
-
-          const tokenHasExpired = authedUser?.expiresAt
-            ? isPast(subMinutes(parseISO(authedUser.expiresAt), 1))
-            : true
-
-          if (tokenHasExpired) {
-            const response = await refreshAccessToken(request)
-            const refreshAccessTokenJson = await response.json()
-
-            if (!response.ok) {
-              removeUserSession(request)
-
-              return { isValid: false }
-            }
-
-            const updatedSession = await updateUserSession(
-              request,
-              refreshAccessTokenJson
-            )
-
-            return {
-              isValid: true,
-              credentials: updatedSession
-            }
-          }
 
           const userSession = await server.app.cache.get(session.sessionId)
 

--- a/designer/server/src/common/helpers/auth/session-cookie.js
+++ b/designer/server/src/common/helpers/auth/session-cookie.js
@@ -1,5 +1,6 @@
 import authCookie from '@hapi/cookie'
 
+import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
 import config from '~/src/config.js'
 
 /**
@@ -30,20 +31,20 @@ const sessionCookie = {
 
         /**
          * Validate session using auth credentials
+         * @param {Request} [request]
+         * @param {{ sessionId: string, user: UserCredentials }} [session] - Session cookie state
          */
         async validate(request, session) {
-          const authedUser = await request.getUserSession()
-
-          const userSession = await server.app.cache.get(session.sessionId)
-
-          if (userSession) {
-            return {
-              isValid: true,
-              credentials: userSession
-            }
+          if (!request) {
+            return { isValid: false }
           }
 
-          return { isValid: false }
+          const credentials = await getUserSession(request, session)
+
+          return {
+            credentials,
+            isValid: !!credentials
+          }
         }
       })
 
@@ -59,4 +60,9 @@ export { sessionCookie }
 /**
  * @template {object | void} [PluginOptions=void]
  * @typedef {import('@hapi/hapi').ServerRegisterPluginObject<PluginOptions>} ServerRegisterPluginObject
+ */
+
+/**
+ * @typedef {import('@hapi/hapi').Request} Request
+ * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials
  */

--- a/designer/server/src/common/helpers/auth/user-session.js
+++ b/designer/server/src/common/helpers/auth/user-session.js
@@ -12,7 +12,7 @@ async function createUserSession(request, sessionId) {
 
   const { profile } = request.auth.credentials
 
-  await request.server.app.cache.set(sessionId, {
+  await request.server.methods.session.set(sessionId, {
     id: profile.id,
     email: profile.email,
     displayName: profile.displayName,

--- a/designer/server/src/common/helpers/auth/user-session.js
+++ b/designer/server/src/common/helpers/auth/user-session.js
@@ -1,4 +1,3 @@
-import jwt from '@hapi/jwt'
 import { addSeconds } from 'date-fns'
 
 function removeUserSession(request) {
@@ -26,28 +25,4 @@ async function createUserSession(request, sessionId) {
   })
 }
 
-async function updateUserSession(request, refreshedSession) {
-  const refreshedPayload = jwt.token.decode(refreshedSession.access_token)
-    .decoded.payload
-
-  // Update userSession with new access token and new expiry details
-  const expiresInSeconds = refreshedSession.expires_in
-  const expiresInMilliSeconds = expiresInSeconds * 1000
-  const expiresAt = addSeconds(new Date(), expiresInSeconds)
-
-  await request.server.app.cache.set(request.state.userSession.sessionId, {
-    id: refreshedPayload.oid,
-    email: refreshedPayload.preferred_username,
-    displayName: refreshedPayload.name,
-    loginHint: refreshedPayload.login_hint,
-    isAuthenticated: true,
-    token: refreshedSession.access_token,
-    refreshToken: refreshedSession.refresh_token,
-    expiresIn: expiresInMilliSeconds,
-    expiresAt
-  })
-
-  return await request.getUserSession()
-}
-
-export { createUserSession, updateUserSession, removeUserSession }
+export { createUserSession, removeUserSession }

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
 
+import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
 import { createLogger } from '~/src/common/helpers/logging/logger.js'
 import { buildNavigation } from '~/src/common/nunjucks/context/build-navigation.js'
 import config from '~/src/config.js'
@@ -26,7 +27,7 @@ export async function context(request) {
     }
   }
 
-  const authedUser = await request?.getUserSession()
+  const credentials = request ? await getUserSession(request) : undefined
 
   return {
     breadcrumbs: [],
@@ -37,8 +38,8 @@ export async function context(request) {
     navigation: buildNavigation(request),
     getAssetPath: (asset = '') => `/${webpackManifest?.[asset] ?? asset}`,
     assetPath: '/assets',
-    isAuthenticated: authedUser?.isAuthenticated ?? false,
-    authedUser
+    isAuthenticated: request?.auth.isAuthenticated ?? false,
+    authedUser: credentials?.user
   }
 }
 

--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -26,7 +26,7 @@ const serverOptions = (): ServerOptions => {
     routes: {
       auth: {
         mode: 'required',
-        strategy: 'session'
+        strategies: ['session']
       },
       validate: {
         options: {

--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -61,7 +61,7 @@ const serverOptions = (): ServerOptions => {
 export async function createServer() {
   const server = hapi.server(serverOptions())
 
-  server.app.cache = server.cache({
+  const cache = server.cache({
     cache: 'session',
     segment: config.redisKeyPrefix,
     expiresIn: config.sessionTtl
@@ -69,6 +69,9 @@ export async function createServer() {
 
   server.decorate('request', 'getUserSession', getUserSession)
   server.decorate('request', 'dropUserSession', dropUserSession)
+  server.method('session.get', (id) => cache.get(id))
+  server.method('session.set', (id, value) => cache.set(id, value))
+  server.method('session.drop', (id) => cache.drop(id))
 
   await server.register(inert)
   await server.register(sessionManager)

--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -7,8 +7,6 @@ import {
   azureOidc,
   azureOidcNoop
 } from '~/src/common/helpers/auth/azure-oidc.js'
-import { dropUserSession } from '~/src/common/helpers/auth/drop-user-session.js'
-import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
 import { sessionCookie } from '~/src/common/helpers/auth/session-cookie.js'
 import { requestLogger } from '~/src/common/helpers/logging/request-logger.js'
 import { buildRedisClient } from '~/src/common/helpers/redis-client.js'
@@ -67,8 +65,6 @@ export async function createServer() {
     expiresIn: config.sessionTtl
   })
 
-  server.decorate('request', 'getUserSession', getUserSession)
-  server.decorate('request', 'dropUserSession', dropUserSession)
   server.method('session.get', (id) => cache.get(id))
   server.method('session.set', (id, value) => cache.set(id, value))
   server.method('session.drop', (id) => cache.drop(id))

--- a/designer/server/src/routes/account/auth.js
+++ b/designer/server/src/routes/account/auth.js
@@ -26,7 +26,9 @@ export default [
       return h.redirect(redirect)
     },
     options: {
-      auth: 'azure-oidc',
+      auth: {
+        strategies: ['azure-oidc']
+      },
       response: {
         failAction: () => boom.boomify(boom.unauthorized())
       }

--- a/designer/server/src/routes/account/auth.js
+++ b/designer/server/src/routes/account/auth.js
@@ -1,5 +1,4 @@
-import boom from '@hapi/boom'
-import { v4 as uuidv4 } from 'uuid'
+import Boom from '@hapi/boom'
 
 import { createUserSession } from '~/src/common/helpers/auth/user-session.js'
 
@@ -11,26 +10,30 @@ export default [
     method: ['GET', 'POST'],
     path: '/auth/callback',
     async handler(request, h) {
-      const { auth, cookieAuth, yar } = request
+      const { cookieAuth, yar } = request
 
-      if (auth.isAuthenticated) {
-        const sessionId = uuidv4()
+      // Create user session
+      const credentials = await createUserSession(request)
 
-        await createUserSession(request, sessionId)
-
-        cookieAuth.set({ sessionId })
+      if (!credentials?.user) {
+        return Boom.unauthorized()
       }
 
-      const redirect = yar.flash('referrer').at(0) ?? '/library'
+      // Add to authentication cookie for session validation
+      cookieAuth.set({ sessionId: credentials.user.id })
 
+      const redirect = yar.flash('referrer').at(0) ?? '/library'
       return h.redirect(redirect)
     },
     options: {
       auth: {
         strategies: ['azure-oidc']
       },
+
       response: {
-        failAction: () => boom.boomify(boom.unauthorized())
+        failAction(request, h, error) {
+          return Boom.unauthorized(error)
+        }
       }
     }
   })

--- a/designer/server/src/routes/account/sign-out.js
+++ b/designer/server/src/routes/account/sign-out.js
@@ -1,30 +1,36 @@
+import { URL } from 'node:url'
+
+import Boom from '@hapi/boom'
+
+import { dropUserSession } from '~/src/common/helpers/auth/drop-user-session.js'
 import config from '~/src/config.js'
 
 export default /** @satisfies {ServerRoute} */ ({
   method: 'GET',
   path: '/auth/sign-out',
   async handler(request, h) {
-    const authedUser = request.pre.authedUser
+    await dropUserSession(request)
 
-    if (!authedUser) {
-      return h.redirect('/library')
+    // Skip OpenID Connect (OIDC) in tests
+    if (config.isTest) {
+      return h.redirect('/')
+    }
+
+    // Otherwise require OpenID Connect (OIDC) configuration
+    if (!config.azureClientId || !config.oidcWellKnownConfigurationUrl) {
+      return Boom.unauthorized()
     }
 
     const oidc = await fetch(config.oidcWellKnownConfigurationUrl).then(
       (response) => /** @type {Promise<OidcMetadata>} */ (response.json())
     )
 
-    const logoutBaseUrl = oidc.end_session_endpoint
-    const referrer = request.info.referrer
+    // Build end session URL
+    const endSessionUrl = new URL(oidc.end_session_endpoint)
+    endSessionUrl.searchParams.set('client_id', config.azureClientId)
 
-    const logoutUrl = encodeURI(
-      `${logoutBaseUrl}?post_logout_redirect_uri=${referrer}`
-    )
-
-    request.dropUserSession()
-    request.cookieAuth.clear()
-
-    return h.redirect(logoutUrl)
+    // Redirect to end session URL
+    return h.redirect(endSessionUrl.href)
   },
   options: {
     auth: {
@@ -34,5 +40,6 @@ export default /** @satisfies {ServerRoute} */ ({
 })
 
 /**
+ * @typedef {import('~/src/common/helpers/auth/azure-oidc.js').OidcMetadata} OidcMetadata
  * @typedef {import('@hapi/hapi').ServerRoute} ServerRoute
  */

--- a/designer/server/src/routes/account/sign-out.js
+++ b/designer/server/src/routes/account/sign-out.js
@@ -1,16 +1,21 @@
 import { provideAuthedUser } from '~/src/common/helpers/auth/pre/provide-authed-user.js'
+import config from '~/src/config.js'
 
 export default /** @satisfies {ServerRoute} */ ({
   method: 'GET',
   path: '/auth/sign-out',
-  handler(request, h) {
+  async handler(request, h) {
     const authedUser = request.pre.authedUser
 
     if (!authedUser) {
       return h.redirect('/library')
     }
 
-    const logoutBaseUrl = request.server.app.oidc.end_session_endpoint
+    const oidc = await fetch(config.oidcWellKnownConfigurationUrl).then(
+      (response) => /** @type {Promise<OidcMetadata>} */ (response.json())
+    )
+
+    const logoutBaseUrl = oidc.end_session_endpoint
     const referrer = request.info.referrer
 
     const logoutUrl = encodeURI(

--- a/designer/server/src/routes/account/sign-out.js
+++ b/designer/server/src/routes/account/sign-out.js
@@ -25,6 +25,11 @@ export default /** @satisfies {ServerRoute} */ ({
     request.cookieAuth.clear()
 
     return h.redirect(logoutUrl)
+  },
+  options: {
+    auth: {
+      mode: 'try'
+    }
   }
 })
 

--- a/designer/server/src/routes/account/sign-out.js
+++ b/designer/server/src/routes/account/sign-out.js
@@ -1,4 +1,3 @@
-import { provideAuthedUser } from '~/src/common/helpers/auth/pre/provide-authed-user.js'
 import config from '~/src/config.js'
 
 export default /** @satisfies {ServerRoute} */ ({
@@ -26,9 +25,6 @@ export default /** @satisfies {ServerRoute} */ ({
     request.cookieAuth.clear()
 
     return h.redirect(logoutUrl)
-  },
-  options: {
-    pre: [provideAuthedUser]
   }
 })
 

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -5,6 +5,10 @@ import { type RequestAuth } from '@hapi/hapi'
 import { type Logger } from 'pino'
 
 import { type sessionNames } from '~/src/common/constants/session-names.js'
+import {
+  type Credentials,
+  type UserProfile
+} from '~/src/common/helpers/auth/azure-oidc.js'
 import { type ValidationFailure } from '~/src/common/helpers/build-error-details.js'
 
 interface SessionCache {
@@ -29,6 +33,41 @@ declare module '@hapi/hapi' {
 
   interface ServerMethods {
     session: SessionCache
+  }
+
+  interface AuthCredentials {
+    provider: 'azure-oidc'
+    query: Credentials['query']
+    token: Credentials['token']
+    refreshToken: Credentials['refreshToken']
+    expiresIn: Credentials['expiresIn']
+  }
+
+  interface UserCredentials {
+    /**
+     * User ID
+     */
+    id: UserProfile['sub']
+
+    /**
+     * User email address
+     */
+    email: UserProfile['email']
+
+    /**
+     * User display name
+     */
+    displayName?: UserProfile['name']
+
+    /**
+     * Session issued time (ISO 8601)
+     */
+    issuedAt?: string
+
+    /**
+     * Session expiry time (ISO 8601)
+     */
+    expiresAt?: string
   }
 }
 

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -1,10 +1,17 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
 
 import { type FormMetadataInput } from '@defra/forms-model'
+import { type RequestAuth } from '@hapi/hapi'
 import { type Logger } from 'pino'
 
 import { type sessionNames } from '~/src/common/constants/session-names.js'
 import { type ValidationFailure } from '~/src/common/helpers/build-error-details.js'
+
+interface SessionCache {
+  drop: (key: string) => Promise<void>
+  get: (key: string) => Promise<RequestAuth['credentials'] | undefined>
+  set: (key: string, credentials: RequestAuth['credentials']) => Promise<void>
+}
 
 declare module '@hapi/hapi' {
   // Here we are decorating Hapi interface types with
@@ -15,6 +22,13 @@ declare module '@hapi/hapi' {
 
   interface Server {
     logger: Logger
+    method(name: 'session.drop', method: SessionCache['drop']): void
+    method(name: 'session.get', method: SessionCache['get']): void
+    method(name: 'session.set', method: SessionCache['set']): void
+  }
+
+  interface ServerMethods {
+    session: SessionCache
   }
 }
 

--- a/designer/server/test/fixtures/auth.js
+++ b/designer/server/test/fixtures/auth.js
@@ -1,27 +1,26 @@
-import { DateTime } from 'luxon'
+import { DateTime, Duration } from 'luxon'
 
 /**
  * @satisfies {ServerInjectOptions['auth']}
  */
 export const auth = {
   strategy: 'azure-oidc',
-  credentials: /** @satisfies {AuthCredentials} */ ({
+  credentials: {
+    provider: 'azure-oidc',
+    query: {},
+    refreshToken: 'dummy-refresh-token',
+    token: 'dummy-token',
+    expiresIn: Duration.fromObject({ minutes: 30 }).as('seconds'),
     user: {
       id: 'dummy-id',
       email: 'dummy@defra.gov.uk',
       displayName: 'John Smith',
-      loginHint: 'dummy-login-hint',
-      isAuthenticated: true,
-      token: 'dummy-token',
-      refreshToken: 'dummy-refresh-token',
-      expiresIn: 30 * 60 * 1000,
-      expiresAt: DateTime.now().plus({ minutes: 30 }).toJSDate()
+      issuedAt: DateTime.now().minus({ minutes: 30 }).toUTC().toISO(),
+      expiresAt: DateTime.now().plus({ minutes: 30 }).toUTC().toISO()
     }
-  })
+  }
 }
 
 /**
- * @typedef {import('~/src/common/helpers/auth/get-user-session.js').UserSession} UserSession
- * @typedef {import('@hapi/hapi').AuthCredentials<UserSession>} AuthCredentials
  * @typedef {import('@hapi/hapi').ServerInjectOptions} ServerInjectOptions
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,8 @@
         "@types/resolve": "^1.20.6",
         "@types/uuid": "^9.0.8",
         "@types/webpack-assets-manifest": "^5.1.4",
-        "@types/webpack-bundle-analyzer": "^4.7.0"
+        "@types/webpack-bundle-analyzer": "^4.7.0",
+        "oidc-client-ts": "^3.0.1"
       }
     },
     "designer": {
@@ -13529,6 +13530,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -14801,6 +14811,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.0.1.tgz",
+      "integrity": "sha512-xX8unZNtmtw3sOz4FPSqDhkLFnxCDsdo2qhFEH2opgWnF/iXMFoYdBQzkwCxAZVgt3FT3DnuBY3k80EZHT0RYg==",
+      "optional": true,
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/on-exit-leak-free": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,8 +114,7 @@
         "react-router-dom": "^5.3.4",
         "react-simple-code-editor": "^0.11.3",
         "react-sortable-hoc": "^1.11.0",
-        "resolve": "^1.22.8",
-        "uuid": "^9.0.1"
+        "resolve": "^1.22.8"
       },
       "devDependencies": {
         "@testing-library/dom": "^9.3.4",
@@ -277,18 +276,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "designer/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "model": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "@types/resolve": "^1.20.6",
     "@types/uuid": "^9.0.8",
     "@types/webpack-assets-manifest": "^5.1.4",
-    "@types/webpack-bundle-analyzer": "^4.7.0"
+    "@types/webpack-bundle-analyzer": "^4.7.0",
+    "oidc-client-ts": "^3.0.1"
   },
   "engines": {
     "node": "^20.9.0",


### PR DESCRIPTION
This PR adds server methods for `session.get()`, `session.set()` and `session.drop()`

I've also typed `request.auth.user` as Hapi expects it to be with all utility methods now typed

Sessions are keyed using `claims.sub` so an expired token can seamlessly re-authenticate without session loss

```js
export function createUser(credentials) {
  const claims = getUserClaims(credentials)

  if (!claims) {
    return
  }

  return /** @satisfies {UserCredentials} */ ({
    id: claims.sub,
    email: claims.email ?? '',
    displayName: claims.name ?? '',
    issuedAt: DateTime.fromSeconds(claims.iat).toUTC().toISO(),
    expiresAt: DateTime.fromSeconds(claims.exp).toUTC().toISO()
  })
}
```

**Note:** Session expiry checks are currently turned off