### PR TITLE
Update display name in header + other tweaks (re-opened)

### DIFF
--- a/designer/server/src/common/components/page-body/template.njk
+++ b/designer/server/src/common/components/page-body/template.njk
@@ -1,7 +1,8 @@
 {% set content = params.html | safe if params.html else params.text %}
 
 <div class="govuk-grid-row">
-  <div class="{{ params.classes if params.classes else "govuk-grid-column-two-thirds" }}" data-testid="app-page-body">
+  <div class="{{ params.classes if params.classes else "govuk-grid-column-two-thirds" }}"
+    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
     {{ caller() if caller else content }}
   </div>
 </div>

--- a/designer/server/src/common/components/page-body/template.njk
+++ b/designer/server/src/common/components/page-body/template.njk
@@ -1,7 +1,7 @@
 {% set content = params.html | safe if params.html else params.text %}
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds" data-testid="app-page-body">
+  <div class="{{ params.classes if params.classes else "govuk-grid-column-two-thirds" }}" data-testid="app-page-body">
     {{ caller() if caller else content }}
   </div>
 </div>

--- a/designer/server/src/common/components/page-body/template.test.js
+++ b/designer/server/src/common/components/page-body/template.test.js
@@ -6,6 +6,11 @@ describe('Page Body Component', () => {
   describe('With child content', () => {
     beforeEach(() => {
       const { document } = renderMacro('appPageBody', 'page-body/macro.njk', {
+        params: {
+          attributes: {
+            'data-testid': 'app-page-body'
+          }
+        },
         callBlock:
           '<p class="govuk-body">Used digger, digs great and is lots of fun to dig huge holes with. Comes with heater, comfy seat and radio.</p>'
       })
@@ -24,7 +29,10 @@ describe('Page Body Component', () => {
     beforeEach(() => {
       const { document } = renderMacro('appPageBody', 'page-body/macro.njk', {
         params: {
-          text: 'Used digger, digs great and is lots of fun to dig huge holes with. Comes with heater, comfy seat and radio.'
+          text: 'Used digger, digs great and is lots of fun to dig huge holes with. Comes with heater, comfy seat and radio.',
+          attributes: {
+            'data-testid': 'app-page-body'
+          }
         }
       })
 
@@ -42,7 +50,10 @@ describe('Page Body Component', () => {
     beforeEach(() => {
       const { document } = renderMacro('appPageBody', 'page-body/macro.njk', {
         params: {
-          html: '<p class="govuk-body">Used digger, digs great and is lots of fun to dig huge holes with. Comes with heater, comfy seat and radio.</p>'
+          html: '<p class="govuk-body">Used digger, digs great and is lots of fun to dig huge holes with. Comes with heater, comfy seat and radio.</p>',
+          attributes: {
+            'data-testid': 'app-page-body'
+          }
         }
       })
 

--- a/designer/server/src/common/components/service-header/template.njk
+++ b/designer/server/src/common/components/service-header/template.njk
@@ -85,10 +85,12 @@ Component options:
           <li class="one-login-header__nav__list-item">
             <a class="one-login-header__nav__link one-login-header__nav__link--one-login" href="{{ accountLink }}">
               <span class="one-login-header__nav__link-content">
-                {{ params.accountName | default("Account", true) }}
+                {{ params.accountName | default("Sign in", true) }}
               </span>
-              {{ littlePersonIcon() }}
-              {{ littlePersonIcon("focus") }}
+              {% if params.accountName %}
+                {{ littlePersonIcon() }}
+                {{ littlePersonIcon("focus") }}
+              {% endif %}
             </a>
           </li>
           {% if params.accountName %}

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -18,9 +18,9 @@ export async function getUserSession(request, session) {
 
   // Fall back to OpenID Connect (OIDC) claim
   if (!sessionId && hasAuthenticated(credentials)) {
-    const { accessToken } = getUserClaims(credentials)
+    const claims = getUserClaims(credentials)
 
-    sessionId = accessToken.sub
+    sessionId = claims.sub
   }
 
   // Retrieve user session from Redis

--- a/designer/server/src/common/helpers/auth/user-session.js
+++ b/designer/server/src/common/helpers/auth/user-session.js
@@ -16,11 +16,20 @@ export function createUser(credentials) {
 
   const claims = getUserClaims(credentials)
 
+  const {
+    name, // Lastname, firstname
+    given_name: firstName,
+    family_name: lastName
+  } = claims
+
+  // Improve display name formatting
+  const displayName = firstName && lastName ? `${firstName} ${lastName}` : name
+
   // Create user object (e.g. signed in token but no session)
   return /** @satisfies {UserCredentials} */ ({
     id: claims.sub,
     email: claims.email ?? '',
-    displayName: claims.name ?? '',
+    displayName: displayName ?? '',
     issuedAt: DateTime.fromSeconds(claims.iat).toUTC().toISO(),
     expiresAt: DateTime.fromSeconds(claims.exp).toUTC().toISO()
   })

--- a/designer/server/src/config.ts
+++ b/designer/server/src/config.ts
@@ -15,7 +15,7 @@ export interface Config {
   managerUrl: string
   serviceName: string
   logLevel: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent'
-  phase: 'alpha' | 'beta' | 'live'
+  phase?: 'alpha' | 'beta' | 'live'
   isProduction: boolean
   isDevelopment: boolean
   isTest: boolean
@@ -64,7 +64,7 @@ const schema = joi.object<Config>({
       then: joi.string().default('silent')
     })
     .valid('fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'),
-  phase: joi.string().valid('alpha', 'beta', 'live').default('beta'),
+  phase: joi.string().valid('alpha', 'beta', 'live').optional(),
   isProduction: joi.boolean().default(false),
   isDevelopment: joi.boolean().default(true),
   isTest: joi.boolean().default(false),

--- a/designer/server/src/createServer.test.ts
+++ b/designer/server/src/createServer.test.ts
@@ -99,6 +99,21 @@ describe('Server tests', () => {
     expect($phaseBanner).not.toBeInTheDocument()
   })
 
+  test('Phase banner is not present by default', async () => {
+    server = await startServer()
+
+    const options = {
+      method: 'get',
+      url: '/help/cookies',
+      auth
+    }
+
+    const { document } = await renderResponse(server, options)
+
+    const $phaseBanner = document.querySelector('.govuk-phase-banner')
+    expect($phaseBanner).not.toBeInTheDocument()
+  })
+
   test('security headers are present', async () => {
     server = await startServer()
 

--- a/designer/server/src/models/forms/create.js
+++ b/designer/server/src/models/forms/create.js
@@ -10,7 +10,10 @@ export function titleViewModel(metadata, validation) {
   const { formValues, formErrors } = validation ?? {}
 
   return {
-    backLink: '/library',
+    backLink: {
+      text: 'Back to form library',
+      href: '/library'
+    },
     pageTitle: 'Enter a name for your form',
     errorList: buildErrorList(formErrors, ['title']),
     formErrors: validation?.formErrors,
@@ -37,7 +40,9 @@ export function organisationViewModel(metadata, validation) {
   const { formValues, formErrors } = validation ?? {}
 
   return {
-    backLink: '/create/title',
+    backLink: {
+      href: '/create/title'
+    },
     pageTitle: 'Choose a lead organisation for this form',
     errorList: buildErrorList(formErrors, ['organisation']),
     formErrors: validation?.formErrors,
@@ -66,7 +71,9 @@ export function teamViewModel(metadata, validation) {
   const { formValues, formErrors } = validation ?? {}
 
   return {
-    backLink: '/create/organisation',
+    backLink: {
+      href: '/create/organisation'
+    },
     pageTitle: 'Team details',
     errorList: buildErrorList(formErrors, ['teamName', 'teamEmail']),
     formErrors: validation?.formErrors,

--- a/designer/server/src/models/forms/editor.js
+++ b/designer/server/src/models/forms/editor.js
@@ -7,6 +7,10 @@ export function editorViewModel(metadata) {
   const pageTitle = metadata.title
 
   return {
+    backLink: {
+      text: 'Back to form library',
+      href: '/library'
+    },
     pageTitle,
     form: metadata,
     previewUrl: config.previewUrl

--- a/designer/server/src/models/forms/editor.js
+++ b/designer/server/src/models/forms/editor.js
@@ -1,0 +1,18 @@
+import config from '~/src/config.js'
+
+/**
+ * @param {FormMetadata} metadata
+ */
+export function editorViewModel(metadata) {
+  const pageTitle = metadata.title
+
+  return {
+    pageTitle,
+    form: metadata,
+    previewUrl: config.previewUrl
+  }
+}
+
+/**
+ * @typedef {import('~/src/lib/forms.js').FormMetadata} FormMetadata
+ */

--- a/designer/server/src/routes/forms/editor.js
+++ b/designer/server/src/routes/forms/editor.js
@@ -1,7 +1,7 @@
 import Boom from '@hapi/boom'
 
-import config from '~/src/config.js'
 import * as forms from '~/src/lib/forms.js'
+import * as editor from '~/src/models/forms/editor.js'
 
 export default [
   /**
@@ -20,14 +20,8 @@ export default [
           return Boom.notFound(`Form with slug '${params.slug}' not found`)
         }
 
-        return h.view('forms/editor', {
-          phase: config.phase,
-          previewUrl: config.previewUrl,
-          form: {
-            id: form.id,
-            slug: form.slug
-          }
-        })
+        const model = editor.editorViewModel(form)
+        return h.view('forms/editor', model)
       }
     }
   })

--- a/designer/server/src/routes/forms/editor.test.js
+++ b/designer/server/src/routes/forms/editor.test.js
@@ -46,8 +46,10 @@ describe('App routes test', () => {
     }
 
     const { document } = await renderResponse(server, options)
-    expect(document.body).toContainHTML(
-      `<div class="govuk-grid-column-full app-editor" data-id="${id}" data-slug="${slug}" data-preview-url="${config.previewUrl}"></div>`
-    )
+
+    const $editor = document.querySelector('.app-editor')
+    expect($editor).toHaveAttribute('data-id', id)
+    expect($editor).toHaveAttribute('data-slug', slug)
+    expect($editor).toHaveAttribute('data-preview-url', config.previewUrl)
   })
 })

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -68,7 +68,7 @@ declare module '@hapi/hapi' {
     /**
      * User display name
      */
-    displayName: NonNullable<UserProfile['name']>
+    displayName: string
 
     /**
      * Session issued time (ISO 8601)

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -1,11 +1,16 @@
 {% extends "layouts/page.njk" %}
 
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "page-body/macro.njk" import appPageBody %}
 {% from "heading/macro.njk" import appHeading %}
 
 {% block head %}
   {{ super() }}
   <link href="{{ getAssetPath("editor.css") }}" rel="stylesheet">
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink(backLink) }}
 {% endblock %}
 
 {% block content %}

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -3,8 +3,6 @@
 {% from "page-body/macro.njk" import appPageBody %}
 {% from "heading/macro.njk" import appHeading %}
 
-{% set pageTitle = "Form editor" %}
-
 {% block head %}
   {{ super() }}
   <link href="{{ getAssetPath("editor.css") }}" rel="stylesheet">

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -1,5 +1,8 @@
 {% extends "layouts/page.njk" %}
 
+{% from "page-body/macro.njk" import appPageBody %}
+{% from "heading/macro.njk" import appHeading %}
+
 {% set pageTitle = "Form editor" %}
 
 {% block head %}
@@ -8,9 +11,20 @@
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full app-editor" data-id="{{ form.id }}" data-slug="{{ form.slug }}" data-preview-url="{{ previewUrl }}"></div>
-  </div>
+  {{ appHeading({
+    text: pageTitle,
+    classes: "govuk-heading-l"
+  }) }}
+
+  {{ appPageBody({
+    classes: "govuk-grid-column-full app-editor",
+    attributes: {
+      "data-id": form.id,
+      "data-slug": form.slug,
+      "data-preview-url": previewUrl
+    }
+  }) }}
+
   <div id="portal-root"></div>
 {% endblock %}
 

--- a/designer/server/src/views/forms/question-input.njk
+++ b/designer/server/src/views/forms/question-input.njk
@@ -6,9 +6,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-    href: backLink
-  }) }}
+  {{ govukBackLink(backLink) }}
 {% endblock %}
 
 {% block content %}

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -6,9 +6,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-    href: backLink
-  }) }}
+  {{ govukBackLink(backLink) }}
 {% endblock %}
 
 {% block content %}

--- a/designer/server/src/views/forms/question-radios.njk
+++ b/designer/server/src/views/forms/question-radios.njk
@@ -6,9 +6,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-    href: backLink
-  }) }}
+  {{ govukBackLink(backLink) }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Accidentally closed and re-opened from #162

---

This PR formats the user display name as `${firstName} ${lastName}`

* Phase banner turned off by default unless `PHASE=beta` is set etc
* Header account link defaults to “Sign in” (when signed out)
* Adds page title and back link to form editor