### PR TITLE
Remove unused `logout_hint` to fix Keycloak sign out

### DIFF
--- a/designer/server/src/routes/account/sign-out.js
+++ b/designer/server/src/routes/account/sign-out.js
@@ -12,10 +12,9 @@ export default /** @satisfies {ServerRoute} */ ({
 
     const logoutBaseUrl = request.server.app.oidc.end_session_endpoint
     const referrer = request.info.referrer
-    const loginHint = authedUser.loginHint
 
     const logoutUrl = encodeURI(
-      `${logoutBaseUrl}?logout_hint=${loginHint}&post_logout_redirect_uri=${referrer}`
+      `${logoutBaseUrl}?post_logout_redirect_uri=${referrer}`
     )
 
     request.dropUserSession()


### PR DESCRIPTION
We were adding `authedUser.loginHint` to `?logout_hint=` (typo?) but this isn't supported anyway

* https://github.com/keycloak/keycloak/issues/21399

We should look to add `?id_token_hint=` to enable sign out redirects in future

I've removed it for now to fix sign out locally