### PR TITLE
Add “Feedback” link to footer

### DIFF
--- a/designer/server/src/common/templates/layouts/page.njk
+++ b/designer/server/src/common/templates/layouts/page.njk
@@ -39,6 +39,10 @@
           text: "Cookies"
         },
         {
+          href: "/help/feedback",
+          text: "Feedback"
+        },
+        {
           href: "https://www.gov.uk/help/privacy-notice",
           text: "Privacy"
         }


### PR DESCRIPTION
The phase banner (and Feedback link) was turned off in https://github.com/DEFRA/forms-designer/pull/163

This PR brings the Feedback link back but in the footer