### PR TITLE
use the access token to check groups. 

### DIFF
--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -78,8 +78,8 @@ export function getUserClaims(credentials) {
  * @returns Array of scopes assigned to the user
  */
 export function getUserScopes(credentials, claims) {
-  const { idToken } = claims ?? getUserClaims(credentials)
-  const { groups } = idToken
+  const { token } = claims ?? getUserClaims(credentials)
+  const { groups } = token
 
   // No groups assigned to the user
   if (!groups?.length) {

--- a/designer/server/test/fixtures/auth.js
+++ b/designer/server/test/fixtures/auth.js
@@ -73,18 +73,18 @@ export function credentials(options) {
 }
 
 const claims = {
-  token: profile(),
-  idToken: profile({ groups: ['valid-test-group'] })
+  token: profile({ groups: ['valid-test-group'] }),
+  idToken: profile()
 }
 
 const claimsGroupsInvalid = {
-  token: profile(),
-  idToken: profile({ groups: ['invalid-test-group'] })
+  token: profile({ groups: ['invalid-test-group'] }),
+  idToken: profile()
 }
 
 const claimsGroupsEmpty = {
-  token: profile(),
-  idToken: profile({ groups: [] })
+  token: profile({ groups: [] }),
+  idToken: profile()
 }
 
 /**
@@ -96,7 +96,7 @@ export const auth = {
   artifacts: artifacts(claims),
   credentials: credentials({
     claims,
-    user: user(claims.idToken),
+    user: user(claims.token),
     scope: [SCOPE_READ, SCOPE_WRITE]
   })
 }
@@ -110,7 +110,7 @@ export const authGroupsInvalid = {
   artifacts: artifacts(claimsGroupsInvalid),
   credentials: credentials({
     claims: claimsGroupsInvalid,
-    user: user(claimsGroupsInvalid.idToken)
+    user: user(claimsGroupsInvalid.token)
   })
 }
 


### PR DESCRIPTION
Makes us consistent with the new setup on forms-manager