### PR TITLE
Remove required from  state in the FormMetadataSchema

### DIFF
--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -85,6 +85,6 @@ export const formMetadataStateSchema = Joi.object<FormMetadataState>().keys({
 export const formMetadataSchema = formMetadataInputSchema.append<FormMetadata>({
   id: idSchema,
   slug: slugSchema,
-  draft: formMetadataStateSchema.required(),
+  draft: formMetadataStateSchema,
   live: formMetadataStateSchema
 })

--- a/model/src/form/form-metadata/types.ts
+++ b/model/src/form/form-metadata/types.ts
@@ -78,7 +78,7 @@ export interface FormMetadata {
   /**
    * The draft state of the form
    */
-  draft: FormMetadataState
+  draft?: FormMetadataState
 
   /**
    * The live state of the form


### PR DESCRIPTION
Just a small PR to make the `draft` state as optional (the draft state is now deleted on making the form live)