### PR TITLE
Switch to form `slug` in editor URLs

### DIFF
--- a/designer/client/src/components/Visualisation/Visualisation.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.tsx
@@ -10,9 +10,10 @@ import { DataContext } from '~/src/context/index.js'
 import '~/src/components/Visualisation/visualisation.scss'
 
 interface Props {
-  previewUrl?: string
+  id: string
+  slug: string
+  previewUrl: string
   persona?: any
-  id?: string
 }
 
 export function useVisualisation(ref) {

--- a/designer/client/src/designer.tsx
+++ b/designer/client/src/designer.tsx
@@ -9,13 +9,12 @@ import { FlyoutContext, DataContext } from '~/src/context/index.js'
 import { i18n } from '~/src/i18n/index.js'
 
 interface Props {
-  match?: any
-  location?: any
-  history?: any
+  id: string
+  slug: string
+  previewUrl: string
 }
 
 interface State {
-  id?: any
   flyoutCount?: number
   loading?: boolean
   newConfig?: boolean // TODO - is this required?
@@ -24,12 +23,20 @@ interface State {
 }
 
 export default class Designer extends Component<Props, State> {
-  state = { loading: true, flyoutCount: 0 }
+  state: State = { loading: true, flyoutCount: 0 }
 
   designerApi = new DesignerApi()
 
   get id() {
-    return this.props.match?.params?.id
+    return this.props.id
+  }
+
+  get slug() {
+    return this.props.slug
+  }
+
+  get previewUrl() {
+    return this.props.previewUrl
   }
 
   incrementFlyoutCounter = (callback = () => {}) => {
@@ -56,16 +63,13 @@ export default class Designer extends Component<Props, State> {
   }
 
   componentDidMount() {
-    const id = this.props.match?.params?.id
-    this.setState({ id })
-    this.designerApi.fetchData(id).then((data) => {
+    this.designerApi.fetchData(this.id).then((data) => {
       this.setState({ loading: false, data })
     })
   }
 
   render() {
     const { flyoutCount, data, loading } = this.state
-    const { previewUrl } = window
     if (loading) {
       return <p className="govuk-body">Loading ...</p>
     }
@@ -83,9 +87,10 @@ export default class Designer extends Component<Props, State> {
             <Prompt message={i18n('leaveDesigner')} />
             <Menu id={this.id} updatePersona={this.updatePersona} />
             <Visualisation
-              persona={this.state.persona}
               id={this.id}
-              previewUrl={previewUrl}
+              slug={this.slug}
+              previewUrl={this.previewUrl}
+              persona={this.state.persona}
             />
           </div>
         </FlyoutContext.Provider>

--- a/designer/client/src/index.tsx
+++ b/designer/client/src/index.tsx
@@ -21,12 +21,31 @@ function NoMatch() {
   )
 }
 
+const container = document.querySelector('.app-editor')
+
 export class App extends React.Component {
   render() {
+    if (
+      !(container instanceof HTMLElement) ||
+      !container.dataset.id ||
+      !container.dataset.slug ||
+      !container.dataset.previewUrl
+    ) {
+      return <NoMatch />
+    }
+
+    // Extract from HTML data-* attributes
+    const { id, slug, previewUrl } = container.dataset
+
     return (
       <Router basename="/editor">
         <Switch>
-          <Route path="/:id" component={Designer} />
+          <Route
+            path="/:id"
+            render={() => (
+              <Designer id={id} slug={slug} previewUrl={previewUrl} />
+            )}
+          />
           <Route path="*">
             <NoMatch />
           </Route>
@@ -36,4 +55,4 @@ export class App extends React.Component {
   }
 }
 
-ReactDOM.render(<App />, document.querySelector('.app-editor'))
+ReactDOM.render(<App />, container)

--- a/designer/client/src/index.tsx
+++ b/designer/client/src/index.tsx
@@ -41,7 +41,7 @@ export class App extends React.Component {
       <Router basename="/editor">
         <Switch>
           <Route
-            path="/:id"
+            path="/:slug"
             render={() => (
               <Designer id={id} slug={slug} previewUrl={previewUrl} />
             )}

--- a/designer/server/src/createServer.test.ts
+++ b/designer/server/src/createServer.test.ts
@@ -70,7 +70,7 @@ describe('Server tests', () => {
 
     const options = {
       method: 'get',
-      url: '/editor/dummy-id-for-demo',
+      url: '/help/cookies',
       auth
     }
 
@@ -89,7 +89,7 @@ describe('Server tests', () => {
 
     const options = {
       method: 'get',
-      url: '/editor/dummy-id-for-demo',
+      url: '/help/cookies',
       auth
     }
 
@@ -104,7 +104,7 @@ describe('Server tests', () => {
 
     const options = {
       method: 'get',
-      url: '/editor/dummy-id-for-demo',
+      url: '/help/cookies',
       auth
     }
 

--- a/designer/server/src/lib/forms.js
+++ b/designer/server/src/lib/forms.js
@@ -15,13 +15,13 @@ export async function list() {
 }
 
 /**
- * Get form by ID
- * @param {string} id
+ * Get form by slug
+ * @param {string} slug
  */
-export async function get(id) {
+export async function get(slug) {
   const getJsonByType = /** @type {typeof getJson<FormMetadata>} */ (getJson)
 
-  const requestUrl = new URL(`./${id}`, formsEndpoint)
+  const requestUrl = new URL(`./slug/${slug}`, formsEndpoint)
   const { body } = await getJsonByType(requestUrl)
 
   return body

--- a/designer/server/src/lib/forms.js
+++ b/designer/server/src/lib/forms.js
@@ -58,15 +58,6 @@ export async function update(id, metadata) {
 }
 
 /**
- * Remove form by ID
- * @param {string} id
- */
-export async function remove(id) {
-  // TODO
-  return Promise.resolve(true)
-}
-
-/**
  * Get draft form definition
  * @param {string} id
  */

--- a/designer/server/src/routes/forms/editor.js
+++ b/designer/server/src/routes/forms/editor.js
@@ -5,11 +5,11 @@ import * as forms from '~/src/lib/forms.js'
 
 export default [
   /**
-   * @satisfies {ServerRoute<{ Params: { id: string } }>}
+   * @satisfies {ServerRoute<{ Params: { slug: string } }>}
    */
   ({
     method: 'get',
-    path: '/editor/{id*}',
+    path: '/editor/{slug*}',
     options: {
       async handler(request, h) {
         const { params } = request
@@ -19,9 +19,9 @@ export default [
 
         // Retrieve form by slug
         try {
-          form = await forms.get(params.id)
+          form = await forms.get(params.slug)
         } catch (error) {
-          return Boom.notFound(`Form with id '${params.id}' not found`)
+          return Boom.notFound(`Form with slug '${params.slug}' not found`)
         }
 
         return h.view('forms/editor', {

--- a/designer/server/src/routes/forms/editor.test.js
+++ b/designer/server/src/routes/forms/editor.test.js
@@ -19,7 +19,7 @@ describe('App routes test', () => {
     await server.stop()
   })
 
-  test('GET /editor/{id*}/ should serve designer editor page', async () => {
+  test('GET /editor/{slug*}/ should serve designer editor page', async () => {
     const id = '661e4ca5039739ef2902b214'
     const slug = 'my-form-slug'
 
@@ -41,7 +41,7 @@ describe('App routes test', () => {
 
     const options = {
       method: 'get',
-      url: '/editor/my-form-id',
+      url: '/editor/my-form-slug',
       auth
     }
 

--- a/designer/server/src/routes/forms/editor.test.js
+++ b/designer/server/src/routes/forms/editor.test.js
@@ -1,6 +1,10 @@
+import config from '~/src/config.js'
 import { createServer } from '~/src/createServer.js'
+import * as forms from '~/src/lib/forms.js'
 import { auth } from '~/test/fixtures/auth.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
+
+jest.mock('~/src/lib/forms.js')
 
 describe('App routes test', () => {
   /** @type {import('@hapi/hapi').Server} */
@@ -15,7 +19,26 @@ describe('App routes test', () => {
     await server.stop()
   })
 
-  test('GET /editor/{:id}/ should serve designer editor page', async () => {
+  test('GET /editor/{id*}/ should serve designer editor page', async () => {
+    const id = '661e4ca5039739ef2902b214'
+    const slug = 'my-form-slug'
+
+    const formMetadataOutput = {
+      id,
+      slug,
+      title: 'My form slug',
+      organisation: 'Defra',
+      teamName: 'Forms',
+      teamEmail: 'defraforms@defra.gov.uk',
+      draft: {
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    }
+
+    // Mock the api call to forms-manager
+    jest.mocked(forms.get).mockResolvedValueOnce(formMetadataOutput)
+
     const options = {
       method: 'get',
       url: '/editor/my-form-id',
@@ -24,7 +47,7 @@ describe('App routes test', () => {
 
     const { document } = await renderResponse(server, options)
     expect(document.body).toContainHTML(
-      '<div class="govuk-grid-column-full app-editor"></div>'
+      `<div class="govuk-grid-column-full app-editor" data-id="${id}" data-slug="${slug}" data-preview-url="${config.previewUrl}"></div>`
     )
   })
 })

--- a/designer/server/src/routes/forms/library.test.js
+++ b/designer/server/src/routes/forms/library.test.js
@@ -15,17 +15,21 @@ describe('Forms library routes', () => {
   })
 
   test('Forms library list page', async () => {
-    const title = 'Form 1'
+    const title = 'My form slug'
 
     // Mock the api call to forms-manager
     jest.mocked(forms.list).mockResolvedValueOnce([
       {
         id: '661e4ca5039739ef2902b214',
         title,
-        slug: 'form-1',
-        organisation: 'DEFRA',
+        slug: 'my-form-slug',
+        organisation: 'Defra',
         teamName: 'Forms',
-        teamEmail: 'defraforms@defra.gov.uk'
+        teamEmail: 'defraforms@defra.gov.uk',
+        draft: {
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
       }
     ])
 

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -7,15 +7,9 @@
   <link href="{{ getAssetPath("editor.css") }}" rel="stylesheet">
 {% endblock %}
 
-{% block bodyStart %}
-  <script type="module">
-    window.previewUrl = '{{ previewUrl }}'
-  </script>
-{% endblock %}
-
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full app-editor"></div>
+    <div class="govuk-grid-column-full app-editor" data-id="{{ form.id }}" data-slug="{{ form.slug }}" data-preview-url="{{ previewUrl }}"></div>
   </div>
   <div id="portal-root"></div>
 {% endblock %}

--- a/designer/server/src/views/forms/library.njk
+++ b/designer/server/src/views/forms/library.njk
@@ -29,7 +29,7 @@
 
     {% for form in formItems %}
       {% set formName %}
-        <a href="/editor/{{ form.id | urlencode }}" class="govuk-link govuk-link--no-visited-state">
+        <a href="/editor/{{ form.slug | urlencode }}" class="govuk-link govuk-link--no-visited-state">
           {{ form.title }}
         </a>
       {% endset %}


### PR DESCRIPTION
This PR overhauls how we pass data into the React editor UI

It uses the form ~`id`~ `slug` property in editor URLs and passes information to React via Nunjucks context

Thankfully this makes `slug` available for preview URLs too in a future PR

### View model
```js
return h.view('forms/editor', {
  phase: config.phase,
  previewUrl: config.previewUrl,
  form: {
    id: form.id,
    slug: form.slug
  }
})
```

### Nunjucks
```html
<div class="govuk-grid-column-full app-editor"
  data-id="{{ form.id }}"
  data-slug="{{ form.slug }}"
  data-preview-url="{{ previewUrl }}">
</div>
```