### PR TITLE
Add user entity checks to routes

### DIFF
--- a/designer/server/src/common/helpers/auth/azure-oidc.js
+++ b/designer/server/src/common/helpers/auth/azure-oidc.js
@@ -134,7 +134,7 @@ export const azureOidcNoop = {
  * @typedef {import('@hapi/bell').BellOptions} ProviderBell - Bell provider options
  * @typedef {import('@hapi/bell').Credentials2} Credentials - Provider OAuth2 credentials
  * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials - User credentials
- * @typedef {import('oidc-client-ts').SigninResponse} SigninResponse - Provider sign in artifacts
  * @typedef {import('oidc-client-ts').OidcMetadata} OidcMetadata - OpenID Connect (OIDC) metadata
- * @typedef {import('oidc-client-ts').UserProfile} UserProfile - User profile
+ * @typedef {import('oidc-client-ts').SigninResponse} SigninResponse - Provider sign in artifacts
+ * @typedef {import('oidc-client-ts').UserProfile & { groups?: string[] }} UserProfile - User profile
  */

--- a/designer/server/src/routes/forms/library.js
+++ b/designer/server/src/routes/forms/library.js
@@ -16,7 +16,10 @@ export default [
     },
     options: {
       auth: {
-        mode: 'required'
+        mode: 'required',
+        access: {
+          entity: 'user'
+        }
       }
     }
   }),
@@ -39,6 +42,12 @@ export default [
 
         const model = library.overviewViewModel(form)
         return h.view('forms/overview', model)
+      },
+      auth: {
+        mode: 'required',
+        access: {
+          entity: 'user'
+        }
       }
     }
   }),
@@ -61,6 +70,12 @@ export default [
 
         const model = library.editorViewModel(form)
         return h.view('forms/editor', model)
+      },
+      auth: {
+        mode: 'required',
+        access: {
+          entity: 'user'
+        }
       }
     }
   })

--- a/designer/server/src/routes/home.js
+++ b/designer/server/src/routes/home.js
@@ -13,7 +13,10 @@ export default /** @satisfies {ServerRoute} */ ({
   },
   options: {
     auth: {
-      mode: 'optional'
+      mode: 'try',
+      access: {
+        entity: 'user'
+      }
     }
   }
 })

--- a/designer/server/test/fixtures/auth.js
+++ b/designer/server/test/fixtures/auth.js
@@ -17,7 +17,8 @@ export const profile = {
   email: 'dummy@defra.gov.uk',
   given_name: 'John',
   family_name: 'Smith',
-  sub: 'dummy_session_id'
+  sub: 'dummy_session_id',
+  groups: ['valid-test-group']
 }
 
 /**
@@ -49,6 +50,7 @@ export const artifacts = {
  */
 export const credentials = {
   provider: 'azure-oidc',
+  scope: ['read', 'write'],
   user,
   query: {},
   token: artifacts.access_token,

--- a/designer/server/test/fixtures/auth.js
+++ b/designer/server/test/fixtures/auth.js
@@ -1,27 +1,75 @@
+import { token } from '@hapi/jwt'
 import { DateTime, Duration } from 'luxon'
+
+const issuedAt = DateTime.now().minus({ minutes: 30 })
+const expiresAt = DateTime.now().plus({ minutes: 30 })
+
+/**
+ * @satisfies {UserProfile}
+ */
+export const profile = {
+  aud: 'dummy-aud',
+  iss: 'https://login.microsoftonline.com/dummy-tid/v2.0',
+  iat: issuedAt.toUTC().toSeconds(),
+  nbf: issuedAt.toUTC().toSeconds(),
+  exp: expiresAt.toUTC().toSeconds(),
+  name: 'John Smith',
+  email: 'dummy@defra.gov.uk',
+  given_name: 'John',
+  family_name: 'Smith',
+  sub: 'dummy_session_id'
+}
+
+/**
+ * @satisfies {UserCredentials}
+ */
+export const user = {
+  id: profile.sub,
+  email: profile.email,
+  displayName: profile.name,
+  issuedAt: issuedAt.toUTC().toISO(),
+  expiresAt: expiresAt.toUTC().toISO()
+}
+
+/**
+ * @satisfies {AuthArtifacts}
+ */
+export const artifacts = {
+  token_type: 'Bearer',
+  scope: 'email openid profile User.Read',
+  expires_in: Duration.fromObject({ minutes: 30 }).as('seconds'),
+  ext_expires_in: Duration.fromObject({ minutes: 30 }).as('seconds'),
+  access_token: token.generate(profile, 'testSecret'),
+  id_token: token.generate(profile, 'testSecret'),
+  refresh_token: 'dummy-encrypted-token'
+}
+
+/**
+ * @satisfies {AuthCredentials}
+ */
+export const credentials = {
+  provider: 'azure-oidc',
+  user,
+  query: {},
+  token: artifacts.access_token,
+  idToken: artifacts.id_token,
+  refreshToken: artifacts.refresh_token,
+  expiresIn: artifacts.expires_in
+}
 
 /**
  * @satisfies {ServerInjectOptions['auth']}
  */
 export const auth = {
   strategy: 'azure-oidc',
-  credentials: {
-    provider: 'azure-oidc',
-    query: {},
-    idToken: 'dummy-id-token',
-    refreshToken: 'dummy-refresh-token',
-    token: 'dummy-token',
-    expiresIn: Duration.fromObject({ minutes: 30 }).as('seconds'),
-    user: {
-      id: 'dummy-id',
-      email: 'dummy@defra.gov.uk',
-      displayName: 'John Smith',
-      issuedAt: DateTime.now().minus({ minutes: 30 }).toUTC().toISO(),
-      expiresAt: DateTime.now().plus({ minutes: 30 }).toUTC().toISO()
-    }
-  }
+  credentials,
+  artifacts
 }
 
 /**
+ * @typedef {import('@hapi/hapi').AuthArtifacts} AuthArtifacts
+ * @typedef {import('@hapi/hapi').AuthCredentials} AuthCredentials
  * @typedef {import('@hapi/hapi').ServerInjectOptions} ServerInjectOptions
+ * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials
+ * @typedef {import('~/src/common/helpers/auth/azure-oidc.js').UserProfile} UserProfile
  */


### PR DESCRIPTION
This PR ensures `request.auth.isAuthorized` is flagged for signed in users

It also splits out our auth fixture into typed properties