### PR TITLE
Set up "Form management" side bar + overview tweaks etc

### DIFF
--- a/designer/client/src/stylesheets/components/_all.scss
+++ b/designer/client/src/stylesheets/components/_all.scss
@@ -1,3 +1,4 @@
 @import "../../../../server/src/common/components/breadcrumbs/breadcrumbs";
+@import "../../../../server/src/common/components/form-card/form-card";
 @import "../../../../server/src/common/components/service-header/service-header";
 @import "button";

--- a/designer/client/src/stylesheets/components/_all.scss
+++ b/designer/client/src/stylesheets/components/_all.scss
@@ -1,2 +1,3 @@
 @import "../../../../server/src/common/components/breadcrumbs/breadcrumbs";
 @import "../../../../server/src/common/components/service-header/service-header";
+@import "button";

--- a/designer/client/src/stylesheets/components/_button.scss
+++ b/designer/client/src/stylesheets/components/_button.scss
@@ -1,0 +1,21 @@
+.govuk-button--secondary-quiet {
+  box-shadow: none;
+  background-color: govuk-colour("white");
+  border-color: govuk-colour("dark-grey");
+
+  &,
+  &:link,
+  &:visited,
+  &:active,
+  &:hover {
+    color: govuk-colour("dark-grey");
+  }
+
+  &:hover {
+    background-color: govuk-colour("light-grey");
+
+    &[disabled] {
+      background-color: govuk-colour("white");
+    }
+  }
+}

--- a/designer/server/src/common/components/form-card/_form-card.scss
+++ b/designer/server/src/common/components/form-card/_form-card.scss
@@ -1,0 +1,12 @@
+.app-form-card {
+  background-color: govuk-colour("light-grey");
+  padding: govuk-spacing(3);
+}
+
+.app-form-card .govuk-button {
+  width: 100%;
+}
+
+.app-form-card :last-child {
+  margin-bottom: 0;
+}

--- a/designer/server/src/common/components/form-card/macro.njk
+++ b/designer/server/src/common/components/form-card/macro.njk
@@ -1,0 +1,3 @@
+{% macro appFormCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/designer/server/src/common/components/form-card/template.njk
+++ b/designer/server/src/common/components/form-card/template.njk
@@ -1,0 +1,9 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "heading/macro.njk" import appHeading %}
+
+<aside class="app-form-card">
+  {{ appHeading(params.heading) }}
+  {% for button in params.buttons %}
+    {{ govukButton(button) }}
+  {% endfor %}
+</aside>

--- a/designer/server/src/common/components/heading/template.njk
+++ b/designer/server/src/common/components/heading/template.njk
@@ -17,13 +17,10 @@
 <div class="govuk-grid-row app-heading" data-testid="app-heading">
   <div class="govuk-grid-column-two-thirds">
     <h{{ headingLevel }} class="{{ headingClass + " " + params.classes if params.classes else headingClass }}" data-testid="app-heading-title">
+      {% if params.caption -%}
+        <span class="{{ captionClass }}">{{ params.caption }}</span>
+      {% endif -%}
       {{ params.html | safe | indent(6) if params.html else params.text }}
     </h{{ headingLevel }}>
-
-  {% if params.caption %}
-    <span class="{{ captionClass }}" data-testid="app-heading-caption">
-      {{ params.caption }}
-    </span>
-  {% endif %}
   </div>
 </div>

--- a/designer/server/src/common/components/heading/template.njk
+++ b/designer/server/src/common/components/heading/template.njk
@@ -1,11 +1,27 @@
+{% set headingLevel = params.level if params.level else 1 -%}
+{% set headingClass = "govuk-heading-xl" -%}
+{% set captionClass = "govuk-caption-xl" -%}
+
+{% switch params.size %}
+  {% case "small" %}
+    {% set headingClass = "govuk-heading-s" %}
+    {% set captionClass = "govuk-caption-s" %}
+  {% case "medium" %}
+    {% set headingClass = "govuk-heading-m" %}
+    {% set captionClass = "govuk-caption-m" %}
+  {% case "large" %}
+    {% set headingClass = "govuk-heading-l" %}
+    {% set captionClass = "govuk-caption-l" %}
+{% endswitch -%}
+
 <div class="govuk-grid-row app-heading" data-testid="app-heading">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="{{ params.classes if params.classes else "govuk-heading-xl" }}" data-testid="app-heading-title">
-      {{ params.text }}
-    </h1>
+    <h{{ headingLevel }} class="{{ headingClass + " " + params.classes if params.classes else headingClass }}" data-testid="app-heading-title">
+      {{ params.html | safe | indent(6) if params.html else params.text }}
+    </h{{ headingLevel }}>
 
   {% if params.caption %}
-    <span class="govuk-caption-m" data-testid="app-heading-caption">
+    <span class="{{ captionClass }}" data-testid="app-heading-caption">
       {{ params.caption }}
     </span>
   {% endif %}

--- a/designer/server/src/common/components/heading/template.njk
+++ b/designer/server/src/common/components/heading/template.njk
@@ -14,13 +14,9 @@
     {% set captionClass = "govuk-caption-l" %}
 {% endswitch -%}
 
-<div class="govuk-grid-row app-heading" data-testid="app-heading">
-  <div class="govuk-grid-column-two-thirds">
-    <h{{ headingLevel }} class="{{ headingClass + " " + params.classes if params.classes else headingClass }}" data-testid="app-heading-title">
-      {% if params.caption -%}
-        <span class="{{ captionClass }}">{{ params.caption }}</span>
-      {% endif -%}
-      {{ params.html | safe | indent(6) if params.html else params.text }}
-    </h{{ headingLevel }}>
-  </div>
-</div>
+<h{{ headingLevel }} class="{{ headingClass + " " + params.classes if params.classes else headingClass }}">
+  {% if params.caption -%}
+    <span class="{{ captionClass }}">{{ params.caption }}</span>
+  {% endif -%}
+  {{ params.html | safe | indent(2) if params.html else params.text }}
+</h{{ headingLevel }}>

--- a/designer/server/src/common/components/heading/template.test.js
+++ b/designer/server/src/common/components/heading/template.test.js
@@ -27,7 +27,7 @@ describe('Heading Component', () => {
 
     test('Should have expected heading caption', () => {
       expect(
-        $heading?.querySelector('[data-testid="app-heading-caption"]')
+        $heading?.querySelector("[class^='govuk-caption']")
       ).toHaveTextContent('A page showing available services')
     })
   })

--- a/designer/server/src/common/components/heading/template.test.js
+++ b/designer/server/src/common/components/heading/template.test.js
@@ -12,7 +12,7 @@ describe('Heading Component', () => {
         }
       })
 
-      $heading = document.querySelector('[data-testid="app-heading"]')
+      $heading = document.querySelector('h1')
     })
 
     test('Should render app heading component', () => {
@@ -20,9 +20,7 @@ describe('Heading Component', () => {
     })
 
     test('Should contain expected heading', () => {
-      expect(
-        $heading?.querySelector('[data-testid="app-heading-title"]')
-      ).toHaveTextContent('Services')
+      expect($heading).toHaveTextContent('Services')
     })
 
     test('Should have expected heading caption', () => {

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -30,6 +30,20 @@ export function overviewViewModel(metadata) {
     navigation,
     pageTitle,
     form: metadata,
+    formManagement: {
+      heading: {
+        text: 'Form management',
+        size: 'medium',
+        level: '3'
+      },
+      buttons: [
+        {
+          text: 'Edit draft',
+          href: `${formPath}/editor`,
+          classes: 'govuk-button--secondary-quiet'
+        }
+      ]
+    },
     previewUrl: config.previewUrl
   }
 }

--- a/designer/server/src/views/account/signed-out.njk
+++ b/designer/server/src/views/account/signed-out.njk
@@ -4,7 +4,7 @@
 {% block content %}
   {{ appHeading({
     text: "You have signed out",
-    classes: "govuk-heading-l"
+    size: "large"
   }) }}
 
   {% call appPageBody() %}

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -16,7 +16,7 @@
 {% block content %}
   {{ appHeading({
     text: pageTitle,
-    classes: "govuk-heading-l"
+    size: "large"
   }) }}
 
   {{ appPageBody({

--- a/designer/server/src/views/forms/library.njk
+++ b/designer/server/src/views/forms/library.njk
@@ -10,7 +10,9 @@
     text: pageTitle
   }) }}
 
-  {% call appPageBody() %}
+  {% call appPageBody({
+    classes: "govuk-grid-column-two-thirds-from-desktop"
+  }) %}
     {% if formItems | length %}
       <h2 class="govuk-heading-m">
         {{ formItems | length + (" form" if formItems | length == 1 else " forms" ) }}

--- a/designer/server/src/views/forms/overview.njk
+++ b/designer/server/src/views/forms/overview.njk
@@ -11,111 +11,131 @@
   {{ govukBackLink(backLink) }}
 {% endblock %}
 
+{% set formStatus %}
+  {{ appFormStatus({
+    metadata: form
+  }) }}
+{% endset %}
+
+{% set formUpdated %}
+  {{ (form.draft.updatedAt if form.draft.updatedAt else "2024-04-09") | formatDate }}
+  by {{ form.draft.updatedBy.displayName | default("Enrique Chase", true) }}
+{% endset %}
+
+{% set formCreated %}
+  {{ (form.draft.createdAt if form.draft.createdAt else "2024-03-01") | formatDate }}
+  by {{ form.draft.createdBy.displayName | default("Nathanael Booker", true) }}
+{% endset %}
+
+{% set formLink %}
+  {% set linkHref = previewUrl + "/" + form.slug | urlencode %}
+  <a href="{{ linkHref }}" class="govuk-link govuk-link--no-visited-state">
+    {{ linkHref }}
+  </a>
+{% endset %}
+
+{% set formDetails %}
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Status"
+        },
+        value: {
+          html: formStatus
+        }
+      },
+      {
+        key: {
+          text: "Updated"
+        },
+        value: {
+          text: formUpdated
+        }
+      },
+      {
+        key: {
+          text: "Created"
+        },
+        value: {
+          text: formCreated
+        }
+      },
+      {
+        key: {
+          text: "Preview link"
+        },
+        value: {
+          text: formLink | safe
+        }
+      }
+    ]
+  }) }}
+
+  {{ appHeading({
+    text: "Organisation details",
+    classes: "govuk-heading-m"
+  }) }}
+
+  {{ govukSummaryList({
+    rows: [
+      {
+        key: {
+          text: "Form name"
+        },
+        value: {
+          html: form.title
+        }
+      },
+      {
+        key: {
+          text: "Lead organisation"
+        },
+        value: {
+          html: form.organisation
+        }
+      },
+      {
+        key: {
+          text: "Team name"
+        },
+        value: {
+          html: form.teamName
+        }
+      }
+    ]
+  }) }}
+{% endset %}
+
+{% set formManagement %}
+  {{ appHeading({
+    text: "Form management",
+    classes: "govuk-heading-m"
+  }) }}
+
+  {{ govukButton({
+    text: "Edit draft ",
+    href: "/library/" + form.slug | urlencode + "/editor",
+    classes: "govuk-button--secondary"
+  }) }}
+{% endset %}
+
 {% block content %}
   {{ appHeading({
     text: pageTitle,
     classes: "govuk-heading-l"
   }) }}
 
-  {% set formStatus %}
-    {{ appFormStatus({
-      metadata: form
-    }) }}
-  {% endset %}
-
-  {% set formUpdated %}
-    {{ (form.draft.updatedAt if form.draft.updatedAt else "2024-04-09") | formatDate }}
-    by {{ form.draft.updatedBy.displayName | default("Enrique Chase", true) }}
-  {% endset %}
-
-  {% set formCreated %}
-    {{ (form.draft.createdAt if form.draft.createdAt else "2024-03-01") | formatDate }}
-    by {{ form.draft.createdBy.displayName | default("Nathanael Booker", true) }}
-  {% endset %}
-
-  {% set formLink %}
-    {% set linkHref = previewUrl + "/" + form.slug | urlencode %}
-    <a href="{{ linkHref }}" class="govuk-link govuk-link--no-visited-state">
-      {{ linkHref }}
-    </a>
-  {% endset %}
-
-  {% call appPageBody() %}
-    {{ govukSummaryList({
-      rows: [
-        {
-          key: {
-            text: "Status"
-          },
-          value: {
-            html: formStatus
-          }
-        },
-        {
-          key: {
-            text: "Updated"
-          },
-          value: {
-            text: formUpdated
-          }
-        },
-        {
-          key: {
-            text: "Created"
-          },
-          value: {
-            text: formCreated
-          }
-        },
-        {
-          key: {
-            text: "Preview link"
-          },
-          value: {
-            text: formLink | safe
-          }
-        }
-      ]
-    }) }}
-
-    {{ appHeading({
-      text: "Organisation details",
-      classes: "govuk-heading-m"
-    }) }}
-
-    {{ govukSummaryList({
-      rows: [
-        {
-          key: {
-            text: "Form name"
-          },
-          value: {
-            html: form.title
-          }
-        },
-        {
-          key: {
-            text: "Lead organisation"
-          },
-          value: {
-            html: form.organisation
-          }
-        },
-        {
-          key: {
-            text: "Team name"
-          },
-          value: {
-            html: form.teamName
-          }
-        }
-      ]
-    }) }}
-
-    {{ govukButton({
-      text: "Edit draft ",
-      href: "/library/" + form.slug | urlencode + "/editor",
-      classes: "govuk-button--secondary"
-    }) }}
-  {% endcall %}
+  {{ appPageBody([
+    [
+      {
+        html: formDetails,
+        classes: "govuk-grid-column-two-thirds-from-desktop"
+      },
+      {
+        html: formManagement,
+        classes: "govuk-grid-column-one-third-from-desktop"
+      }
+    ]
+  ]) }}
 {% endblock %}

--- a/designer/server/src/views/forms/overview.njk
+++ b/designer/server/src/views/forms/overview.njk
@@ -80,10 +80,12 @@
 
   {{ appHeading({
     text: "Organisation details",
-    size: "medium"
+    size: "medium",
+    classes: "govuk-!-margin-top-8"
   }) }}
 
   {{ govukSummaryList({
+    classes: "govuk-!-margin-bottom-8",
     rows: [
       {
         key: {

--- a/designer/server/src/views/forms/overview.njk
+++ b/designer/server/src/views/forms/overview.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "page-body/macro.njk" import appPageBody %}
 {% from "heading/macro.njk" import appHeading %}
+{% from "form-card/macro.njk" import appFormCard %}
 {% from "form-status/macro.njk" import appFormStatus %}
 
 {% block beforeContent %}
@@ -35,6 +36,11 @@
 {% endset %}
 
 {% set formDetails %}
+  {{ appHeading({
+    text: pageTitle,
+    size: "large"
+  }) }}
+
   {{ govukSummaryList({
     rows: [
       {
@@ -107,25 +113,7 @@
   }) }}
 {% endset %}
 
-{% set formManagement %}
-  {{ appHeading({
-    text: "Form management",
-    size: "medium"
-  }) }}
-
-  {{ govukButton({
-    text: "Edit draft ",
-    href: "/library/" + form.slug | urlencode + "/editor",
-    classes: "govuk-button--secondary"
-  }) }}
-{% endset %}
-
 {% block content %}
-  {{ appHeading({
-    text: pageTitle,
-    size: "large"
-  }) }}
-
   {{ appPageBody([
     [
       {
@@ -133,7 +121,7 @@
         classes: "govuk-grid-column-two-thirds-from-desktop"
       },
       {
-        html: formManagement,
+        html: appFormCard(formManagement),
         classes: "govuk-grid-column-one-third-from-desktop"
       }
     ]

--- a/designer/server/src/views/forms/overview.njk
+++ b/designer/server/src/views/forms/overview.njk
@@ -30,7 +30,7 @@
 
 {% set formLink %}
   {% set linkHref = previewUrl + "/" + form.slug | urlencode %}
-  <a href="{{ linkHref }}" class="govuk-link govuk-link--no-visited-state">
+  <a href="{{ linkHref }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noreferrer">
     {{ linkHref }}
   </a>
 {% endset %}

--- a/designer/server/src/views/forms/overview.njk
+++ b/designer/server/src/views/forms/overview.njk
@@ -74,7 +74,7 @@
 
   {{ appHeading({
     text: "Organisation details",
-    classes: "govuk-heading-m"
+    size: "medium"
   }) }}
 
   {{ govukSummaryList({
@@ -110,7 +110,7 @@
 {% set formManagement %}
   {{ appHeading({
     text: "Form management",
-    classes: "govuk-heading-m"
+    size: "medium"
   }) }}
 
   {{ govukButton({
@@ -123,7 +123,7 @@
 {% block content %}
   {{ appHeading({
     text: pageTitle,
-    classes: "govuk-heading-l"
+    size: "large"
   }) }}
 
   {{ appPageBody([

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -12,7 +12,7 @@
 {% block content %}
   {{ appHeading({
     text: pageTitle,
-    classes: "govuk-heading-l"
+    size: "large"
   }) }}
 
   {% call appPageBody() %}


### PR DESCRIPTION
This PR uses the grid layout changes in https://github.com/DEFRA/forms-designer/pull/169 to set up the "Form management" side bar

There's also some spacing changes around "Organisation details" and the preview link opens in a new tab

<br>

<img width="1026" alt="Form management side bar" src="https://github.com/DEFRA/forms-designer/assets/415517/9036ec23-a92d-4c92-b5ef-54ecee656505">
