### PR TITLE
Add unique slug validation to “Form name” step

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -172,6 +172,9 @@ module.exports = {
       files: ['**/*.{cjs,js,mjs}'],
       plugins: ['jsdoc'],
       rules: {
+        // Promise.prototype.catch() errors cannot be typed in JavaScript
+        '@typescript-eslint/use-unknown-in-catch-callback-variable': 'off',
+
         // JSDoc blocks are optional but must be valid
         'jsdoc/require-jsdoc': [
           'error',

--- a/designer/server/src/lib/fetch.js
+++ b/designer/server/src/lib/fetch.js
@@ -9,6 +9,10 @@ import Wreck from '@hapi/wreck'
 export async function request(method, url, options) {
   const response = await Wreck.request(method, url.href, options)
 
+  if (response.statusCode === 404) {
+    return { response, body: undefined }
+  }
+
   if (response.statusCode !== 200) {
     throw new Error(response.statusMessage)
   }

--- a/designer/server/src/routes/forms/create.js
+++ b/designer/server/src/routes/forms/create.js
@@ -11,8 +11,11 @@ import Joi from 'joi'
 
 import { sessionNames } from '~/src/common/constants/session-names.js'
 import { buildErrorDetails } from '~/src/common/helpers/build-error-details.js'
+import { createLogger } from '~/src/common/helpers/logging/logger.js'
 import * as forms from '~/src/lib/forms.js'
 import * as create from '~/src/models/forms/create.js'
+
+const logger = createLogger()
 
 export default [
   /**
@@ -86,7 +89,7 @@ export default [
                   const { value: slug } = titleToSlug
 
                   // Retrieve form by slug
-                  const form = await forms.get(slug)
+                  const form = await forms.get(slug).catch(logger.error)
                   if (!form) {
                     return
                   }

--- a/designer/server/src/routes/forms/create.js
+++ b/designer/server/src/routes/forms/create.js
@@ -73,7 +73,7 @@ export default [
       validate: {
         payload: Joi.object().keys({
           title: titleSchema.messages({
-            'string.empty': 'Enter your form name',
+            'string.empty': 'Enter a form name',
             'string.max': 'Form name must be 250 characters or less'
           })
         }),
@@ -231,13 +231,13 @@ export default [
       validate: {
         payload: Joi.object().keys({
           teamName: teamNameSchema.messages({
-            'string.empty': 'Enter your team name',
-            'string.max': 'Team name must be 100 characters or less'
+            'string.empty': 'Enter name of team',
+            'string.max': 'Name of team must be 100 characters or less'
           }),
           teamEmail: teamEmailSchema.messages({
-            'string.empty': 'Enter your shared team email address',
+            'string.empty': 'Enter a shared team email address',
             'string.email':
-              'Enter your shared team email address in the correct format, like name@example.gov.uk'
+              'Enter a shared team email address in the correct format, like name@example.gov.uk'
           })
         }),
 

--- a/designer/server/src/routes/forms/editor.js
+++ b/designer/server/src/routes/forms/editor.js
@@ -14,13 +14,9 @@ export default [
       async handler(request, h) {
         const { params } = request
 
-        /** @type {FormMetadata | undefined} */
-        let form
-
         // Retrieve form by slug
-        try {
-          form = await forms.get(params.slug)
-        } catch (error) {
+        const form = await forms.get(params.slug)
+        if (!form) {
           return Boom.notFound(`Form with slug '${params.slug}' not found`)
         }
 

--- a/model/src/form/form-metadata/index.test.js
+++ b/model/src/form/form-metadata/index.test.js
@@ -1,0 +1,41 @@
+import { slugSchema } from '~/src/form/form-metadata/index.js'
+
+describe('Form metadata schema', () => {
+  describe('Slug schema', () => {
+    it.each([
+      {
+        title: 'This is a form title',
+        slug: 'this-is-a-form-title'
+      },
+      {
+        title: 'This is a form’s—really—punctuated: title',
+        slug: 'this-is-a-forms-really-punctuated-title'
+      },
+      {
+        title: '  This is a form title with leading spaces',
+        slug: 'this-is-a-form-title-with-leading-spaces'
+      },
+      {
+        title: 'This is a form title with trailing spaces  ',
+        slug: 'this-is-a-form-title-with-trailing-spaces'
+      },
+      {
+        title: 'This is a   heavily   spaced  form title',
+        slug: 'this-is-a-heavily-spaced-form-title'
+      },
+      {
+        title: 'With a prefix: This is a form title',
+        slug: 'with-a-prefix-this-is-a-form-title'
+      },
+      {
+        title: 'With something in brackets (surprise)',
+        slug: 'with-something-in-brackets-surprise'
+      }
+    ])("formats '$title' to '$slug'", ({ title, slug }) => {
+      const result = slugSchema.validate(title)
+
+      expect(result).toMatchObject({ value: slug })
+      expect(result.error).toBeUndefined()
+    })
+  })
+})

--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -21,10 +21,18 @@ export const organisations = [
 
 export const idSchema = Joi.string().hex().length(24).required()
 export const titleSchema = Joi.string().max(250).trim().required()
-export const slugSchema = Joi.string().required()
+export const slugSchema = Joi.string()
+  .lowercase()
+  .trim()
+  .replace(/[\s–—]/g, '-') // replace spaces, en-dashes and em-dashes with hyphens
+  .replace(/[^a-z0-9-]/g, '') // remove non-matching characters except spaces
+  .replace(/-+/g, '-') // replace multiple hyphens with a single hyphen
+  .required()
+
 export const organisationSchema = Joi.string()
   .valid(...organisations)
   .required()
+
 export const teamNameSchema = Joi.string().max(100).trim().required()
 export const teamEmailSchema = Joi.string()
   .email({ tlds: { allow: ['uk'] } })


### PR DESCRIPTION
This PR adds validation to the "Form name" step to check if it's unique

I've also reviewed and updated validation messages with @Daniel-Da-Silveira

<img width="586" alt="Form validation showing form name already exists" src="https://github.com/DEFRA/forms-designer/assets/415517/f7201547-47eb-48c7-bf45-b83b74381938">
