### PR TITLE
Upgrade to GOV.UK Frontend v5.4.0

### DIFF
--- a/designer/client/src/components/ComponentCreate/ComponentCreate.scss
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.scss
@@ -1,6 +1,6 @@
-@import "govuk-frontend/govuk/base";
+@import "govuk-frontend/dist/govuk/base";
 
 .component-create .govuk-back-link {
   margin-top: 0;
-  @include govuk-responsive-margin(7, "bottom");
+  @include govuk-responsive-margin(6, "bottom");
 }

--- a/designer/client/src/components/Flyout/Flyout.scss
+++ b/designer/client/src/components/Flyout/Flyout.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend/govuk/base";
+@import "govuk-frontend/dist/govuk/base";
 @import "../../stylesheets/editor-colours.scss";
 
 .flyout {

--- a/designer/client/src/components/Visualisation/visualisation.scss
+++ b/designer/client/src/components/Visualisation/visualisation.scss
@@ -1,6 +1,6 @@
 $govuk-assets-path: "/assets/";
 
-@import "govuk-frontend/govuk/base";
+@import "govuk-frontend/dist/govuk/base";
 
 .visualisation {
   position: relative;

--- a/designer/client/src/javascripts/application.js
+++ b/designer/client/src/javascripts/application.js
@@ -1,6 +1,15 @@
 import { ServiceHeader } from '@defra/forms-designer/server/src/common/components/service-header/service-header.js'
-import { initAll } from 'govuk-frontend'
+import {
+  createAll,
+  Button,
+  ErrorSummary,
+  CharacterCount,
+  Radios
+} from 'govuk-frontend'
 
-initAll()
+createAll(Button)
+createAll(CharacterCount)
+createAll(ErrorSummary)
+createAll(Radios)
 
 new ServiceHeader(document.querySelector("[data-module='one-login-header']"))

--- a/designer/client/src/stylesheets/application.scss
+++ b/designer/client/src/stylesheets/application.scss
@@ -1,6 +1,6 @@
 $govuk-assets-path: "/assets/";
 
-@import "govuk-frontend/govuk/all";
+@import "govuk-frontend/dist/govuk/all";
 
 @import "variables/all";
 @import "helpers/all";

--- a/designer/client/src/stylesheets/editor-colours.scss
+++ b/designer/client/src/stylesheets/editor-colours.scss
@@ -1,1 +1,1 @@
-@import "govuk-frontend/govuk/helpers/colour";
+@import "govuk-frontend/dist/govuk/helpers/colour";

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -42,7 +42,7 @@ $govuk-assets-path: "/assets/";
 
 button.govuk-link {
   @extend %app-button-link;
-  @include govuk-font($size: 16);
+  @include govuk-font-size($size: 16);
   padding: 0;
 
   &:hover {
@@ -58,7 +58,7 @@ button.govuk-link {
   .govuk-button {
     @include govuk-responsive-margin(1, "right");
     @include govuk-responsive-margin(1, "bottom");
-    @include govuk-font($size: 16);
+    @include govuk-font-size($size: 16);
   }
 
   &__row:not(:first-child) {
@@ -67,7 +67,7 @@ button.govuk-link {
 }
 
 .submenu__link {
-  @include govuk-font($size: 16);
+  @include govuk-font-size($size: 16);
   @include govuk-responsive-margin(4, "right");
 }
 

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -1,6 +1,6 @@
 $govuk-assets-path: "/assets/";
 
-@import "govuk-frontend/govuk/base";
+@import "govuk-frontend/dist/govuk/base";
 
 %app-button-link {
   @include govuk-link-common;

--- a/designer/package.json
+++ b/designer/package.json
@@ -48,7 +48,7 @@
     "date-fns": "^3.6.0",
     "depth-first": "^4.0.0",
     "focus-trap-react": "^8.11.3",
-    "govuk-frontend": "^4.8.0",
+    "govuk-frontend": "^5.4.0",
     "hapi-pino": "^12.1.0",
     "i18next": "^23.11.4",
     "i18next-http-backend": "^2.5.1",

--- a/designer/server/src/common/components/service-header/_service-header.scss
+++ b/designer/server/src/common/components/service-header/_service-header.scss
@@ -1,6 +1,6 @@
-@import "govuk-frontend/govuk/base";
-@import "govuk-frontend/govuk/objects/width-container";
-@import "govuk-frontend/govuk/objects/grid";
+@import "govuk-frontend/dist/govuk/base";
+@import "govuk-frontend/dist/govuk/objects/width-container";
+@import "govuk-frontend/dist/govuk/objects/grid";
 
 // start mixins and variables
 $govuk-header-link-underline-thickness: 3px;

--- a/designer/server/src/common/components/service-header/template.njk
+++ b/designer/server/src/common/components/service-header/template.njk
@@ -35,7 +35,6 @@ Component options:
   {%- set class = "focus" if modifier == "focus" else "default" %}
   {%- set backgroundColour = "black" if modifier == "focus" else "white" %}
   {%- set personColour = "white" if modifier == "focus" else "#008531" %}
-        <!--[if gt IE 8]><!-->
           <span class="cross-service-header__button-icon cross-service-header__button-icon--{{class}}">
             <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" focusable="false" aria-hidden="true">
               <circle cx="11" cy="11" r="11" fill="{{backgroundColour}}"/>
@@ -44,7 +43,6 @@ Component options:
               <circle cx="11" cy="11" r="10" stroke="{{backgroundColour}}" stroke-width="2"/>
             </svg>
           </span>
-        <!--<![endif]-->
 {%- endmacro -%}
 <header class="cross-service-header" role="banner" data-module="one-login-header">
   <div class="one-login-header" data-one-login-header-nav>

--- a/designer/server/src/common/nunjucks/environment.js
+++ b/designer/server/src/common/nunjucks/environment.js
@@ -12,7 +12,7 @@ export const environment = nunjucks.configure(
     join(config.appDir, 'views'),
     join(config.appDir, 'common/templates'),
     join(config.appDir, 'common/components'),
-    dirname(resolvePkg.sync('govuk-frontend/package.json'))
+    join(dirname(resolvePkg.sync('govuk-frontend/package.json')), 'dist')
   ],
   {
     trimBlocks: true,

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -1,4 +1,4 @@
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 
 import CopyPlugin from 'copy-webpack-plugin'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
@@ -13,6 +13,12 @@ const { NODE_ENV = 'development', REACT_LOG_LEVEL } = process.env
 const govukFrontendPath = dirname(
   resolvePkg.sync('govuk-frontend/package.json', {
     basedir: import.meta.dirname
+  })
+)
+
+const govukFrontendLegacyPath = dirname(
+  resolvePkg.sync('govuk-frontend/package.json', {
+    basedir: resolve(import.meta.dirname, '../')
   })
 )
 
@@ -169,7 +175,13 @@ export default /** @type {import('webpack').Configuration} */ ({
       patterns: [
         {
           from: join(govukFrontendPath, 'dist/govuk/assets'),
-          to: 'assets'
+          to: 'assets',
+          priority: 2
+        },
+        {
+          from: join(govukFrontendLegacyPath, 'govuk/assets'),
+          to: 'assets',
+          priority: 1
         },
         {
           from: 'i18n/translations',
@@ -182,7 +194,10 @@ export default /** @type {import('webpack').Configuration} */ ({
     alias: {
       '~': join(import.meta.dirname, 'client'),
       'govuk-frontend/dist': join(govukFrontendPath, 'dist'),
-      'govuk-frontend/govuk': join(govukFrontendPath, 'dist/govuk'),
+      'govuk-frontend/govuk': [
+        join(govukFrontendPath, 'dist/govuk'),
+        join(govukFrontendLegacyPath, 'govuk')
+      ],
       '/assets': join(govukFrontendPath, 'dist/govuk/assets')
     },
     extensions: ['.js', '.json', '.mjs'],

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -42,7 +42,7 @@ export default /** @type {import('webpack').Configuration} */ ({
   module: {
     rules: [
       {
-        test: /\.js$/,
+        test: /\.(js|mjs)$/,
         loader: 'source-map-loader',
         enforce: 'pre'
       },
@@ -168,7 +168,7 @@ export default /** @type {import('webpack').Configuration} */ ({
     new CopyPlugin({
       patterns: [
         {
-          from: join(govukFrontendPath, 'govuk/assets'),
+          from: join(govukFrontendPath, 'dist/govuk/assets'),
           to: 'assets'
         },
         {
@@ -181,8 +181,9 @@ export default /** @type {import('webpack').Configuration} */ ({
   resolve: {
     alias: {
       '~': join(import.meta.dirname, 'client'),
-      'govuk-frontend': govukFrontendPath,
-      '/assets': join(govukFrontendPath, 'govuk/assets/')
+      'govuk-frontend/dist': join(govukFrontendPath, 'dist'),
+      'govuk-frontend/govuk': join(govukFrontendPath, 'dist/govuk'),
+      '/assets': join(govukFrontendPath, 'dist/govuk/assets')
     },
     extensions: ['.js', '.json', '.mjs'],
     extensionAlias: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "date-fns": "^3.6.0",
         "depth-first": "^4.0.0",
         "focus-trap-react": "^8.11.3",
-        "govuk-frontend": "^4.8.0",
+        "govuk-frontend": "^5.4.0",
         "hapi-pino": "^12.1.0",
         "i18next": "^23.11.4",
         "i18next-http-backend": "^2.5.1",
@@ -252,9 +252,9 @@
       "dev": true
     },
     "designer/node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
       "engines": {
         "node": ">= 4.2.0"
       }


### PR DESCRIPTION
This PR upgrades to GOV.UK Frontend v5.4.0 (new tag style)

But I've configured webpack to allow GOV.UK Frontend v4.x assets used by the React components

<img width="694" alt="New tag style" src="https://github.com/DEFRA/forms-designer/assets/415517/f0b31135-0e38-4b5a-8fbb-e794a0f7d165">
