### PR TITLE
Update hint and error message for shared team email

### DIFF
--- a/designer/server/src/models/forms/create.js
+++ b/designer/server/src/models/forms/create.js
@@ -115,6 +115,9 @@ export function teamViewModel(metadata, validation) {
         label: {
           text: 'Shared team email address'
         },
+        hint: {
+          text: 'Used to contact the form subject matter expert (SME) or key stakeholder. Must be a UK email address, like name@example.gov.uk'
+        },
         value: formValues?.teamEmail ?? metadata?.teamEmail,
         autocomplete: 'email',
         spellcheck: false

--- a/designer/server/src/routes/forms/create.js
+++ b/designer/server/src/routes/forms/create.js
@@ -53,8 +53,7 @@ const schema = Joi.object().keys({
   }),
   teamEmail: teamEmailSchema.messages({
     'string.empty': 'Enter a shared team email address',
-    'string.email':
-      'Enter a shared team email address in the correct format, like name@example.gov.uk'
+    'string.email': 'Enter a shared team email address in the correct format'
   })
 })
 


### PR DESCRIPTION
This PR clarifies that the **Shared team email address** must be a valid UK email address

It also includes the following:

* Adds hint text to explain what the email address is used for
* Moves the "correct format" example from the error message to the hint text

This was discussed and agreed on Slack

<img width="686" alt="Hint text showing the purpose and correct format for a shared team email" src="https://github.com/DEFRA/forms-designer/assets/415517/cea36b60-528b-4913-a1c8-e85d9d06128d">
