### PR TITLE
Extend wrapper `appErrorSummary()` for custom errors

### DIFF
--- a/designer/server/src/common/components/error-summary/template.njk
+++ b/designer/server/src/common/components/error-summary/template.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% set errorList = [] %}
+{% set errorList = params.errorList | default([], true) %}
 
 {% for key, error in params.formErrors %}
   {% set errorList = (errorList.push({

--- a/designer/server/src/common/components/error-summary/template.njk
+++ b/designer/server/src/common/components/error-summary/template.njk
@@ -10,6 +10,6 @@
 {% endfor %}
 
 {{ govukErrorSummary({
-  titleText: "There is a problem",
+  titleText: params.titleText | default("There is a problem", true),
   errorList: errorList
 }) }}


### PR DESCRIPTION
This PR extends `appErrorSummary()` with support for custom errors not from Hapi

```njk
{% set errorHtml %}
  We couldn’t sign you in. Please contact the system administrator for help,
  <a href="mailto:steven.thomas@defra.gov.uk" class="govuk-link">steven.thomas@defra.gov.uk</a>
{% endset %}

{% if userFailedAuthorisation %}
  {{ appErrorSummary({
    errorList: [{
      html: errorHtml | safe
    }]
  }) }}
{% endif %}
```