### PR TITLE
Add Defra service header

### DIFF
--- a/designer/server/src/common/components/service-header/_service-header.scss
+++ b/designer/server/src/common/components/service-header/_service-header.scss
@@ -169,6 +169,15 @@ $govuk-header-link-underline-thickness: 3px;
   }
 }
 
+.one-login-header__logotype-text {
+  margin: 0 5px 0 2px;
+}
+
+.one-login-header__product-name {
+  @include govuk-font($size: 24, $line-height: 1);
+  display: inline-table;
+}
+
 .one-login-header__link,
 .one-login-header__nav__link {
   &:link,

--- a/designer/server/src/common/components/service-header/_service-header.scss
+++ b/designer/server/src/common/components/service-header/_service-header.scss
@@ -5,6 +5,12 @@
 // start mixins and variables
 $govuk-header-link-underline-thickness: 3px;
 
+$defra-brand-colour: govuk-organisation-colour(department-for-environment-food-rural-affairs);
+$defra-brand-colour-high-contrast: #008531;
+
+$defra-link-colour: govuk-shade($defra-brand-colour-high-contrast, 25%);
+$defra-link-colour-hover: govuk-shade($defra-link-colour, 50%);
+
 @mixin toggle-button-focus($default-text-colour) {
   color: $default-text-colour;
   // apply focus style on :focus for browsers which support :focus but not :focus-visible
@@ -146,7 +152,7 @@ $govuk-header-link-underline-thickness: 3px;
   @include govuk-font($size: 19);
   color: govuk-colour("white");
   background: govuk-colour("black");
-  border-bottom: govuk-spacing(2) solid $govuk-link-colour;
+  border-bottom: govuk-spacing(2) solid $defra-brand-colour;
   position: relative;
 }
 
@@ -403,7 +409,7 @@ $govuk-header-link-underline-thickness: 3px;
 
   &.service-header__nav-list-item--active {
     padding-left: govuk-spacing(3);
-    border-left: govuk-spacing(1) solid $govuk-link-colour;
+    border-left: govuk-spacing(1) solid $defra-brand-colour;
   }
 
   @include govuk-media-query($from: tablet) {
@@ -418,7 +424,7 @@ $govuk-header-link-underline-thickness: 3px;
     &.service-header__nav-list-item--active {
       border-left: 0;
       padding-left: 0;
-      border-bottom: govuk-spacing(1) solid $govuk-link-colour;
+      border-bottom: govuk-spacing(1) solid $defra-brand-colour;
     }
   }
 }
@@ -427,6 +433,19 @@ $govuk-header-link-underline-thickness: 3px;
   @include govuk-link-common;
   @include govuk-link-style-default;
   @include govuk-link-style-no-visited-state;
+
+  &:link,
+  &:visited {
+    color: $defra-link-colour;
+  }
+
+  &:hover {
+    color: $defra-link-colour-hover;
+  }
+
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
 
   &:not(:hover) {
     text-decoration: none;

--- a/designer/server/src/common/components/service-header/template.njk
+++ b/designer/server/src/common/components/service-header/template.njk
@@ -116,8 +116,10 @@ Component options:
   <div class="service-header" data-one-login-header-nav>
     <div class="govuk-width-container">
       <div class="service-header__container">
+        {%- if params.serviceName %}
         <!-- The name of your service goes here -->
         <h2 class="service-header__heading">{{ params.serviceName }}</h2>
+        {% endif %}
         {%- if params.navigationItems %}
         <div>
           <!-- Label the toggle button appropriately (you might want to use the name of your service) to provide support for screen reader users -->

--- a/designer/server/src/common/components/service-header/template.njk
+++ b/designer/server/src/common/components/service-header/template.njk
@@ -34,7 +34,7 @@ Component options:
 {%- macro littlePersonIcon(modifier="default") -%}
   {%- set class = "focus" if modifier == "focus" else "default" %}
   {%- set backgroundColour = "black" if modifier == "focus" else "white" %}
-  {%- set personColour = "white" if modifier == "focus" else "#1D70B8" %}
+  {%- set personColour = "white" if modifier == "focus" else "#008531" %}
         <!--[if gt IE 8]><!-->
           <span class="cross-service-header__button-icon cross-service-header__button-icon--{{class}}">
             <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">

--- a/designer/server/src/common/components/service-header/template.njk
+++ b/designer/server/src/common/components/service-header/template.njk
@@ -1,6 +1,8 @@
 {#
 Component options:
-  - serviceName (string): The name of the service. The service navigation bar will not render unless serviceName is specified
+  - organisationName (string): The name of the organisation
+  - productName (string): The name of the product
+  - serviceName (string): The name of the service (optional)
   - navigationItems (array): An array of objects representing service navigation links.
     Each link object contains the following fields:
       - url (string – indicates the link destination),
@@ -62,9 +64,14 @@ Component options:
                 <path fill="currentColor" fill-rule="evenodd" d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8"></path>
             </svg>
             <!--<![endif]-->
-            <span>
-              GOV.UK
+            <span class="one-login-header__logotype-text">
+              {{ params.organisationName | default("GOV.UK", true) }}
             </span>
+            {% if (params.productName) %}
+            <span class="one-login-header__product-name">
+              {{ params.productName }}
+            </span>
+            {% endif %}
           </span>
         </a>
       </div>
@@ -104,7 +111,7 @@ Component options:
       </nav>
     </div>
   </div>
-  {% if params.serviceName %}
+  {% if params.serviceName or params.navigationItems %}
   <!-- Start of service navigation -->
   <div class="service-header" data-one-login-header-nav>
     <div class="govuk-width-container">

--- a/designer/server/src/common/templates/partials/navigation.njk
+++ b/designer/server/src/common/templates/partials/navigation.njk
@@ -2,6 +2,8 @@
 {% from "service-header/macro.njk" import appServiceHeader %}
 
 {{ appServiceHeader({
+  organisationName: "Defra",
+  productName: "Forms designer",
   serviceName: config.serviceName,
   navigationItems: navigation if isAuthenticated,
   accountName: authedUser.displayName if isAuthenticated,

--- a/designer/server/src/common/templates/partials/navigation.njk
+++ b/designer/server/src/common/templates/partials/navigation.njk
@@ -3,7 +3,7 @@
 
 {{ appServiceHeader({
   organisationName: "Defra",
-  productName: "Forms designer",
+  productName: "Forms Designer",
   navigationItems: navigation if isAuthenticated,
   accountName: authedUser.displayName if isAuthenticated,
   accountLink: "/library",

--- a/designer/server/src/common/templates/partials/navigation.njk
+++ b/designer/server/src/common/templates/partials/navigation.njk
@@ -4,7 +4,6 @@
 {{ appServiceHeader({
   organisationName: "Defra",
   productName: "Forms designer",
-  serviceName: config.serviceName,
   navigationItems: navigation if isAuthenticated,
   accountName: authedUser.displayName if isAuthenticated,
   accountLink: "/library",

--- a/designer/server/src/common/templates/partials/navigation.njk
+++ b/designer/server/src/common/templates/partials/navigation.njk
@@ -8,7 +8,7 @@
   accountName: authedUser.displayName if isAuthenticated,
   accountLink: "/library",
   signOutLink: "/auth/sign-out",
-  homepageLink: "/library"
+  homepageLink: "/"
 }) }}
 
 {% if ["alpha", "beta"].includes(config.phase) %}


### PR DESCRIPTION
This PR adds the green Defra header used on the prototype

We now use a `productName` and the `serviceName` is turned off by default

<br>

<img width="797" alt="New defra header" src="https://github.com/DEFRA/forms-designer/assets/415517/9f20d054-8f31-497c-95d2-acc4caa96edf">
