### PR TITLE
Add navigation entries for form overview and editor pages

### DIFF
--- a/designer/server/src/common/nunjucks/context/build-navigation.js
+++ b/designer/server/src/common/nunjucks/context/build-navigation.js
@@ -1,13 +1,13 @@
 /**
- * @param {Partial<Request> | null} request
  * @param {string} text
  * @param {string} url
+ * @param {{ isActive: boolean }} [options]
  */
-function buildEntry(request, text, url) {
+export function buildEntry(text, url, options) {
   return {
     text,
     url,
-    isActive: request?.path === url
+    isActive: !!options?.isActive
   }
 }
 
@@ -15,7 +15,11 @@ function buildEntry(request, text, url) {
  * @param {Partial<Request> | null} request
  */
 export function buildNavigation(request) {
-  return [buildEntry(request, 'Forms library', '/library')]
+  return [
+    buildEntry('Forms library', '/library', {
+      isActive: request?.path === '/library'
+    })
+  ]
 }
 
 /**

--- a/designer/server/src/common/nunjucks/context/build-navigation.js
+++ b/designer/server/src/common/nunjucks/context/build-navigation.js
@@ -17,7 +17,7 @@ export function buildEntry(text, url, options) {
 export function buildNavigation(request) {
   return [
     buildEntry('Forms library', '/library', {
-      isActive: request?.path === '/library'
+      isActive: !!request?.path?.startsWith('/library')
     })
   ]
 }

--- a/designer/server/src/common/templates/partials/navigation.njk
+++ b/designer/server/src/common/templates/partials/navigation.njk
@@ -3,7 +3,7 @@
 
 {{ appServiceHeader({
   organisationName: "Defra",
-  productName: "Forms designer",
+  productName: "Forms Designer",
   navigationItems: navigation if isAuthenticated,
   accountName: authedUser.displayName if isAuthenticated,
   accountLink: "/library",

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -1,3 +1,4 @@
+import { buildEntry } from '~/src/common/nunjucks/context/build-navigation.js'
 import config from '~/src/config.js'
 import * as forms from '~/src/lib/forms.js'
 
@@ -13,12 +14,20 @@ export async function listViewModel() {
  */
 export function overviewViewModel(metadata) {
   const pageTitle = metadata.title
+  const formPath = `/library/${metadata.slug}`
+
+  const navigation = [
+    buildEntry('Forms library', `/library`),
+    buildEntry('Overview', formPath, { isActive: true }),
+    buildEntry('Editor', `${formPath}/editor`)
+  ]
 
   return {
     backLink: {
       text: 'Back to forms library',
       href: '/library'
     },
+    navigation,
     pageTitle,
     form: metadata,
     previewUrl: config.previewUrl
@@ -30,12 +39,20 @@ export function overviewViewModel(metadata) {
  */
 export function editorViewModel(metadata) {
   const pageTitle = metadata.title
+  const formPath = `/library/${metadata.slug}`
+
+  const navigation = [
+    buildEntry('Forms library', `/library`),
+    buildEntry('Overview', formPath),
+    buildEntry('Editor', `${formPath}/editor`, { isActive: true })
+  ]
 
   return {
     backLink: {
       text: 'Back to form overview',
       href: `/library/${metadata.slug}`
     },
+    navigation,
     pageTitle,
     form: metadata,
     previewUrl: config.previewUrl


### PR DESCRIPTION
This PR updates the `navigation` context for form overview and editor pages

I've also updated the `buildEntry()` helper to work without a Hapi request object

<br>

<img width="495" alt="Navigation entries" src="https://github.com/DEFRA/forms-designer/assets/415517/53614c91-67e7-47c9-9db4-a82b0305eb8b">
