### PR TITLE
Reduce editor JavaScript by 300KB

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -3,13 +3,12 @@
  * @type {import('@babel/core').TransformOptions}
  */
 module.exports = {
+  browserslistEnv: 'node',
   plugins: ['@babel/plugin-syntax-import-attributes'],
   presets: [
     [
       '@babel/preset-env',
       {
-        browserslistEnv: 'node',
-
         // Apply bug fixes to avoid transforms
         bugfixes: true
       }

--- a/designer/babel.config.cjs
+++ b/designer/babel.config.cjs
@@ -24,7 +24,6 @@ module.exports = {
     '@babel/plugin-syntax-import-attributes'
   ],
   presets: [
-    '@babel/preset-typescript',
     [
       '@babel/preset-env',
       {
@@ -35,7 +34,8 @@ module.exports = {
         // https://jestjs.io/docs/ecmascript-modules
         modules: NODE_ENV === 'test' ? 'auto' : false
       }
-    ]
+    ],
+    '@babel/preset-typescript'
   ],
   env: {
     test: {

--- a/designer/babel.config.cjs
+++ b/designer/babel.config.cjs
@@ -35,7 +35,12 @@ module.exports = {
         modules: NODE_ENV === 'test' ? 'auto' : false
       }
     ],
-    '@babel/preset-typescript'
+    [
+      '@babel/preset-typescript',
+      {
+        allowDeclareFields: true
+      }
+    ]
   ],
   env: {
     test: {

--- a/designer/babel.config.cjs
+++ b/designer/babel.config.cjs
@@ -5,6 +5,7 @@ const { NODE_ENV } = process.env
  * @type {import('@babel/core').TransformOptions}
  */
 module.exports = {
+  browserslistEnv: 'node',
   plugins: [
     [
       'module-resolver',
@@ -27,8 +28,6 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        browserslistEnv: 'node',
-
         // Apply bug fixes to avoid transforms
         bugfixes: true,
 

--- a/designer/client/babel.config.cjs
+++ b/designer/client/babel.config.cjs
@@ -48,7 +48,12 @@ module.exports = {
         useBuiltIns: true
       }
     ],
-    '@babel/preset-typescript'
+    [
+      '@babel/preset-typescript',
+      {
+        allowDeclareFields: true
+      }
+    ]
   ],
   sourceType: 'unambiguous',
   env: {

--- a/designer/client/babel.config.cjs
+++ b/designer/client/babel.config.cjs
@@ -25,15 +25,6 @@ module.exports = {
     ]
   ],
   presets: [
-    '@babel/preset-typescript',
-    [
-      '@babel/preset-react',
-      {
-        development: NODE_ENV === 'development',
-        runtime: 'automatic',
-        useBuiltIns: true
-      }
-    ],
     [
       '@babel/preset-env',
       {
@@ -48,7 +39,16 @@ module.exports = {
         corejs: pkg.devDependencies['core-js'],
         useBuiltIns: 'usage'
       }
-    ]
+    ],
+    [
+      '@babel/preset-react',
+      {
+        development: NODE_ENV === 'development',
+        runtime: 'automatic',
+        useBuiltIns: true
+      }
+    ],
+    '@babel/preset-typescript'
   ],
   sourceType: 'unambiguous',
   env: {

--- a/designer/client/babel.config.cjs
+++ b/designer/client/babel.config.cjs
@@ -40,6 +40,7 @@ module.exports = {
 
         // Add polyfills by Browserslist environment
         corejs: pkg.devDependencies['core-js'],
+        shippedProposals: true,
         useBuiltIns: 'usage'
       }
     ],

--- a/designer/client/babel.config.cjs
+++ b/designer/client/babel.config.cjs
@@ -31,6 +31,9 @@ module.exports = {
         // Apply bug fixes to avoid transforms
         bugfixes: true,
 
+        // Apply smaller "loose" transforms for browsers
+        loose: true,
+
         // Apply ES module transforms for Jest
         // https://jestjs.io/docs/ecmascript-modules
         modules: NODE_ENV === 'test' ? 'auto' : false,

--- a/designer/client/babel.config.cjs
+++ b/designer/client/babel.config.cjs
@@ -7,6 +7,7 @@ const { NODE_ENV } = process.env
  * @type {import('@babel/core').TransformOptions}
  */
 module.exports = {
+  browserslistEnv: 'javascripts',
   plugins: [
     [
       'module-resolver',
@@ -36,8 +37,6 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        browserslistEnv: 'javascripts',
-
         // Apply bug fixes to avoid transforms
         bugfixes: true,
 

--- a/designer/package.json
+++ b/designer/package.json
@@ -10,6 +10,7 @@
     "directory": "designer"
   },
   "license": "OGL-UK-3.0",
+  "sideEffects": false,
   "type": "module",
   "scripts": {
     "audit": "npm audit --audit-level=high",

--- a/designer/server/src/common/templates/layouts/page.njk
+++ b/designer/server/src/common/templates/layouts/page.njk
@@ -52,5 +52,6 @@
 {% endblock %}
 
 {% block bodyEnd %}
+  <script type="module" src="{{ getAssetPath("shared.js") }}"></script>
   <script type="module" src="{{ getAssetPath("application.js") }}"></script>
 {% endblock %}

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -65,7 +65,10 @@ export default /** @type {import('webpack').Configuration} */ ({
         },
 
         // Fix missing file extensions in React components
-        resolve: { fullySpecified: false }
+        resolve: { fullySpecified: false },
+
+        // Flag loaded modules as side effect free
+        sideEffects: false
       },
       {
         test: /\.scss$/,
@@ -141,6 +144,10 @@ export default /** @type {import('webpack').Configuration} */ ({
       })
     ],
     concatenateModules: true,
+
+    // Skip bundling unused modules
+    providedExports: true,
+    sideEffects: true,
     usedExports: true
   },
   output: {

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -65,7 +65,10 @@ export default /** @type {import('webpack').Configuration} */ ({
         },
 
         // Fix missing file extensions in React components
-        resolve: { fullySpecified: false },
+        resolve: {
+          fullySpecified: false,
+          symlinks: false
+        },
 
         // Flag loaded modules as side effect free
         sideEffects: false

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -60,6 +60,7 @@ export default /** @type {import('webpack').Configuration} */ ({
           not: [/@xgovformbuilder\/govuk-react-jsx/]
         },
         options: {
+          cacheDirectory: true,
           extends: join(import.meta.dirname, 'client/babel.config.cjs')
         },
 

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -143,7 +143,18 @@ export default /** @type {import('webpack').Configuration} */ ({
         }
       })
     ],
-    concatenateModules: true,
+
+    // Apply cache groups in production
+    splitChunks: {
+      cacheGroups: {
+        shared: {
+          chunks: 'all',
+          name: 'shared',
+          test: /node_modules/,
+          usedExports: true
+        }
+      }
+    },
 
     // Skip bundling unused modules
     providedExports: true,
@@ -159,7 +170,7 @@ export default /** @type {import('webpack').Configuration} */ ({
 
     chunkFilename:
       NODE_ENV === 'production'
-        ? 'javascripts/[name].[contenthash:7].min.js'
+        ? 'javascripts/[name].[chunkhash:7].min.js'
         : 'javascripts/[name].js',
     libraryTarget: 'module',
     module: true

--- a/model/babel.config.cjs
+++ b/model/babel.config.cjs
@@ -37,7 +37,12 @@ module.exports = {
         modules: NODE_ENV === 'test' ? 'auto' : false
       }
     ],
-    '@babel/preset-typescript'
+    [
+      '@babel/preset-typescript',
+      {
+        allowDeclareFields: true
+      }
+    ]
   ],
   env: {
     test: {

--- a/model/babel.config.cjs
+++ b/model/babel.config.cjs
@@ -5,9 +5,6 @@ const { BABEL_ENV = 'node', NODE_ENV } = process.env
  * @type {import('@babel/core').TransformOptions}
  */
 module.exports = {
-  assumptions: {
-    enumerableModuleMeta: true
-  },
   browserslistEnv: BABEL_ENV,
   plugins: [
     [

--- a/model/babel.config.cjs
+++ b/model/babel.config.cjs
@@ -26,7 +26,6 @@ module.exports = {
     ]
   ],
   presets: [
-    '@babel/preset-typescript',
     [
       '@babel/preset-env',
       {
@@ -37,7 +36,8 @@ module.exports = {
         // https://jestjs.io/docs/ecmascript-modules
         modules: NODE_ENV === 'test' ? 'auto' : false
       }
-    ]
+    ],
+    '@babel/preset-typescript'
   ],
   env: {
     test: {

--- a/model/babel.config.cjs
+++ b/model/babel.config.cjs
@@ -8,6 +8,7 @@ module.exports = {
   assumptions: {
     enumerableModuleMeta: true
   },
+  browserslistEnv: BABEL_ENV,
   plugins: [
     [
       'module-resolver',
@@ -29,8 +30,6 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        browserslistEnv: BABEL_ENV,
-
         // Apply bug fixes to avoid transforms
         bugfixes: true,
 

--- a/model/package.json
+++ b/model/package.json
@@ -9,9 +9,10 @@
     "directory": "model"
   },
   "license": "OGL-UK-3.0",
+  "sideEffects": false,
+  "type": "module",
   "main": "dist/module/index.js",
   "types": "dist/types/index.d.ts",
-  "type": "module",
   "scripts": {
     "build": "npm run build:types && npm run build:node",
     "build:node": "BABEL_ENV=node babel --delete-dir-on-start --extensions \".ts\" --ignore \"**/*.test.*\" --copy-files --no-copy-ignored --source-maps --out-dir ./dist/module ./src",


### PR DESCRIPTION
This PR enables webpack production settings to remove unused code

These file sizes are still not great but together with https://github.com/DEFRA/forms-designer/pull/190 we've made a considerable dent to load times in browsers

We now only use 5x components from `@xgovformbuilder/govuk-react-jsx`

```js
import {
  Hint,
  Input,
  Label,
  Select,
  Textarea
} from '@xgovformbuilder/govuk-react-jsx'
```

---

### Before

909KB `editor.[hash].min.js`
38KB `application.[hash].min.js`

### After

459KB `shared.[hash].min.js`
183KB `editor.[hash].min.js`
2KB `application.[hash].min.js`
