### PR TITLE
Update "Create a new form" to redirect to previous steps with errors

### DIFF
--- a/designer/server/src/common/helpers/build-error-details.js
+++ b/designer/server/src/common/helpers/build-error-details.js
@@ -19,13 +19,16 @@ export function buildErrorDetails(error) {
 
 /**
  * @param {ErrorDetails | undefined} errorDetails
+ * @param {string[]} [names] - Field names to filter error list by
  */
-export function buildErrorList(errorDetails) {
+export function buildErrorList(errorDetails, names) {
   if (!errorDetails) {
     return []
   }
 
-  return Object.entries(errorDetails).map(([, message]) => message)
+  return Object.entries(errorDetails)
+    .filter(([key]) => names?.includes(key) ?? true)
+    .map(([, message]) => message)
 }
 
 /**

--- a/designer/server/src/models/forms/create.js
+++ b/designer/server/src/models/forms/create.js
@@ -73,6 +73,16 @@ export function teamViewModel(metadata, validation) {
     formValues: validation?.formValues,
     fields: [
       {
+        type: 'hidden',
+        name: 'title',
+        value: metadata?.title
+      },
+      {
+        type: 'hidden',
+        name: 'organisation',
+        value: metadata?.organisation
+      },
+      {
         id: 'teamName',
         name: 'teamName',
         label: {

--- a/designer/server/src/models/forms/create.js
+++ b/designer/server/src/models/forms/create.js
@@ -12,7 +12,7 @@ export function titleViewModel(metadata, validation) {
   return {
     backLink: '/library',
     pageTitle: 'Enter a name for your form',
-    errorList: buildErrorList(formErrors),
+    errorList: buildErrorList(formErrors, ['title']),
     formErrors: validation?.formErrors,
     formValues: validation?.formValues,
     field: {
@@ -39,7 +39,7 @@ export function organisationViewModel(metadata, validation) {
   return {
     backLink: '/create/title',
     pageTitle: 'Choose a lead organisation for this form',
-    errorList: buildErrorList(formErrors),
+    errorList: buildErrorList(formErrors, ['organisation']),
     formErrors: validation?.formErrors,
     formValues: validation?.formValues,
     field: {
@@ -68,7 +68,7 @@ export function teamViewModel(metadata, validation) {
   return {
     backLink: '/create/organisation',
     pageTitle: 'Team details',
-    errorList: buildErrorList(formErrors),
+    errorList: buildErrorList(formErrors, ['teamName', 'teamEmail']),
     formErrors: validation?.formErrors,
     formValues: validation?.formValues,
     fields: [

--- a/designer/server/src/routes/forms/create.js
+++ b/designer/server/src/routes/forms/create.js
@@ -73,7 +73,7 @@ export default [
       yar.clear(sessionNames.validationFailure)
 
       // Redirect to first step
-      return h.redirect('/create/title').code(303)
+      return h.redirect('/create/title').temporary()
     }
   }),
 
@@ -112,6 +112,7 @@ export default [
         title: payload.title
       })
 
+      // Redirect POST to GET without resubmit on back button
       return h.redirect('/create/organisation').code(303)
     },
     options: {
@@ -121,7 +122,8 @@ export default [
         }),
 
         failAction(request, h, error) {
-          const { payload, yar } = request
+          const { payload, yar, url } = request
+          const { pathname: redirectTo } = url
 
           if (error instanceof Joi.ValidationError) {
             yar.flash('validationFailure', {
@@ -130,7 +132,8 @@ export default [
             })
           }
 
-          return h.redirect('/create/title').code(303).takeover()
+          // Redirect POST to GET without resubmit on back button
+          return h.redirect(redirectTo).code(303).takeover()
         }
       }
     }
@@ -171,6 +174,7 @@ export default [
         organisation: payload.organisation
       })
 
+      // Redirect POST to GET without resubmit on back button
       return h.redirect('/create/team').code(303)
     },
     options: {
@@ -180,7 +184,8 @@ export default [
         }),
 
         failAction(request, h, error) {
-          const { payload, yar } = request
+          const { payload, yar, url } = request
+          const { pathname: redirectTo } = url
 
           if (error instanceof Joi.ValidationError) {
             yar.flash('validationFailure', {
@@ -189,7 +194,8 @@ export default [
             })
           }
 
-          return h.redirect('/create/organisation').code(303).takeover()
+          // Redirect POST to GET without resubmit on back button
+          return h.redirect(redirectTo).code(303).takeover()
         }
       }
     }
@@ -240,8 +246,8 @@ export default [
         yar.clear(sessionNames.create)
 
         /**
-         * Temporarily redirect to library
-         * @todo Redirect to new form
+         * Redirect POST to GET without resubmit on back button
+         * @todo Redirect to new form instead of library
          */
         return h.redirect('/library').code(303)
       } catch (cause) {
@@ -257,7 +263,8 @@ export default [
         payload: schema,
 
         failAction(request, h, error) {
-          const { payload, yar } = request
+          const { payload, yar, url } = request
+          const { pathname: redirectTo } = url
 
           if (error instanceof Joi.ValidationError) {
             const formErrors = buildErrorDetails(error)
@@ -271,7 +278,8 @@ export default [
             })
           }
 
-          return h.redirect('/create/team').code(303).takeover()
+          // Redirect POST to GET without resubmit on back button
+          return h.redirect(redirectTo).code(303).takeover()
         }
       }
     }

--- a/designer/server/src/routes/forms/create.js
+++ b/designer/server/src/routes/forms/create.js
@@ -264,10 +264,17 @@ export default [
 
         failAction(request, h, error) {
           const { payload, yar, url } = request
-          const { pathname: redirectTo } = url
+          let { pathname: redirectTo } = url
 
           if (error instanceof Joi.ValidationError) {
             const formErrors = buildErrorDetails(error)
+
+            // Optionally redirect to errors on previous steps
+            if ('title' in formErrors) {
+              redirectTo = '/create/title'
+            } else if ('organisation' in formErrors) {
+              redirectTo = '/create/organisation'
+            }
 
             yar.flash('validationFailure', {
               formErrors: {

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -27,19 +27,23 @@
       {% endif %}
 
       {% for field in fields %}
-        {{ govukInput({
-          label: field.label,
-          hint: field.hint,
-          id: field.id,
-          name: field.name,
-          value: field.value,
-          errorMessage: {
-            text: formErrors[field.name].text
-          } if formErrors[field.name],
-          autocapitalize: field.autocapitalize,
-          autocomplete: field.autocomplete,
-          spellcheck: field.spellcheck
-        }) }}
+        {% if field.type === "hidden" %}
+          <input type="hidden" name="{{ field.name }}" value="{{ field.value }}">
+        {% else %}
+          {{ govukInput({
+            label: field.label,
+            hint: field.hint,
+            id: field.id,
+            name: field.name,
+            value: field.value,
+            errorMessage: {
+              text: formErrors[field.name].text
+            } if formErrors[field.name],
+            autocapitalize: field.autocapitalize,
+            autocomplete: field.autocomplete,
+            spellcheck: field.spellcheck
+          }) }}
+        {% endif %}
       {% endfor %}
 
       {{ govukButton({


### PR DESCRIPTION
This PR consolidates the create form schema and validates the entire payload before submission

It solves a problem when submitting the **Team details** step, where the form name may not be unique anymore

Errors found at the end of the create form journey will be redirected and displayed on the relevant step

This change enhances https://github.com/DEFRA/forms-designer/pull/147