### PR TITLE
Fix all type linting issues for `FormDefinition` properties

### DIFF
--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -44,7 +44,10 @@ describe('ComponentTypeEdit', () => {
           section: 'home'
         }
       ],
-      lists: []
+      lists: [],
+      sections: [],
+      conditions: [],
+      outputs: []
     }
   })
 

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -27,11 +27,16 @@ describe('Field Edit', () => {
             options: {
               required: true
             },
-            type: 'List'
+            type: 'List',
+            list: 'myList'
           }
         ]
       }
-    ]
+    ],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
   const dataValue = { data, save: jest.fn() }

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -22,7 +22,8 @@ describe('ComponentCreate:', () => {
     pages: [{ path: '/1', title: '', controller: '', section: '' }],
     lists: [],
     sections: [],
-    startPage: ''
+    conditions: [],
+    outputs: []
   }
 
   const page = { path: '/1' }

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
@@ -49,7 +49,10 @@ describe('ComponentListSelect', () => {
         type: 'string',
         items: [{ text: 'An item', description: 'A hint', value: '12' }]
       }
-    ]
+    ],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
   const dataValue = { data, save: jest.fn() }

--- a/designer/client/src/components/FieldEditors/para-edit.test.tsx
+++ b/designer/client/src/components/FieldEditors/para-edit.test.tsx
@@ -17,14 +17,18 @@ describe('ParaEdit', () => {
             {
               name: 'IDDQl4',
               title: 'abc',
-              schema: {},
+              type: 'Para',
+              content: '',
               options: {},
-              type: 'Para'
+              schema: {}
             }
           ]
         }
       ],
-      conditions: []
+      lists: [],
+      sections: [],
+      conditions: [],
+      outputs: []
     }
     const dataValue = { data, save: jest.fn() }
     const compContextValue = {

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -62,9 +62,15 @@ const data: FormDefinition = {
         }
       ]
     },
-    { title: 'my second page', path: '/2' }
+    {
+      title: 'my second page',
+      path: '/2'
+    }
   ],
-  sections: []
+  lists: [],
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 
 const providerProps = {

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -47,8 +47,10 @@ describe('Visualisation', () => {
         },
         { title: 'my second page', path: '/2' }
       ],
+      lists: [],
+      sections: [],
       conditions: [],
-      sections: []
+      outputs: []
     }
     const providerProps = {
       data,
@@ -97,10 +99,15 @@ describe('Visualisation', () => {
           path: '/link-source',
           next: [{ path: '/link-target' }]
         },
-        { title: 'link target', path: '/link-target' }
+        {
+          title: 'link target',
+          path: '/link-target'
+        }
       ],
+      lists: [],
+      sections: [],
       conditions: [],
-      sections: []
+      outputs: []
     }
     const providerProps = {
       data,

--- a/designer/client/src/conditions/ConditionsEdit.test.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.test.tsx
@@ -14,21 +14,50 @@ const flyoutValue = {
 }
 const data: FormDefinition = {
   pages: [
-    { path: '/1', next: [{ path: '/2' }] },
     {
+      title: 'page1',
+      path: '/1',
+      next: [{ path: '/2' }]
+    },
+    {
+      title: 'page2',
       path: '/2',
-      components: [{ type: 'TextField', name: 'field1', title: 'Something' }],
+      components: [
+        {
+          type: 'TextField',
+          name: 'field1',
+          title: 'Something',
+          options: {},
+          schema: {}
+        }
+      ],
       next: [{ path: '/3' }]
     },
     {
+      title: 'page3',
       path: '/3',
       components: [
-        { type: 'TextField', name: 'field2', title: 'Something else' },
-        { type: 'TextField', name: 'field3', title: 'beep' }
+        {
+          type: 'TextField',
+          name: 'field2',
+          title: 'Something else',
+          options: {},
+          schema: {}
+        },
+        {
+          type: 'TextField',
+          name: 'field3',
+          title: 'beep',
+          options: {},
+          schema: {}
+        }
       ]
     }
   ],
-  conditions: []
+  lists: [],
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 
 const dataValue = { data, save: jest.fn() }
@@ -63,7 +92,13 @@ describe('ConditionsEdit', () => {
 
     test('no field hint test is correct', () => {
       customRender(<ConditionsEdit />, {
-        data: { pages: [], conditions: [] },
+        data: {
+          pages: [],
+          lists: [],
+          sections: [],
+          conditions: [],
+          outputs: []
+        },
         save: jest.fn()
       })
       const hint =
@@ -127,7 +162,13 @@ describe('ConditionsEdit', () => {
 
     test('Renders no new condition message if there are no inputs available', () => {
       customRender(<ConditionsEdit />, {
-        data: { pages: [], conditions: [] },
+        data: {
+          pages: [],
+          lists: [],
+          sections: [],
+          conditions: [],
+          outputs: []
+        },
         save: jest.fn()
       })
 

--- a/designer/client/src/conditions/InlineConditions.test.tsx
+++ b/designer/client/src/conditions/InlineConditions.test.tsx
@@ -20,23 +20,50 @@ describe('InlineConditions', () => {
 
     const data: FormDefinition = {
       pages: [
-        { path: '/1', next: [{ path: '/2' }] },
         {
+          title: 'page1',
+          path: '/1',
+          next: [{ path: '/2' }]
+        },
+        {
+          title: 'page2',
           path: '/2',
           components: [
-            { type: 'TextField', name: 'field1', title: 'Something' }
+            {
+              type: 'TextField',
+              name: 'field1',
+              title: 'Something',
+              options: {},
+              schema: {}
+            }
           ],
           next: [{ path: '/3' }]
         },
         {
+          title: 'page3',
           path: '/3',
           components: [
-            { type: 'TextField', name: 'field2', title: 'Something else' },
-            { type: 'TextField', name: 'field3', title: 'beep' }
+            {
+              type: 'TextField',
+              name: 'field2',
+              title: 'Something else',
+              options: {},
+              schema: {}
+            },
+            {
+              type: 'TextField',
+              name: 'field3',
+              title: 'beep',
+              options: {},
+              schema: {}
+            }
           ]
         }
       ],
-      conditions: []
+      lists: [],
+      sections: [],
+      conditions: [],
+      outputs: []
     }
 
     render(

--- a/designer/client/src/conditions/SelectConditions.test.tsx
+++ b/designer/client/src/conditions/SelectConditions.test.tsx
@@ -12,11 +12,11 @@ describe('SelectConditions', () => {
   const { getByText, getByTestId, queryByText } = screen
 
   const data: FormDefinition = {
-    lists: [],
     pages: [],
+    lists: [],
     sections: [],
-    startPage: '',
-    conditions: []
+    conditions: [],
+    outputs: []
   }
 
   const dataValue = { data, save: jest.fn() }

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -1,5 +1,6 @@
 import {
   type Condition,
+  type ConditionRef,
   ConditionsModel,
   type FormDefinition
 } from '@defra/forms-model'
@@ -39,7 +40,7 @@ interface State {
 
 interface ConditionObject {
   name: string
-  conditions: Condition[]
+  conditions: ConditionRef[]
 }
 
 export interface ConditionData {

--- a/designer/client/src/conditions/conditionsByType.test.ts
+++ b/designer/client/src/conditions/conditionsByType.test.ts
@@ -1,3 +1,6 @@
+import { Coordinator } from '@defra/forms-model'
+
+import { type ConditionData } from '~/src/conditions/SelectConditions.js'
 import { conditionsByType } from '~/src/conditions/select-condition-helpers.js'
 
 const stringCondition = {
@@ -40,13 +43,21 @@ const nestedCondition = {
         conditionName: 'likesScrambledEggs',
         conditionDisplayName: 'likes scrambled eggs'
       },
-      { coordinator: 'and', ...objectCondition }
+      {
+        coordinator: Coordinator.AND,
+        ...objectCondition
+      }
     ]
   }
 }
 
 test('conditionsByType', () => {
-  const conditions = [stringCondition, objectCondition, nestedCondition]
+  const conditions: ConditionData[] = [
+    stringCondition,
+    objectCondition,
+    nestedCondition
+  ]
+
   expect(conditionsByType(conditions)).toEqual({
     string: [stringCondition],
     nested: [nestedCondition],

--- a/designer/client/src/data/component/addComponent.test.ts
+++ b/designer/client/src/data/component/addComponent.test.ts
@@ -4,21 +4,19 @@ import { addComponent } from '~/src/data/index.js'
 
 test('addComponent throws an error when no page can be found', () => {
   const data: FormDefinition = {
-    conditions: [],
-    lists: [],
     pages: [],
-    sections: []
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
-  expect(() => {
-    addComponent(data, 'doesntExist', {})
-  }).toThrow()
+  // @ts-expect-error - Allow invalid component for test
+  expect(() => addComponent(data, 'doesntExist', {})).toThrow()
 })
 
 test('addComponent adds a component to the correct page', () => {
   const data: FormDefinition = {
-    conditions: [],
-    lists: [],
     pages: [
       {
         title: 'first page',
@@ -28,6 +26,7 @@ test('addComponent adds a component to the correct page', () => {
             type: 'TextField',
             name: 'firstName',
             title: 'First name',
+            options: {},
             schema: {}
           }
         ]
@@ -40,12 +39,16 @@ test('addComponent adds a component to the correct page', () => {
             type: 'TextField',
             name: 'lastName',
             title: 'Surname',
+            options: {},
             schema: {}
           }
         ]
       }
     ],
-    sections: []
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
   expect(
@@ -53,11 +56,10 @@ test('addComponent adds a component to the correct page', () => {
       type: 'TextField',
       name: 'aNewComponent',
       title: 'new component',
+      options: {},
       schema: {}
     })
-  ).toEqual({
-    conditions: [],
-    lists: [],
+  ).toEqual<FormDefinition>({
     pages: [
       {
         title: 'first page',
@@ -67,13 +69,15 @@ test('addComponent adds a component to the correct page', () => {
             type: 'TextField',
             name: 'firstName',
             title: 'First name',
+            options: {},
             schema: {}
           },
           {
+            type: 'TextField',
             name: 'aNewComponent',
-            schema: {},
             title: 'new component',
-            type: 'TextField'
+            options: {},
+            schema: {}
           }
         ]
       },
@@ -85,11 +89,15 @@ test('addComponent adds a component to the correct page', () => {
             type: 'TextField',
             name: 'lastName',
             title: 'Surname',
+            options: {},
             schema: {}
           }
         ]
       }
     ],
-    sections: []
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   })
 })

--- a/designer/client/src/data/component/inputs.test.ts
+++ b/designer/client/src/data/component/inputs.test.ts
@@ -1,85 +1,159 @@
 import { type FormDefinition } from '@defra/forms-model'
 
-import { allInputs } from '~/src/data/index.js'
+import { allInputs, type Input } from '~/src/data/index.js'
 
 test('should return all inputs from the page model', () => {
   const data: FormDefinition = {
     pages: [
       {
-        path: 'page1',
+        title: 'page1',
+        path: '/1',
         section: 'section1',
         components: [
-          { name: 'name1', type: 'RadiosField' },
-          { name: 'name2', type: 'RadiosField' }
+          {
+            name: 'name1',
+            type: 'RadiosField',
+            title: 'Radios',
+            list: 'radios',
+            options: {},
+            schema: {}
+          },
+          {
+            name: 'name2',
+            type: 'RadiosField',
+            title: 'Radios',
+            list: 'radios',
+            options: {},
+            schema: {}
+          }
         ]
       },
       {
-        path: 'page2',
+        title: 'page2',
+        path: '/2',
         section: 'section1',
         components: [
-          { name: 'name3', type: 'RadiosField' },
-          { name: 'name4', type: 'RadiosField' }
+          {
+            name: 'name3',
+            type: 'RadiosField',
+            title: 'Radios',
+            list: 'radios',
+            options: {},
+            schema: {}
+          },
+          {
+            name: 'name4',
+            type: 'RadiosField',
+            title: 'Radios',
+            list: 'radios',
+            options: {},
+            schema: {}
+          }
         ]
       }
-    ]
+    ],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
-  expect(allInputs(data)).toEqual([
+  expect(allInputs(data)).toEqual<Input[]>([
     {
       name: 'name1',
-      page: { path: 'page1', section: 'section1' },
+      page: {
+        path: '/1',
+        section: 'section1'
+      },
       propertyPath: 'section1.name1',
-      list: undefined,
-      title: undefined,
-      type: 'RadiosField'
+      type: 'RadiosField',
+      title: 'Radios',
+      list: 'radios'
     },
     {
       name: 'name2',
-      page: { path: 'page1', section: 'section1' },
+      page: {
+        path: '/1',
+        section: 'section1'
+      },
       propertyPath: 'section1.name2',
-      list: undefined,
-      title: undefined,
-      type: 'RadiosField'
+      type: 'RadiosField',
+      title: 'Radios',
+      list: 'radios'
     },
     {
       name: 'name3',
-      page: { path: 'page2', section: 'section1' },
+      page: {
+        path: '/2',
+        section: 'section1'
+      },
       propertyPath: 'section1.name3',
-      list: undefined,
-      title: undefined,
-      type: 'RadiosField'
+      type: 'RadiosField',
+      title: 'Radios',
+      list: 'radios'
     },
     {
       name: 'name4',
-      page: { path: 'page2', section: 'section1' },
+      page: {
+        path: '/2',
+        section: 'section1'
+      },
       propertyPath: 'section1.name4',
-      list: undefined,
-      title: undefined,
-      type: 'RadiosField'
+      type: 'RadiosField',
+      title: 'Radios',
+      list: 'radios'
     }
   ])
 })
 
 test('should handle no pages', () => {
-  const data: FormDefinition = { pages: [] }
+  const data: FormDefinition = {
+    pages: [],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
+  }
   expect(allInputs(data)).toEqual([])
 })
 
 test('should handle undefined pages', () => {
-  const data: FormDefinition = {}
+  const data: FormDefinition = {
+    // @ts-expect-error - Allow invalid property for test
+    pages: undefined,
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
+  }
   expect(allInputs(data)).toEqual([])
 })
 
 test('should handle pages with undefined components', () => {
   const data: FormDefinition = {
-    pages: [{}]
+    // @ts-expect-error - Allow invalid property for test
+    pages: [{}],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
   expect(allInputs(data)).toEqual([])
 })
 
 test('should handle pages with no components', () => {
   const data: FormDefinition = {
-    pages: [{ components: [] }]
+    pages: [
+      {
+        title: 'No components',
+        path: '/start',
+        components: []
+      }
+    ],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
   expect(allInputs(data)).toEqual([])
 })

--- a/designer/client/src/data/component/updateComponent.test.ts
+++ b/designer/client/src/data/component/updateComponent.test.ts
@@ -4,8 +4,6 @@ import { updateComponent } from '~/src/data/index.js'
 
 test('updateComponent throws an error when the target component cannot be found', () => {
   const data: FormDefinition = {
-    conditions: [],
-    lists: [],
     pages: [
       {
         title: 'first page',
@@ -15,27 +13,28 @@ test('updateComponent throws an error when the target component cannot be found'
             type: 'TextField',
             name: 'firstName',
             title: 'First name',
+            options: {},
             schema: {}
           }
         ]
       },
       { title: '2', path: '/2' }
     ],
-    sections: []
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
-  expect(() => {
-    updateComponent(data, '/2', 'doesntExist', {})
-  }).toThrow()
-  expect(() => {
-    updateComponent(data, '/3', 'doesntExist', {})
-  }).toThrow()
+  // @ts-expect-error - Allow invalid component for test
+  expect(() => updateComponent(data, '/2', 'doesntExist', {})).toThrow()
+
+  // @ts-expect-error - Allow invalid component for test
+  expect(() => updateComponent(data, '/3', 'doesntExist', {})).toThrow()
 })
 
 test('addComponent adds a component to the correct page', () => {
   const data: FormDefinition = {
-    conditions: [],
-    lists: [],
     pages: [
       {
         title: 'first page',
@@ -45,6 +44,7 @@ test('addComponent adds a component to the correct page', () => {
             type: 'TextField',
             name: 'firstName',
             title: 'First name',
+            options: {},
             schema: {}
           }
         ]
@@ -57,12 +57,16 @@ test('addComponent adds a component to the correct page', () => {
             type: 'TextField',
             name: 'lastName',
             title: 'Surname',
+            options: {},
             schema: {}
           }
         ]
       }
     ],
-    sections: []
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
   expect(
@@ -70,11 +74,10 @@ test('addComponent adds a component to the correct page', () => {
       type: 'TextField',
       name: 'fullName',
       title: 'full name',
+      options: {},
       schema: {}
     })
-  ).toEqual({
-    conditions: [],
-    lists: [],
+  ).toEqual<FormDefinition>({
     pages: [
       {
         title: 'first page',
@@ -84,6 +87,7 @@ test('addComponent adds a component to the correct page', () => {
             type: 'TextField',
             name: 'fullName',
             title: 'full name',
+            options: {},
             schema: {}
           }
         ]
@@ -96,11 +100,15 @@ test('addComponent adds a component to the correct page', () => {
             type: 'TextField',
             name: 'lastName',
             title: 'Surname',
+            options: {},
             schema: {}
           }
         ]
       }
     ],
-    sections: []
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   })
 })

--- a/designer/client/src/data/component/updateComponent.ts
+++ b/designer/client/src/data/component/updateComponent.ts
@@ -1,9 +1,9 @@
-import { type ComponentDef } from '@defra/forms-model'
+import { type FormDefinition, type ComponentDef } from '@defra/forms-model'
 
 import { type Path, findPage } from '~/src/data/index.js'
 
 export function updateComponent(
-  data,
+  data: FormDefinition,
   pagePath: Path,
   componentName: ComponentDef['name'],
   component: ComponentDef

--- a/designer/client/src/data/condition/addCondition.test.ts
+++ b/designer/client/src/data/condition/addCondition.test.ts
@@ -3,6 +3,9 @@ import { type ConditionRawData, type FormDefinition } from '@defra/forms-model'
 import { addCondition } from '~/src/data/index.js'
 
 const data: FormDefinition = {
+  pages: [],
+  lists: [],
+  sections: [],
   conditions: [
     {
       displayName: 'a condition',
@@ -10,26 +13,25 @@ const data: FormDefinition = {
       value: { name: 'name', conditions: [] }
     }
   ],
-  lists: [],
-  name: '',
-  pages: [],
-  sections: [],
-  startPage: ''
+  outputs: []
 }
 
 test('addCondition adds a condition to the list', () => {
   const condition: ConditionRawData = {
     displayName: 'added condition',
     name: 'new',
-    value: { name: 'newCondition', conditions: [] }
+    value: {
+      name: 'newCondition',
+      conditions: []
+    }
   }
-  expect(addCondition(data, condition)).toEqual({
-    conditions: [...data.conditions, condition],
-    lists: [],
-    name: '',
+
+  expect(addCondition(data, condition)).toEqual<FormDefinition>({
     pages: [],
+    lists: [],
     sections: [],
-    startPage: ''
+    conditions: [...data.conditions, condition],
+    outputs: []
   })
 })
 
@@ -38,7 +40,10 @@ test('addCondition throws if a condition with the same name already exists', () 
     addCondition(data, {
       displayName: 'a condition',
       name: 'isCondition',
-      value: { name: 'name', conditions: [] }
+      value: {
+        name: 'name',
+        conditions: []
+      }
     })
   ).toThrow(/A condition/)
 })

--- a/designer/client/src/data/condition/hasConditions.test.ts
+++ b/designer/client/src/data/condition/hasConditions.test.ts
@@ -4,22 +4,31 @@ import { hasConditions } from '~/src/data/index.js'
 
 test('hasCondition returns true when there are conditions', () => {
   const data: FormDefinition = {
-    conditions: [
-      { name: 'a', displayName: 'b', value: { name: 'c', conditions: [] } }
-    ],
-    lists: [],
     pages: [],
-    sections: []
+    lists: [],
+    sections: [],
+    conditions: [
+      {
+        name: 'a',
+        displayName: 'b',
+        value: {
+          name: 'c',
+          conditions: []
+        }
+      }
+    ],
+    outputs: []
   }
   expect(hasConditions(data.conditions)).toBe(true)
 })
 
 test("hasCondition returns false when there aren't any conditions", () => {
   const data: FormDefinition = {
-    conditions: [],
-    lists: [],
     pages: [],
-    sections: []
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
   expect(hasConditions(data.conditions)).toBe(false)
 })

--- a/designer/client/src/data/condition/hasConditions.ts
+++ b/designer/client/src/data/condition/hasConditions.ts
@@ -1,3 +1,5 @@
-export function hasConditions(conditions: any[]): boolean {
+import { type FormDefinition } from '@defra/forms-model'
+
+export function hasConditions(conditions: FormDefinition['conditions']) {
   return conditions.length > 0
 }

--- a/designer/client/src/data/condition/removeCondition.test.ts
+++ b/designer/client/src/data/condition/removeCondition.test.ts
@@ -4,28 +4,75 @@ import { removeCondition } from '~/src/data/index.js'
 
 const data: FormDefinition = {
   pages: [
-    { next: [], path: '/' },
     {
+      title: 'start',
+      next: [],
+      path: '/'
+    },
+    {
+      title: 'badgers',
       path: '/badgers',
-      next: [{ path: '/summary' }, { path: '/disaster', condition: 'someName' }]
+      next: [
+        {
+          path: '/summary'
+        },
+        {
+          path: '/disaster',
+          condition: 'someName'
+        }
+      ]
     }
   ],
-  conditions: [{ name: 'someName' }, { name: 'anotherName' }]
+  lists: [],
+  sections: [],
+  conditions: [
+    {
+      displayName: 'Some name',
+      name: 'someName',
+      value: 'true'
+    },
+    {
+      displayName: 'Another name',
+      name: 'anotherName',
+      value: 'true'
+    }
+  ],
+  outputs: []
 }
+
 test('removeCondition should remove conditions from the conditions key and in page links', () => {
   const updated = removeCondition(data, 'someName')
-  expect(updated).toEqual({
+  expect(updated).toEqual<FormDefinition>({
     pages: [
-      { next: [], path: '/' },
       {
+        title: 'start',
+        next: [],
+        path: '/'
+      },
+      {
+        title: 'badgers',
         path: '/badgers',
-        next: [{ path: '/summary' }, { path: '/disaster' }]
+        next: [
+          expect.objectContaining({
+            path: '/summary'
+          }),
+          expect.objectContaining({
+            path: '/disaster'
+          })
+        ]
       }
     ],
-    conditions: [{ name: 'anotherName' }]
+    lists: [],
+    sections: [],
+    conditions: [
+      expect.objectContaining({
+        name: 'anotherName'
+      })
+    ],
+    outputs: []
   })
 })
 
 test('removeCondition should do nothing if the condition does not exist', () => {
-  expect(removeCondition(data, '404')).toEqual(data)
+  expect(removeCondition(data, '404')).toEqual<FormDefinition>(data)
 })

--- a/designer/client/src/data/condition/removeCondition.ts
+++ b/designer/client/src/data/condition/removeCondition.ts
@@ -1,6 +1,9 @@
 import { type FormDefinition } from '@defra/forms-model'
 
-export function removeCondition(data: FormDefinition, name) {
+export function removeCondition(
+  data: FormDefinition,
+  name: string
+): FormDefinition {
   const pages = [...data.pages].map((page) => {
     return {
       ...page,

--- a/designer/client/src/data/condition/updateCondition.test.ts
+++ b/designer/client/src/data/condition/updateCondition.test.ts
@@ -5,16 +5,20 @@ import { updateCondition } from '~/src/data/index.js'
 const condition = {
   displayName: 'condition',
   name: 'isCatPerson',
-  value: { name: 'newCondition', conditions: [] }
+  value: {
+    name: 'newCondition',
+    conditions: []
+  }
 }
+
 const data: FormDefinition = {
-  conditions: [{ ...condition }],
-  lists: [],
-  name: '',
   pages: [],
+  lists: [],
   sections: [],
-  startPage: ''
+  conditions: [{ ...condition }],
+  outputs: []
 }
+
 test('updateCondition throws if no condition could be found', () => {
   expect(() => updateCondition(data, 'isDogPerson', {})).toThrow()
 })
@@ -28,7 +32,10 @@ test('updateCondition successfully updates a condition', () => {
         conditions: []
       }
     })
-  ).toEqual({
+  ).toEqual<FormDefinition>({
+    pages: [],
+    lists: [],
+    sections: [],
     conditions: [
       {
         displayName: 'cats rule',
@@ -36,10 +43,6 @@ test('updateCondition successfully updates a condition', () => {
         value: { name: 'valueName', conditions: [] }
       }
     ],
-    lists: [],
-    name: '',
-    pages: [],
-    sections: [],
-    startPage: ''
+    outputs: []
   })
 })

--- a/designer/client/src/data/list/addList.test.ts
+++ b/designer/client/src/data/list/addList.test.ts
@@ -3,32 +3,53 @@ import { type FormDefinition } from '@defra/forms-model'
 import { addList } from '~/src/data/index.js'
 
 const data: FormDefinition = {
-  conditions: [],
+  pages: [],
   lists: [
     {
-      name: 'listA'
+      name: 'listA',
+      title: 'List A',
+      type: 'string',
+      items: []
     },
     {
-      name: 'listB'
+      name: 'listB',
+      title: 'List B',
+      type: 'string',
+      items: []
     }
   ],
-  pages: [],
-  sections: []
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 
 test('findList throws when a list with the same name already exists', () => {
   expect(() =>
-    addList(data, { name: 'listA', title: 'list a', items: [], type: 'string' })
+    addList(data, {
+      name: 'listA',
+      title: 'list a',
+      type: 'string',
+      items: []
+    })
   ).toThrow(/A list with the name/)
 })
 
 test('addList returns a tuple of the list and the index', () => {
   expect(
-    addList(data, { name: 'pokedex', title: '151', items: [], type: 'number' })
-      .lists
+    addList(data, {
+      name: 'pokedex',
+      title: '151',
+      type: 'number',
+      items: []
+    }).lists
   ).toEqual([
-    { name: 'listA' },
-    { name: 'listB' },
-    { items: [], name: 'pokedex', title: '151', type: 'number' }
+    expect.objectContaining({ name: 'listA' }),
+    expect.objectContaining({ name: 'listB' }),
+    expect.objectContaining({
+      name: 'pokedex',
+      title: '151',
+      type: 'number',
+      items: []
+    })
   ])
 })

--- a/designer/client/src/data/list/findList.test.ts
+++ b/designer/client/src/data/list/findList.test.ts
@@ -3,17 +3,24 @@ import { type FormDefinition } from '@defra/forms-model'
 import { findList } from '~/src/data/index.js'
 
 const data: FormDefinition = {
-  conditions: [],
+  pages: [],
   lists: [
     {
-      name: 'listA'
+      name: 'listA',
+      title: 'List A',
+      type: 'string',
+      items: []
     },
     {
-      name: 'listB'
+      name: 'listB',
+      title: 'List B',
+      type: 'string',
+      items: []
     }
   ],
-  pages: [],
-  sections: []
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 
 test('findList throws when no list can be found', () => {
@@ -22,9 +29,9 @@ test('findList throws when no list can be found', () => {
 
 test('findList returns a tuple of the list and the index', () => {
   expect(findList(data, 'listA')).toEqual([
-    {
+    expect.objectContaining({
       name: 'listA'
-    },
+    }),
     0
   ])
 })

--- a/designer/client/src/data/page/addLink.test.ts
+++ b/designer/client/src/data/page/addLink.test.ts
@@ -3,9 +3,6 @@ import { type FormDefinition } from '@defra/forms-model'
 import { addLink } from '~/src/data/index.js'
 
 const data: FormDefinition = {
-  conditions: [],
-  lists: [],
-  name: '',
   pages: [
     {
       title: 'scrambled',
@@ -15,8 +12,10 @@ const data: FormDefinition = {
     { title: 'poached', path: '/poached' },
     { title: 'sunny', path: '/sunny' }
   ],
+  lists: [],
   sections: [],
-  startPage: ''
+  conditions: [],
+  outputs: []
 }
 
 test('addLink throws if to, from or both are not found', () => {
@@ -32,10 +31,7 @@ test('addLink throws if to and from are equal', () => {
 })
 
 test('addLink successfully adds a new link', () => {
-  expect(addLink(data, '/poached', '/sunny')).toEqual({
-    conditions: [],
-    lists: [],
-    name: '',
+  expect(addLink(data, '/poached', '/sunny')).toEqual<FormDefinition>({
     pages: [
       {
         title: 'scrambled',
@@ -45,16 +41,15 @@ test('addLink successfully adds a new link', () => {
       { title: 'poached', path: '/poached', next: [{ path: '/sunny' }] },
       { title: 'sunny', path: '/sunny' }
     ],
+    lists: [],
     sections: [],
-    startPage: ''
+    conditions: [],
+    outputs: []
   })
 })
 
 test('addLink does nothing happens if the link already exists', () => {
   expect(addLink(data, '/scrambled', '/poached')).toEqual({
-    conditions: [],
-    lists: [],
-    name: '',
     pages: [
       {
         title: 'scrambled',
@@ -64,7 +59,9 @@ test('addLink does nothing happens if the link already exists', () => {
       { title: 'poached', path: '/poached' },
       { title: 'sunny', path: '/sunny' }
     ],
+    lists: [],
     sections: [],
-    startPage: ''
+    conditions: [],
+    outputs: []
   })
 })

--- a/designer/client/src/data/page/addPage.test.ts
+++ b/designer/client/src/data/page/addPage.test.ts
@@ -3,9 +3,6 @@ import { type FormDefinition } from '@defra/forms-model'
 import { addPage } from '~/src/data/index.js'
 
 const data: FormDefinition = {
-  conditions: [],
-  lists: [],
-  name: '',
   pages: [
     {
       title: 'scrambled',
@@ -15,18 +12,29 @@ const data: FormDefinition = {
     { title: 'poached', path: '/poached' },
     { title: 'sunny', path: '/sunny' }
   ],
+  lists: [],
   sections: [],
-  startPage: ''
+  conditions: [],
+  outputs: []
 }
 
 test('addPage throws if a page with the same path already exists', () => {
-  expect(() => addPage(data, { path: '/scrambled' })).toThrow(
-    /A page with the path/
-  )
+  expect(() =>
+    addPage(data, {
+      title: 'scrambled',
+      path: '/scrambled'
+    })
+  ).toThrow(/A page with the path/)
 })
 
 test('addPage adds a page if one does not exist with the same path', () => {
-  expect(addPage(data, { path: '/soft-boiled' }).pages).toContainEqual({
+  expect(
+    addPage(data, {
+      title: 'soft boiled',
+      path: '/soft-boiled'
+    }).pages
+  ).toContainEqual({
+    title: 'soft boiled',
     path: '/soft-boiled'
   })
 })

--- a/designer/client/src/data/page/allPathsLeadingTo.test.ts
+++ b/designer/client/src/data/page/allPathsLeadingTo.test.ts
@@ -6,17 +6,24 @@ test('allPathsLeadingTo should work with cycle in paths', () => {
   const data: FormDefinition = {
     pages: [
       {
+        title: 'page1',
         path: '/1',
         next: [{ path: '/2' }]
       },
       {
+        title: 'page2',
         path: '/2',
         next: [{ path: '/1' }]
       },
       {
+        title: 'page3',
         path: '/3'
       }
-    ]
+    ],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
   const paths = allPathsLeadingTo(data, '/2')
   expect(paths).toEqual(['/2', '/1'])
@@ -26,17 +33,24 @@ test('allPathsLeadingTo should work with single parents', () => {
   const data: FormDefinition = {
     pages: [
       {
+        title: 'page1',
         path: '/1',
         next: [{ path: '/2' }]
       },
       {
+        title: 'page2',
         path: '/2',
         next: [{ path: '/3' }]
       },
       {
+        title: 'page3',
         path: '/3'
       }
-    ]
+    ],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
   expect(allPathsLeadingTo(data, '/3')).toEqual(['/3', '/2', '/1'])
 })
@@ -45,21 +59,29 @@ test('allPathsLeadingTo should work with multiple parents', () => {
   const data: FormDefinition = {
     pages: [
       {
+        title: 'page1',
         path: '/1',
         next: [{ path: '/2' }, { path: '/3' }]
       },
       {
+        title: 'page2',
         path: '/2',
         next: [{ path: '/4' }]
       },
       {
+        title: 'page3',
         path: '/3',
         next: [{ path: '/4' }]
       },
       {
+        title: 'page4',
         path: '/4'
       }
-    ]
+    ],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
   expect(allPathsLeadingTo(data, '/4')).toEqual(['/4', '/2', '/1', '/3'])

--- a/designer/client/src/data/page/findPage.test.ts
+++ b/designer/client/src/data/page/findPage.test.ts
@@ -5,20 +5,54 @@ import { findPage } from '~/src/data/index.js'
 const data: FormDefinition = {
   pages: [
     {
-      name: 'page1',
+      title: 'page1',
       section: 'section1',
       path: '/1',
       next: [{ path: '/2' }],
-      components: [{ name: 'name1' }, { name: 'name2' }]
+      components: [
+        {
+          type: 'TextField',
+          name: 'name1',
+          title: 'Name 1',
+          options: {},
+          schema: {}
+        },
+        {
+          type: 'TextField',
+          name: 'name2',
+          title: 'Name 2',
+          options: {},
+          schema: {}
+        }
+      ]
     },
     {
-      name: 'page2',
+      title: 'page2',
       section: 'section1',
       path: '/2',
       next: [{ path: '/3' }],
-      components: [{ name: 'name3' }, { name: 'name4' }]
+      components: [
+        {
+          type: 'TextField',
+          name: 'name3',
+          title: 'Name 3',
+          options: {},
+          schema: {}
+        },
+        {
+          type: 'TextField',
+          name: 'name4',
+          title: 'Name 4',
+          options: {},
+          schema: {}
+        }
+      ]
     }
-  ]
+  ],
+  lists: [],
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 test('findPage should throw if the page does not exist', () => {
   expect(() => findPage(data, '/404')).toThrow()
@@ -27,11 +61,14 @@ test('findPage should throw if the page does not exist', () => {
 test('findPage should return the page and index if the page exists', () => {
   expect(findPage(data, '/2')).toEqual([
     {
-      name: 'page2',
+      title: 'page2',
       section: 'section1',
       path: '/2',
       next: [{ path: '/3' }],
-      components: [{ name: 'name3' }, { name: 'name4' }]
+      components: [
+        expect.objectContaining({ name: 'name3' }),
+        expect.objectContaining({ name: 'name4' })
+      ]
     },
     1
   ])

--- a/designer/client/src/data/page/updateLink.test.ts
+++ b/designer/client/src/data/page/updateLink.test.ts
@@ -5,19 +5,66 @@ import { updateLink } from '~/src/data/index.js'
 const data: FormDefinition = {
   pages: [
     {
+      title: 'page1',
       path: '/1',
       next: [{ path: '/2', condition: 'badgers' }],
-      components: [{ name: 'name1' }, { name: 'name2' }]
+      components: [
+        {
+          type: 'TextField',
+          name: 'name1',
+          title: 'Name 1',
+          options: {},
+          schema: {}
+        },
+        {
+          type: 'TextField',
+          name: 'name2',
+          title: 'Name 2',
+          options: {},
+          schema: {}
+        }
+      ]
     },
     {
+      title: 'page2',
       path: '/2',
-      components: [{ name: 'name3' }, { name: 'name4' }]
+      components: [
+        {
+          type: 'TextField',
+          name: 'name3',
+          title: 'Name 3',
+          options: {},
+          schema: {}
+        },
+        {
+          type: 'TextField',
+          name: 'name4',
+          title: 'Name 4',
+          options: {},
+          schema: {}
+        }
+      ]
     },
     {
+      title: 'page3',
       path: '/3'
     }
   ],
-  conditions: [{ name: 'badgers' }, { name: 'isKangaroo' }]
+  lists: [],
+  sections: [],
+  conditions: [
+    {
+      displayName: 'Badgers',
+      name: 'badgers',
+      value: 'true'
+    },
+    {
+      displayName: 'Kangaroos',
+      name: 'isKangaroo',
+      value: 'true'
+    }
+  ],
+  outputs: []
 }
 
 test('updateLink throws if from, to, or there is no existing link', () => {
@@ -27,11 +74,13 @@ test('updateLink throws if from, to, or there is no existing link', () => {
 })
 
 test('updateLink should remove a condition from a link to the next page', () => {
-  expect(updateLink(data, '/1', '/2').pages[0].next).toEqual([{ path: '/2' }])
+  expect(updateLink(data, '/1', '/2').pages[0].next).toEqual([
+    expect.objectContaining({ path: '/2' })
+  ])
 })
 
 test('updateLink should add a condition to a link to the next page', () => {
   expect(updateLink(data, '/1', '/2', 'isKangaroos').pages[0].next).toEqual([
-    { path: '/2', condition: 'isKangaroos' }
+    expect.objectContaining({ path: '/2', condition: 'isKangaroos' })
   ])
 })

--- a/designer/client/src/data/page/updateLinksTo.test.ts
+++ b/designer/client/src/data/page/updateLinksTo.test.ts
@@ -8,59 +8,135 @@ const data: FormDefinition = {
       title: 'page0',
       path: '/0',
       next: [{ path: '/2', condition: 'badgers' }],
-      components: [{ name: 'name1' }, { name: 'name2' }]
+      components: [
+        {
+          type: 'TextField',
+          name: 'name1',
+          title: 'Name 1',
+          options: {},
+          schema: {}
+        },
+        {
+          type: 'TextField',
+          name: 'name2',
+          title: 'Name 2',
+          options: {},
+          schema: {}
+        }
+      ]
     },
     {
       title: 'page1',
       section: 'section1',
       path: '/1',
       next: [{ path: '/2' }],
-      components: [{ name: 'name1' }, { name: 'name2' }]
+      components: [
+        {
+          type: 'TextField',
+          name: 'name1',
+          title: 'Name 1',
+          options: {},
+          schema: {}
+        },
+        {
+          type: 'TextField',
+          name: 'name2',
+          title: 'Name 2',
+          options: {},
+          schema: {}
+        }
+      ]
     },
     {
       title: 'page2',
       section: 'section1',
       path: '/2',
       next: [{ path: '/3' }],
-      components: [{ name: 'name3' }, { name: 'name4' }]
+      components: [
+        {
+          type: 'TextField',
+          name: 'name3',
+          title: 'Name 3',
+          options: {},
+          schema: {}
+        },
+        {
+          type: 'TextField',
+          name: 'name4',
+          title: 'Name 4',
+          options: {},
+          schema: {}
+        }
+      ]
     },
     {
+      title: 'page3',
       section: 'section1',
       path: '/3',
       components: []
     }
-  ]
+  ],
+  lists: [],
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 test('updateLinksTo should update all links pointing to the specified path to the new path', () => {
   const returned = updateLinksTo(data, '/2', '/7')
-  expect(returned).toEqual({
+  expect(returned).toEqual<FormDefinition>({
     pages: [
       {
         title: 'page0',
         path: '/0',
         next: [{ path: '/7', condition: 'badgers' }],
-        components: [{ name: 'name1' }, { name: 'name2' }]
+        components: [
+          expect.objectContaining({
+            name: 'name1'
+          }),
+          expect.objectContaining({
+            name: 'name2'
+          })
+        ]
       },
       {
         title: 'page1',
         section: 'section1',
         path: '/1',
         next: [{ path: '/7' }],
-        components: [{ name: 'name1' }, { name: 'name2' }]
+        components: [
+          expect.objectContaining({
+            name: 'name1'
+          }),
+          expect.objectContaining({
+            name: 'name2'
+          })
+        ]
       },
       {
         title: 'page2',
         section: 'section1',
         path: '/7',
         next: [{ path: '/3' }],
-        components: [{ name: 'name3' }, { name: 'name4' }]
+        components: [
+          expect.objectContaining({
+            name: 'name3'
+          }),
+          expect.objectContaining({
+            name: 'name4'
+          })
+        ]
       },
       {
+        title: 'page3',
         section: 'section1',
         path: '/3',
         components: [],
         next: []
       }
-    ]
+    ],
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   })
 })

--- a/designer/client/src/data/section/addSection.test.ts
+++ b/designer/client/src/data/section/addSection.test.ts
@@ -11,7 +11,8 @@ const data: FormDefinition = {
       title: 'your details',
       name: 'yourDetails'
     }
-  ]
+  ],
+  outputs: []
 }
 test('addSection throws if a section with the same name already exists', () => {
   expect(() =>

--- a/designer/client/src/data/types.ts
+++ b/designer/client/src/data/types.ts
@@ -24,7 +24,10 @@ export const isNotContentType = (
 
 export interface Input {
   name: string
-  page: { path: Page['path']; section: Page['section'] }
+  page: {
+    path: Page['path']
+    section: Page['section']
+  }
   propertyPath: string
   list: string | undefined
   title: string

--- a/designer/client/src/field-edit.test.tsx
+++ b/designer/client/src/field-edit.test.tsx
@@ -19,7 +19,10 @@ describe('Field edit', () => {
         section: 'home'
       }
     ],
-    lists: []
+    lists: [],
+    sections: [],
+    conditions: [],
+    outputs: []
   }
 
   let stateProps

--- a/designer/client/src/link-create.test.tsx
+++ b/designer/client/src/link-create.test.tsx
@@ -14,7 +14,6 @@ import { DataContext } from '~/src/context/index.js'
 import LinkCreate from '~/src/link-create.js'
 
 const rawData: FormDefinition = {
-  lists: [],
   pages: [
     {
       title: 'First page',
@@ -24,7 +23,7 @@ const rawData: FormDefinition = {
           type: 'YesNoField',
           name: 'ukPassport',
           title: 'Do you have a UK passport?',
-          option: {
+          options: {
             required: true
           },
           schema: {}
@@ -43,9 +42,10 @@ const rawData: FormDefinition = {
       components: []
     }
   ],
+  lists: [],
   sections: [],
-  startPage: '',
-  conditions: []
+  conditions: [],
+  outputs: []
 }
 
 const data: FormDefinition = { ...rawData }

--- a/designer/client/src/link-edit.test.tsx
+++ b/designer/client/src/link-edit.test.tsx
@@ -12,10 +12,21 @@ const data: FormDefinition = {
     { path: '/1', title: 'Page 1', next: [{ path: '/2' }] },
     { path: '/2', title: 'Page 2' }
   ],
+  lists: [],
+  sections: [],
   conditions: [
-    { name: 'someCondition', displayName: 'My condition' },
-    { name: 'anotherCondition', displayName: 'Another condition' }
-  ]
+    {
+      name: 'someCondition',
+      displayName: 'My condition',
+      value: 'true'
+    },
+    {
+      name: 'anotherCondition',
+      displayName: 'Another condition',
+      value: 'true'
+    }
+  ],
+  outputs: []
 }
 
 const dataValue = { data, save: jest.fn() }

--- a/designer/client/src/list/ListEdit.test.tsx
+++ b/designer/client/src/list/ListEdit.test.tsx
@@ -8,12 +8,11 @@ import { customRenderForLists } from '~/test/helpers/renderers-lists.jsx'
 
 const data: FormDefinition = {
   pages: [],
-  sections: [],
-  startPage: '',
   lists: [
     {
       name: 'myList',
       title: 'My list',
+      type: 'string',
       items: [
         { text: 'text a', description: 'desc a', value: 'value a' },
         { text: 'text b', description: 'desc b', value: 'value b' }
@@ -22,9 +21,13 @@ const data: FormDefinition = {
     {
       name: 'myEmptyList',
       title: 'My empty list',
+      type: 'string',
       items: []
     }
-  ]
+  ],
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 
 const dataValue = { data, save: jest.fn() }

--- a/designer/client/src/list/ListItemEdit.test.tsx
+++ b/designer/client/src/list/ListItemEdit.test.tsx
@@ -40,7 +40,7 @@ const data: FormDefinition = {
           options: {
             required: true
           },
-          type: '',
+          type: 'SelectField',
           list: 'myList'
         }
       ]
@@ -52,6 +52,7 @@ const data: FormDefinition = {
     {
       name: 'myList',
       title: 'My list',
+      type: 'string',
       items: [
         { text: 'text a', description: 'desc a', value: 'value a' },
         { text: 'text b', description: 'desc b', value: 'value b' }

--- a/designer/client/src/list/ListSelect.test.tsx
+++ b/designer/client/src/list/ListSelect.test.tsx
@@ -6,6 +6,7 @@ import { ListSelect } from '~/src/list/ListSelect.jsx'
 import { customRenderForLists } from '~/test/helpers/renderers-lists.jsx'
 
 const data: FormDefinition = {
+  pages: [],
   lists: [
     {
       name: 'myList',
@@ -19,7 +20,10 @@ const data: FormDefinition = {
       type: 'string',
       items: [{ text: 'An item', description: 'A hint', value: 12 }]
     }
-  ]
+  ],
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 
 const dataValue = { data, save: jest.fn() }

--- a/designer/client/src/list/Warning.test.tsx
+++ b/designer/client/src/list/Warning.test.tsx
@@ -7,18 +7,20 @@ import { customRenderForLists } from '~/test/helpers/renderers-lists.jsx'
 
 const data: FormDefinition = {
   pages: [],
-  sections: [],
-  startPage: '',
   lists: [
     {
       name: 'myList',
       title: 'My list',
+      type: 'string',
       items: [
         { text: 'text a', description: 'desc a', value: 'value a' },
         { text: 'text b', description: 'desc b', value: 'value b' }
       ]
     }
-  ]
+  ],
+  sections: [],
+  conditions: [],
+  outputs: []
 }
 
 const dataValue = { data, save: jest.fn() }

--- a/designer/client/src/outputs/output-edit.test.tsx
+++ b/designer/client/src/outputs/output-edit.test.tsx
@@ -25,17 +25,19 @@ describe('OutputEdit', () => {
           components: [
             {
               name: '9WH4EX',
-              options: {},
               type: 'TextField',
-              title: 'Email'
+              title: 'Email',
+              options: {},
+              schema: {}
             }
           ],
           controller: './pages/summary.js'
         }
       ],
-      outputs: [],
+      lists: [],
+      sections: [],
       conditions: [],
-      lists: []
+      outputs: []
     }
   })
 

--- a/designer/client/tsconfig.json
+++ b/designer/client/tsconfig.json
@@ -6,8 +6,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "paths": {
-      "~/*": ["./*", "../../model/*"],
-      "@defra/forms-model": ["../../model/src/index.ts"]
+      "~/*": ["./*", "../../model/*"]
     },
     "types": ["@testing-library/jest-dom"]
   },

--- a/designer/server/src/routes/forms/api.test.js
+++ b/designer/server/src/routes/forms/api.test.js
@@ -22,32 +22,13 @@ describe('Server API', () => {
       method: 'put',
       url: '/api/test-form-id/data',
       auth,
-      payload: {
-        metadata: {},
-        startPage: '/first-page',
-        pages: [
-          {
-            title: 'First page',
-            path: '/first-page',
-            components: [],
-            next: [
-              {
-                path: '/summary'
-              }
-            ]
-          },
-          {
-            title: 'Summary',
-            path: '/summary',
-            controller: './pages/summary.js',
-            components: []
-          }
-        ],
+      payload: /** @satisfies {FormDefinition} */ ({
+        pages: [],
         lists: [],
+        sections: [],
         conditions: [],
-        outputs: [],
-        version: 2
-      }
+        outputs: []
+      })
     }
 
     const result = /** @type {ServerInjectResponse<{ err: Error }>}) */ (
@@ -68,7 +49,7 @@ describe('Server API', () => {
       method: 'put',
       url: '/api/test-form-id/data',
       auth,
-      payload: {
+      payload: /** @satisfies {FormDefinition} */ ({
         metadata: {},
         startPage: '/first-page',
         pages: [
@@ -92,9 +73,8 @@ describe('Server API', () => {
         lists: [],
         sections: [],
         conditions: [],
-        outputs: [],
-        version: 2
-      }
+        outputs: []
+      })
     }
 
     // When
@@ -107,6 +87,10 @@ describe('Server API', () => {
     expect(result.result.err.message).toBe('Error in persistence service')
   })
 })
+
+/**
+ * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
+ */
 
 /**
  * @template {object} Result

--- a/designer/server/tsconfig.json
+++ b/designer/server/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "~/*": ["./*", "../../model/*"],
-      "@defra/forms-model": ["../../model/src/index.ts"]
+      "~/*": ["./*", "../../model/*"]
     },
     "types": ["@testing-library/jest-dom"]
   },

--- a/designer/tsconfig.json
+++ b/designer/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "~/*": ["./server/*", "../model/*"],
-      "@defra/forms-model": ["../model/src/index.ts"]
+      "~/*": ["./server/*", "../model/*"]
     }
   },
   "files": [],

--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -1,6 +1,7 @@
 import { formDefinitionSchema } from '~/src/form/form-definition/index.js'
+import { type FormDefinition } from '~/src/form/form-definition/types.js'
 
-const baseConfiguration = {
+const baseConfiguration: FormDefinition = {
   metadata: {},
   startPage: '/first-page',
   pages: [],
@@ -8,7 +9,6 @@ const baseConfiguration = {
   sections: [],
   conditions: [],
   outputs: [],
-  version: 2,
   skipSummary: false,
   phaseBanner: {}
 }


### PR DESCRIPTION
This PR reviews and fixes all `FormDefinition` properties in tests

We're going to want to catch form definitions issues early to keep the editor reliable