### PR TITLE
Update `appPageBody()` to support `params.errorList`

### DIFF
--- a/designer/server/src/common/components/page-body/macro.njk
+++ b/designer/server/src/common/components/page-body/macro.njk
@@ -1,16 +1,30 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "grid-layout/macro.njk" import appGridLayout %}
 {% from "heading/macro.njk" import appHeading %}
 
 {% macro appPageBody(params) %}
+  {% set beforeContent = "" %}
+
   {%- set rows = [{
     html: caller(),
     classes: params.classes,
     attributes: params.attributes
   }] if caller else [params] %}
 
+  {% if params.errorList | length %}
+    {% set beforeContent = beforeContent + govukErrorSummary({
+      titleText: "There is a problem",
+      errorList: params.errorList
+    }) %}
+  {% endif %}
+
   {%- if params.heading %}
+    {% set beforeContent = beforeContent + appHeading(params.heading) %}
+  {% endif %}
+
+  {%- if beforeContent %}
     {% set rows = (rows.unshift({
-      html: appHeading(params.heading) | trim,
+      html: beforeContent | trim,
       classes: "govuk-grid-column-two-thirds"
     }), rows) %}
   {% endif %}

--- a/designer/server/src/views/feedback.njk
+++ b/designer/server/src/views/feedback.njk
@@ -7,6 +7,7 @@
 
 {% block content %}
   {% call appPageBody({
+    errorList: errorList,
     heading: {
       text: pageTitle
     }

--- a/designer/server/src/views/feedback.njk
+++ b/designer/server/src/views/feedback.njk
@@ -6,13 +6,13 @@
 {% set pageTitle = "Give feedback" %}
 
 {% block content %}
-  {% call appPageBody({
-    errorList: errorList,
-    heading: {
-      text: pageTitle
-    }
-  }) %}
-    <form method="post" novalidate>
+  <form method="post" novalidate>
+    {% call appPageBody({
+      errorList: errorList,
+      heading: {
+        text: pageTitle
+      }
+    }) %}
       {{ govukCharacterCount({
         name: "feedback",
         id: "feedback",
@@ -37,6 +37,6 @@
           classes: "govuk-button--secondary"
         }) }}
       </div>
-    </form>
-  {% endcall %}
+    {% endcall %}
+  </form>
 {% endblock %}

--- a/designer/server/src/views/forms/question-input.njk
+++ b/designer/server/src/views/forms/question-input.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block beforeContent %}
@@ -11,14 +10,9 @@
 
 {% block content %}
   <form method="post" novalidate>
-    {% call appPageBody() %}
-      {% if errorList | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errorList
-        }) }}
-      {% endif %}
-
+    {% call appPageBody({
+      errorList: errorList
+    }) %}
       {{ govukInput({
         label: {
           text: field.label.text,

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -9,11 +9,11 @@
 {% endblock %}
 
 {% block content %}
-  {% call appPageBody({
-    errorList: errorList,
-    heading: pageHeading
-  }) %}
-    <form method="post" novalidate>
+  <form method="post" novalidate>
+    {% call appPageBody({
+      errorList: errorList,
+      heading: pageHeading
+    }) %}
       {% for field in fields %}
         {% if field.type === "hidden" %}
           <input type="hidden" name="{{ field.name }}" value="{{ field.value }}">
@@ -37,6 +37,6 @@
       {{ govukButton({
         text: buttonText
       }) }}
-    </form>
-  {% endcall %}
+    {% endcall %}
+  </form>
 {% endblock %}

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block beforeContent %}
@@ -11,16 +10,10 @@
 
 {% block content %}
   {% call appPageBody({
+    errorList: errorList,
     heading: pageHeading
   }) %}
     <form method="post" novalidate>
-      {% if errorList | length %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: errorList
-        }) }}
-      {% endif %}
-
       {% for field in fields %}
         {% if field.type === "hidden" %}
           <input type="hidden" name="{{ field.name }}" value="{{ field.value }}">

--- a/designer/server/src/views/forms/question-radios.njk
+++ b/designer/server/src/views/forms/question-radios.njk
@@ -2,7 +2,6 @@
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block beforeContent %}
@@ -11,14 +10,9 @@
 
 {% block content %}
   <form method="post" novalidate>
-    {% if errorList | length %}
-      {{ govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: errorList
-      }) }}
-    {% endif %}
-
-    {% call appPageBody() %}
+    {% call appPageBody({
+      errorList: errorList
+    }) %}
       {{ govukRadios({
         fieldset: {
           legend: {


### PR DESCRIPTION
This PR ensures the HTML `<form>` element wraps the page titles and error summary

It also fixes an issue where the error summary is displayed after the page title in **question-inputs.njk**

## Before

Error summary displays _after_ the page title

<img width="683" alt="Before" src="https://github.com/DEFRA/forms-designer/assets/415517/507126e7-498e-48e9-b519-d76d8fef3b6c">

## After

Error summary displays _before_ the page title

<img width="677" alt="After" src="https://github.com/DEFRA/forms-designer/assets/415517/a8641961-41fe-405f-bd37-1f4b941f6c00">
