### PR TITLE
Add types and utilities for levels of authentication

### DIFF
--- a/designer/server/src/common/helpers/auth/drop-user-session.js
+++ b/designer/server/src/common/helpers/auth/drop-user-session.js
@@ -1,4 +1,7 @@
-import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
+import {
+  getUserSession,
+  hasUser
+} from '~/src/common/helpers/auth/get-user-session.js'
 
 /**
  * @param {Request} request
@@ -9,7 +12,7 @@ export async function dropUserSession(request) {
   const credentials = await getUserSession(request)
 
   // Remove user session from Redis
-  if (credentials?.user?.id) {
+  if (hasUser(credentials)) {
     await server.methods.session.drop(credentials.user.id)
   }
 

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -32,6 +32,18 @@ export async function getUserSession(request, session) {
 
 /**
  * @param {AuthCredentials | null} [credentials]
+ * @returns {credentials is AuthWithTokens}
+ */
+export function hasAuthenticated(credentials) {
+  return !!(
+    credentials?.token &&
+    credentials.idToken &&
+    credentials.refreshToken
+  )
+}
+
+/**
+ * @param {AuthCredentials | null} [credentials]
  */
 export function getUserClaims(credentials) {
   if (!credentials?.token) {
@@ -54,6 +66,14 @@ export function getUser(credentials) {
   }
 
   return credentials.user
+}
+
+/**
+ * @param {AuthCredentials | null} [credentials]
+ * @returns {credentials is AuthSignedIn}
+ */
+export function hasUser(credentials) {
+  return hasAuthenticated(credentials) && !!credentials.user
 }
 
 /**

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -65,17 +65,6 @@ export function hasUser(credentials) {
 }
 
 /**
- * @param {AuthCredentials | null} [credentials]
- */
-export function getUser(credentials) {
-  if (!credentials?.user) {
-    return
-  }
-
-  return credentials.user
-}
-
-/**
  * @typedef {import('@hapi/hapi').Request} Request
  * @typedef {import('@hapi/hapi').AuthCredentials} AuthCredentials
  * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -64,6 +64,12 @@ export function getUser(credentials) {
  */
 
 /**
+ * @typedef {Pick<AuthCredentials, 'token' | 'idToken' | 'refreshToken'>} Tokens - Known tokens
+ * @typedef {Extract<AuthCredentials, Required<Tokens>>} AuthWithTokens - Auth credentials with tokens (but maybe no user session)
+ * @typedef {Required<AuthCredentials>} AuthSignedIn - Auth credentials with tokens and user session
+ */
+
+/**
  * @template {object} Payload
  * @typedef {import('@hapi/jwt').HapiJwt.Artifacts<{ JwtPayload?: Payload }>} UserToken
  */

--- a/designer/server/src/common/helpers/auth/session-cookie.js
+++ b/designer/server/src/common/helpers/auth/session-cookie.js
@@ -1,6 +1,9 @@
 import authCookie from '@hapi/cookie'
 
-import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
+import {
+  getUserSession,
+  hasUser
+} from '~/src/common/helpers/auth/get-user-session.js'
 import config from '~/src/config.js'
 
 /**
@@ -43,7 +46,7 @@ const sessionCookie = {
 
           return {
             credentials,
-            isValid: !!credentials
+            isValid: hasUser(credentials)
           }
         }
       })

--- a/designer/server/src/common/helpers/auth/user-session.js
+++ b/designer/server/src/common/helpers/auth/user-session.js
@@ -29,15 +29,19 @@ export function createUser(credentials) {
  */
 export async function createUserSession(request) {
   const { auth, server } = request
+  const { artifacts, credentials } = auth
+
+  // Patch missing properties using Bell artifacts
+  credentials.idToken = artifacts.id_token
 
   // Optionally create user object (e.g. signed in token but no session)
-  const user = !getUser(auth.credentials)
-    ? createUser(auth.credentials)
-    : auth.credentials.user
+  const user = !getUser(credentials)
+    ? createUser(credentials)
+    : credentials.user
 
   // Create and retrieve user session from Redis
   if (user?.id) {
-    await server.methods.session.set(user.id, { ...auth.credentials, user })
+    await server.methods.session.set(user.id, { ...credentials, user })
     return server.methods.session.get(user.id)
   }
 }

--- a/designer/server/src/common/helpers/auth/user-session.js
+++ b/designer/server/src/common/helpers/auth/user-session.js
@@ -25,7 +25,7 @@ export function createUser(credentials) {
 }
 
 /**
- * @param {Request} request
+ * @param {Request<{ AuthArtifactsExtra: AuthArtifacts }>} request
  */
 export async function createUserSession(request) {
   const { auth, server } = request
@@ -43,7 +43,12 @@ export async function createUserSession(request) {
 }
 
 /**
- * @typedef {import('@hapi/hapi').Request} Request
+ * @typedef {import('@hapi/hapi').AuthArtifacts} AuthArtifacts
  * @typedef {import('@hapi/hapi').AuthCredentials} AuthCredentials
  * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials
+ */
+
+/**
+ * @template {import('@hapi/hapi').ReqRef} [ReqRef=import('@hapi/hapi').ReqRefDefaults]
+ * @typedef {import('@hapi/hapi').Request<ReqRef>} Request
  */

--- a/designer/server/src/lib/forms.js
+++ b/designer/server/src/lib/forms.js
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom'
 
-import { getUser } from '~/src/common/helpers/auth/get-user-session.js'
+import { hasUser } from '~/src/common/helpers/auth/get-user-session.js'
 import config from '~/src/config.js'
 import { getJson, postJson } from '~/src/lib/fetch.js'
 
@@ -95,13 +95,11 @@ export async function updateDraftFormDefinition(id, definition) {
  * @returns {FormMetadataAuthor}
  */
 export function getAuthor(credentials) {
-  const user = getUser(credentials)
-
-  if (!user) {
+  if (!hasUser(credentials)) {
     throw Boom.unauthorized('Failed to get author from auth credentials')
   }
 
-  const { id, displayName } = user
+  const { id, displayName } = credentials.user
   return { id, displayName }
 }
 

--- a/designer/server/src/routes/account/auth.js
+++ b/designer/server/src/routes/account/auth.js
@@ -4,7 +4,7 @@ import { createUserSession } from '~/src/common/helpers/auth/user-session.js'
 
 export default [
   /**
-   * @satisfies {ServerRoute}
+   * @satisfies {ServerRoute<{ AuthArtifactsExtra: AuthArtifacts }>}
    */
   ({
     method: ['GET', 'POST'],
@@ -40,5 +40,10 @@ export default [
 ]
 
 /**
- * @typedef {import('@hapi/hapi').ServerRoute} ServerRoute
+ * @typedef {import('@hapi/hapi').AuthArtifacts} AuthArtifacts
+ */
+
+/**
+ * @template {import('@hapi/hapi').ReqRef} [ReqRef=import('@hapi/hapi').ReqRefDefaults]
+ * @typedef {import('@hapi/hapi').ServerRoute<ReqRef>} ServerRoute
  */

--- a/designer/server/src/routes/account/auth.js
+++ b/designer/server/src/routes/account/auth.js
@@ -1,5 +1,6 @@
 import Boom from '@hapi/boom'
 
+import { hasUser } from '~/src/common/helpers/auth/get-user-session.js'
 import { createUserSession } from '~/src/common/helpers/auth/user-session.js'
 
 export default [
@@ -15,7 +16,7 @@ export default [
       // Create user session
       const credentials = await createUserSession(request)
 
-      if (!credentials?.user) {
+      if (!hasUser(credentials)) {
         return Boom.unauthorized()
       }
 

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -35,6 +35,16 @@ declare module '@hapi/hapi' {
     session: SessionCache
   }
 
+  interface AuthArtifacts {
+    token_type: 'Bearer'
+    scope: string
+    expires_in: number
+    ext_expires_in: number
+    access_token: string
+    refresh_token: string
+    id_token: string
+  }
+
   interface AuthCredentials {
     provider: 'azure-oidc'
     query: Credentials['query']

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -49,6 +49,7 @@ declare module '@hapi/hapi' {
     provider: 'azure-oidc'
     query: Credentials['query']
     token: string
+    idToken: string
     refreshToken: string
     expiresIn: number
   }

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -48,9 +48,9 @@ declare module '@hapi/hapi' {
   interface AuthCredentials {
     provider: 'azure-oidc'
     query: Credentials['query']
-    token: Credentials['token']
-    refreshToken: Credentials['refreshToken']
-    expiresIn: Credentials['expiresIn']
+    token: string
+    refreshToken: string
+    expiresIn: number
   }
 
   interface UserCredentials {

--- a/designer/server/test/fixtures/auth.js
+++ b/designer/server/test/fixtures/auth.js
@@ -8,6 +8,7 @@ export const auth = {
   credentials: {
     provider: 'azure-oidc',
     query: {},
+    idToken: 'dummy-id-token',
     refreshToken: 'dummy-refresh-token',
     token: 'dummy-token',
     expiresIn: Duration.fromObject({ minutes: 30 }).as('seconds'),


### PR DESCRIPTION
This PR adds types for [`@hapi/bell`](https://hapi.dev/module/bell) `AuthArtifacts` immediately following authentication

With this we can do the following:

1. Add artifacts to `auth.credentials` such as **idToken**
2. Add helpers `hasAuthenticated()` (tokens are set) and `hasUser()` (user session available)
3. Add types to narrow `AuthCredentials` based on whether tokens or user checks passed

This means we can extract token properties `given_name`, `family_name` etc without extra checks