### PR TITLE
Move page `<title>` "Error: " prefix to layout

### DIFF
--- a/designer/server/src/common/components/error-summary/macro.njk
+++ b/designer/server/src/common/components/error-summary/macro.njk
@@ -1,3 +1,0 @@
-{% macro appErrorSummary(params) %}
-  {%- include "./template.njk" -%}
-{% endmacro %}

--- a/designer/server/src/common/components/error-summary/template.njk
+++ b/designer/server/src/common/components/error-summary/template.njk
@@ -1,8 +1,0 @@
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-
-{% set errorList = params.errorList | default([], true) %}
-
-{{ govukErrorSummary({
-  titleText: params.titleText | default("There is a problem", true),
-  errorList: errorList
-}) }}

--- a/designer/server/src/common/components/error-summary/template.njk
+++ b/designer/server/src/common/components/error-summary/template.njk
@@ -2,13 +2,6 @@
 
 {% set errorList = params.errorList | default([], true) %}
 
-{% for key, error in params.formErrors %}
-  {% set errorList = (errorList.push({
-    text: error.message,
-    href: "#" + key
-  }), errorList) %}
-{% endfor %}
-
 {{ govukErrorSummary({
   titleText: params.titleText | default("There is a problem", true),
   errorList: errorList

--- a/designer/server/src/common/helpers/build-error-details.js
+++ b/designer/server/src/common/helpers/build-error-details.js
@@ -1,11 +1,16 @@
 /**
- * @param {ValidationErrorItem[]} errorDetails
+ * @param {ValidationError} error
  */
-export function buildErrorDetails(errorDetails) {
-  return errorDetails.reduce((errors, detail) => {
+export function buildErrorDetails(error) {
+  return error.details.reduce((errors, { context, message }) => {
+    if (!context?.key) {
+      return errors
+    }
+
     return {
-      [detail.context?.key ?? 'unknown']: {
-        message: detail.message
+      [context.key]: {
+        text: message,
+        href: `#${context.key}`
       },
       ...errors
     }
@@ -13,8 +18,19 @@ export function buildErrorDetails(errorDetails) {
 }
 
 /**
- * @typedef {import('joi').ValidationErrorItem} ValidationErrorItem
- * @typedef {Record<string, { message: string }>} ErrorDetails
+ * @param {ErrorDetails | undefined} errorDetails
+ */
+export function buildErrorList(errorDetails) {
+  if (!errorDetails) {
+    return []
+  }
+
+  return Object.entries(errorDetails).map(([, message]) => message)
+}
+
+/**
+ * @typedef {import('joi').ValidationError} ValidationError
+ * @typedef {Record<string, { text: string, href: string }>} ErrorDetails
  */
 
 /**

--- a/designer/server/src/common/templates/layouts/page.njk
+++ b/designer/server/src/common/templates/layouts/page.njk
@@ -12,7 +12,9 @@
   {% include "partials/navigation.njk" %}
 {% endblock %}
 
-{% block pageTitle %}{{ pageTitle }} - {{ config.serviceName }}{% endblock %}
+{% block pageTitle -%}
+  {{ "Error: " if errorList | length }}{{ pageTitle }} - {{ config.serviceName }}
+{%- endblock %}
 
 {% block beforeContent %}
   {% if breadcrumbs.length > 1 %}

--- a/designer/server/src/models/forms/create.js
+++ b/designer/server/src/models/forms/create.js
@@ -68,7 +68,6 @@ export function teamViewModel(metadata, validation) {
   return {
     backLink: '/create/organisation',
     pageTitle: 'Team details',
-    pageHeading: 'Team details',
     errorList: buildErrorList(formErrors),
     formErrors: validation?.formErrors,
     formValues: validation?.formValues,

--- a/designer/server/src/models/forms/create.js
+++ b/designer/server/src/models/forms/create.js
@@ -1,13 +1,18 @@
 import { organisations } from '@defra/forms-model'
 
+import { buildErrorList } from '~/src/common/helpers/build-error-details.js'
+
 /**
  * @param {Partial<FormMetadataInput>} [metadata]
  * @param {ValidationFailure} [validation]
  */
 export function titleViewModel(metadata, validation) {
+  const { formValues, formErrors } = validation ?? {}
+
   return {
     backLink: '/library',
     pageTitle: 'Enter a name for your form',
+    errorList: buildErrorList(formErrors),
     formErrors: validation?.formErrors,
     formValues: validation?.formValues,
     field: {
@@ -16,7 +21,7 @@ export function titleViewModel(metadata, validation) {
       label: {
         text: 'Enter a name for your form'
       },
-      value: validation?.formValues.title ?? metadata?.title,
+      value: formValues?.title ?? metadata?.title,
       autocapitalize: true,
       spellcheck: true
     },
@@ -29,9 +34,12 @@ export function titleViewModel(metadata, validation) {
  * @param {ValidationFailure} [validation]
  */
 export function organisationViewModel(metadata, validation) {
+  const { formValues, formErrors } = validation ?? {}
+
   return {
     backLink: '/create/title',
     pageTitle: 'Choose a lead organisation for this form',
+    errorList: buildErrorList(formErrors),
     formErrors: validation?.formErrors,
     formValues: validation?.formValues,
     field: {
@@ -44,7 +52,7 @@ export function organisationViewModel(metadata, validation) {
         text: organisation,
         value: organisation
       })),
-      value: validation?.formValues.organisation ?? metadata?.organisation
+      value: formValues?.organisation ?? metadata?.organisation
     },
     buttonText: 'Continue'
   }
@@ -55,10 +63,13 @@ export function organisationViewModel(metadata, validation) {
  * @param {ValidationFailure} [validation]
  */
 export function teamViewModel(metadata, validation) {
+  const { formValues, formErrors } = validation ?? {}
+
   return {
     backLink: '/create/organisation',
     pageTitle: 'Team details',
     pageHeading: 'Team details',
+    errorList: buildErrorList(formErrors),
     formErrors: validation?.formErrors,
     formValues: validation?.formValues,
     fields: [
@@ -71,7 +82,7 @@ export function teamViewModel(metadata, validation) {
         hint: {
           text: 'Enter the name of the policy team or business area responsible for this form'
         },
-        value: validation?.formValues.teamName ?? metadata?.teamName,
+        value: formValues?.teamName ?? metadata?.teamName,
         autocapitalize: true,
         spellcheck: true
       },
@@ -81,7 +92,7 @@ export function teamViewModel(metadata, validation) {
         label: {
           text: 'Shared team email address'
         },
-        value: validation?.formValues.teamEmail ?? metadata?.teamEmail,
+        value: formValues?.teamEmail ?? metadata?.teamEmail,
         autocomplete: 'email',
         spellcheck: false
       }

--- a/designer/server/src/routes/forms/create.js
+++ b/designer/server/src/routes/forms/create.js
@@ -109,7 +109,7 @@ export default [
 
           if (error instanceof Joi.ValidationError) {
             yar.flash('validationFailure', {
-              formErrors: buildErrorDetails(error.details),
+              formErrors: buildErrorDetails(error),
               formValues: payload
             })
           }
@@ -171,7 +171,7 @@ export default [
 
           if (error instanceof Joi.ValidationError) {
             yar.flash('validationFailure', {
-              formErrors: buildErrorDetails(error.details),
+              formErrors: buildErrorDetails(error),
               formValues: payload
             })
           }
@@ -271,7 +271,7 @@ export default [
           const { payload, yar } = request
 
           if (error instanceof Joi.ValidationError) {
-            const formErrors = buildErrorDetails(error.details)
+            const formErrors = buildErrorDetails(error)
 
             yar.flash('validationFailure', {
               formErrors: {

--- a/designer/server/src/views/forms/question-input.njk
+++ b/designer/server/src/views/forms/question-input.njk
@@ -5,10 +5,6 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "error-summary/macro.njk" import appErrorSummary %}
 
-{% if errorList | length %}
-  {% set pageTitle = "Error: " + pageTitle %}
-{% endif %}
-
 {% block beforeContent %}
   {{ govukBackLink({
     href: backLink

--- a/designer/server/src/views/forms/question-input.njk
+++ b/designer/server/src/views/forms/question-input.njk
@@ -2,8 +2,8 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "error-summary/macro.njk" import appErrorSummary %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -15,7 +15,8 @@
   <form method="post" novalidate>
     {% call appPageBody() %}
       {% if errorList | length %}
-        {{ appErrorSummary({
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
           errorList: errorList
         }) }}
       {% endif %}

--- a/designer/server/src/views/forms/question-input.njk
+++ b/designer/server/src/views/forms/question-input.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "error-summary/macro.njk" import appErrorSummary %}
 
-{% if formErrors | length %}
+{% if errorList | length %}
   {% set pageTitle = "Error: " + pageTitle %}
 {% endif %}
 
@@ -18,9 +18,9 @@
 {% block content %}
   <form method="post" novalidate>
     {% call appPageBody() %}
-      {% if formErrors | length %}
+      {% if errorList | length %}
         {{ appErrorSummary({
-          formErrors: formErrors
+          errorList: errorList
         }) }}
       {% endif %}
 
@@ -34,7 +34,7 @@
         name: field.name,
         value: field.value,
         errorMessage: {
-          text: formErrors[field.name].message
+          text: formErrors[field.name].text
         } if formErrors[field.name],
         autocapitalize: field.autocapitalize,
         autocomplete: field.autocomplete,

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "error-summary/macro.njk" import appErrorSummary %}
 
-{% if formErrors | length %}
+{% if errorList | length %}
   {% set pageTitle = "Error: " + pageTitle %}
 {% endif %}
 
@@ -23,9 +23,9 @@
 
   {% call appPageBody() %}
     <form method="post" novalidate>
-      {% if formErrors | length %}
+      {% if errorList | length %}
         {{ appErrorSummary({
-          formErrors: formErrors
+          errorList: errorList
         }) }}
       {% endif %}
 
@@ -37,7 +37,7 @@
           name: field.name,
           value: field.value,
           errorMessage: {
-            text: formErrors[field.name].message
+            text: formErrors[field.name].text
           } if formErrors[field.name],
           autocapitalize: field.autocapitalize,
           autocomplete: field.autocomplete,

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -2,8 +2,8 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "error-summary/macro.njk" import appErrorSummary %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -20,7 +20,8 @@
   {% call appPageBody() %}
     <form method="post" novalidate>
       {% if errorList | length %}
-        {{ appErrorSummary({
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
           errorList: errorList
         }) }}
       {% endif %}

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -5,10 +5,6 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "error-summary/macro.njk" import appErrorSummary %}
 
-{% if errorList | length %}
-  {% set pageTitle = "Error: " + pageTitle %}
-{% endif %}
-
 {% block beforeContent %}
   {{ govukBackLink({
     href: backLink
@@ -17,7 +13,7 @@
 
 {% block content %}
   {{ appHeading({
-    text: pageHeading or pageTitle,
+    text: pageTitle,
     classes: "govuk-heading-l"
   }) }}
 

--- a/designer/server/src/views/forms/question-radios.njk
+++ b/designer/server/src/views/forms/question-radios.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "error-summary/macro.njk" import appErrorSummary %}
 
-{% if formErrors | length %}
+{% if errorList | length %}
   {% set pageTitle = "Error: " + pageTitle %}
 {% endif %}
 
@@ -17,9 +17,9 @@
 
 {% block content %}
   <form method="post" novalidate>
-    {% if formErrors | length %}
+    {% if errorList | length %}
       {{ appErrorSummary({
-        formErrors: formErrors
+        errorList: errorList
       }) }}
     {% endif %}
 
@@ -37,7 +37,7 @@
         items: field.items,
         value: field.value,
         errorMessage: {
-          text: formErrors[field.name].message
+          text: formErrors[field.name].text
         } if formErrors[field.name]
       }) }}
 

--- a/designer/server/src/views/forms/question-radios.njk
+++ b/designer/server/src/views/forms/question-radios.njk
@@ -2,8 +2,8 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "error-summary/macro.njk" import appErrorSummary %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -14,7 +14,8 @@
 {% block content %}
   <form method="post" novalidate>
     {% if errorList | length %}
-      {{ appErrorSummary({
+      {{ govukErrorSummary({
+        titleText: "There is a problem",
         errorList: errorList
       }) }}
     {% endif %}

--- a/designer/server/src/views/forms/question-radios.njk
+++ b/designer/server/src/views/forms/question-radios.njk
@@ -5,10 +5,6 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "error-summary/macro.njk" import appErrorSummary %}
 
-{% if errorList | length %}
-  {% set pageTitle = "Error: " + pageTitle %}
-{% endif %}
-
 {% block beforeContent %}
   {{ govukBackLink({
     href: backLink


### PR DESCRIPTION
This PR adds a new helper `buildErrorList()` so we can prepare Joi error objects for [**Error summary**](https://design-system.service.gov.uk/components/error-summary/)

This means we can configure the `pageTitle` "Error: " prefix in the Nunjucks layout