### PR TITLE
Restore previous URL path after auth callback

### DIFF
--- a/designer/server/src/common/constants/session-names.js
+++ b/designer/server/src/common/constants/session-names.js
@@ -1,6 +1,6 @@
 export const sessionNames = {
   create: /** @type {const} */ ('create'),
-  referrer: /** @type {const} */ ('referrer'),
+  redirectTo: /** @type {const} */ ('redirectTo'),
   userAuthFailed: /** @type {const} */ ('userAuthFailed'),
   validationFailure: /** @type {const} */ ('validationFailure')
 }

--- a/designer/server/src/common/helpers/auth/azure-oidc.js
+++ b/designer/server/src/common/helpers/auth/azure-oidc.js
@@ -8,6 +8,14 @@ import config from '~/src/config.js'
 
 const authCallbackUrl = new URL(`/auth/callback`, config.appBaseUrl)
 
+export const scope = [
+  `api://${config.azureClientId}/forms.user`,
+  'openid',
+  'profile',
+  'email',
+  'offline_access'
+]
+
 /**
  * @type {ServerRegisterPluginObject}
  */
@@ -39,13 +47,7 @@ export const azureOidc = {
             useParamsAuth: true,
             auth: oidc.authorization_endpoint,
             token: oidc.token_endpoint,
-            scope: [
-              `api://${config.azureClientId}/forms.user`,
-              'openid',
-              'profile',
-              'email',
-              'offline_access'
-            ],
+            scope,
             profile(credentials, params) {
               const artifacts = token.decode(credentials.token)
               const idToken = token.decode(params.id_token)
@@ -134,6 +136,5 @@ export const azureOidcNoop = {
  * @typedef {import('@hapi/bell').Credentials2} Credentials - Provider OAuth2 credentials
  * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials - User credentials
  * @typedef {import('oidc-client-ts').OidcMetadata} OidcMetadata - OpenID Connect (OIDC) metadata
- * @typedef {import('oidc-client-ts').SigninResponse} SigninResponse - Provider sign in artifacts
  * @typedef {import('oidc-client-ts').UserProfile & { groups?: string[], unique_name?: string }} UserProfile - User profile
  */

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -1,4 +1,5 @@
 import { token } from '@hapi/jwt'
+import { isPast, parseISO, subMinutes } from 'date-fns'
 
 import { groupsToScopes } from '~/src/common/constants/scopes.js'
 
@@ -41,6 +42,18 @@ export function hasAuthenticated(credentials) {
     credentials.idToken &&
     credentials.refreshToken
   )
+}
+
+/**
+ * @param {AuthCredentials | null} [credentials]
+ */
+export function hasExpired(credentials) {
+  if (!hasUser(credentials)) {
+    return true
+  }
+
+  const { user } = credentials
+  return !!user.expiresAt && isPast(subMinutes(parseISO(user.expiresAt), 1))
 }
 
 /**
@@ -118,9 +131,4 @@ export function hasUser(credentials) {
 /**
  * @template {import('@hapi/hapi').ReqRef} [ReqRef=import('@hapi/hapi').ReqRefDefaults]
  * @typedef {import('@hapi/hapi').Request<ReqRef>} Request
- */
-
-/**
- * @template {object} Payload
- * @typedef {import('@hapi/jwt').HapiJwt.Artifacts<{ JwtPayload?: Payload }>} UserToken
  */

--- a/designer/server/src/common/helpers/auth/session-cookie.js
+++ b/designer/server/src/common/helpers/auth/session-cookie.js
@@ -2,8 +2,11 @@ import authCookie from '@hapi/cookie'
 
 import {
   getUserSession,
+  hasExpired,
   hasUser
 } from '~/src/common/helpers/auth/get-user-session.js'
+import { refreshAccessToken } from '~/src/common/helpers/auth/refresh-token.js'
+import { createUserSession } from '~/src/common/helpers/auth/user-session.js'
 import config from '~/src/config.js'
 
 /**
@@ -45,7 +48,7 @@ const sessionCookie = {
 
           /**
            * Validate session using auth credentials
-           * @param {Request} [request]
+           * @param {Request<{ AuthArtifactsExtra: AuthArtifacts }>} [request]
            * @param {{ sessionId: string, user: UserCredentials }} [session] - Session cookie state
            */
           async validate(request, session) {
@@ -53,11 +56,24 @@ const sessionCookie = {
               return { isValid: false }
             }
 
-            const credentials = await getUserSession(request, session)
+            let credentials = await getUserSession(request, session)
+
+            if (hasUser(credentials)) {
+              const { auth } = request
+
+              // Rebuild credentials from Redis session
+              auth.credentials = credentials
+
+              // Refresh session when token has expired
+              if (hasExpired(credentials)) {
+                const token = await refreshAccessToken(request)
+                credentials = await createUserSession(request, token)
+              }
+            }
 
             return {
-              credentials,
-              isValid: hasUser(credentials)
+              isValid: !hasExpired(credentials),
+              credentials
             }
           }
         })
@@ -78,7 +94,12 @@ export { sessionCookie }
  */
 
 /**
+ * @template {import('@hapi/hapi').ReqRef} [ReqRef=import('@hapi/hapi').ReqRefDefaults]
+ * @typedef {import('@hapi/hapi').Request<ReqRef>} Request
+ */
+
+/**
  * @typedef {import('@hapi/cookie').Options} ProviderCookie
- * @typedef {import('@hapi/hapi').Request} Request
+ * @typedef {import('@hapi/hapi').AuthArtifacts} AuthArtifacts
  * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials
  */

--- a/designer/server/src/common/helpers/auth/session-cookie.js
+++ b/designer/server/src/common/helpers/auth/session-cookie.js
@@ -31,7 +31,15 @@ const sessionCookie = {
           /**
            * Redirect invalid session to callback route
            */
-          redirectTo() {
+          redirectTo(request) {
+            if (request) {
+              const { url, yar } = request
+
+              // Remember current location for later
+              yar.flash('redirectTo', url.pathname)
+            }
+
+            // Redirect to callback route
             return '/auth/callback'
           },
 

--- a/designer/server/src/common/helpers/auth/session-cookie.js
+++ b/designer/server/src/common/helpers/auth/session-cookie.js
@@ -15,41 +15,45 @@ const sessionCookie = {
     async register(server) {
       await server.register(authCookie)
 
-      server.auth.strategy('session', 'cookie', {
-        cookie: {
-          name: 'userSession',
-          path: '/',
-          password: config.sessionCookiePassword,
-          isSecure: config.isProduction,
-          ttl: config.sessionCookieTtl
-        },
-        keepAlive: true,
+      server.auth.strategy(
+        'session',
+        'cookie',
+        /** @type {ProviderCookie} */ ({
+          cookie: {
+            name: 'userSession',
+            path: '/',
+            password: config.sessionCookiePassword,
+            isSecure: config.isProduction,
+            ttl: config.sessionCookieTtl
+          },
+          keepAlive: true,
 
-        /**
-         * Redirect invalid session to callback route
-         */
-        redirectTo() {
-          return '/auth/callback'
-        },
+          /**
+           * Redirect invalid session to callback route
+           */
+          redirectTo() {
+            return '/auth/callback'
+          },
 
-        /**
-         * Validate session using auth credentials
-         * @param {Request} [request]
-         * @param {{ sessionId: string, user: UserCredentials }} [session] - Session cookie state
-         */
-        async validate(request, session) {
-          if (!request) {
-            return { isValid: false }
+          /**
+           * Validate session using auth credentials
+           * @param {Request} [request]
+           * @param {{ sessionId: string, user: UserCredentials }} [session] - Session cookie state
+           */
+          async validate(request, session) {
+            if (!request) {
+              return { isValid: false }
+            }
+
+            const credentials = await getUserSession(request, session)
+
+            return {
+              credentials,
+              isValid: hasUser(credentials)
+            }
           }
-
-          const credentials = await getUserSession(request, session)
-
-          return {
-            credentials,
-            isValid: hasUser(credentials)
-          }
-        }
-      })
+        })
+      )
 
       server.auth.default({
         strategies: ['azure-oidc', 'session']
@@ -66,6 +70,7 @@ export { sessionCookie }
  */
 
 /**
+ * @typedef {import('@hapi/cookie').Options} ProviderCookie
  * @typedef {import('@hapi/hapi').Request} Request
  * @typedef {import('@hapi/hapi').UserCredentials} UserCredentials
  */

--- a/designer/server/src/routes/account/auth.js
+++ b/designer/server/src/routes/account/auth.js
@@ -1,6 +1,7 @@
 import Boom from '@hapi/boom'
 
 import * as scopes from '~/src/common/constants/scopes.js'
+import { sessionNames } from '~/src/common/constants/session-names.js'
 import { dropUserSession } from '~/src/common/helpers/auth/drop-user-session.js'
 import { hasUser } from '~/src/common/helpers/auth/get-user-session.js'
 import { createUserSession } from '~/src/common/helpers/auth/user-session.js'
@@ -37,7 +38,7 @@ export default [
         return h.redirect('/')
       }
 
-      const redirect = yar.flash('referrer').at(0) ?? '/library'
+      const redirect = yar.flash(sessionNames.redirectTo).at(0) ?? '/library'
       return h.redirect(redirect)
     },
     options: {

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -84,7 +84,7 @@ declare module '@hapi/hapi' {
 
 declare module '@hapi/yar' {
   type CreateKey = (typeof sessionNames)['create']
-  type ReferrerKey = (typeof sessionNames)['referrer']
+  type RedirectToKey = (typeof sessionNames)['redirectTo']
   type ValidationKey = (typeof sessionNames)['validationFailure']
   type UserAuthFailedKey = (typeof sessionNames)['userAuthFailed']
 
@@ -93,7 +93,7 @@ declare module '@hapi/yar' {
      * Get temporary redirect path for after sign in
      * (Deleted when read, e.g. after a redirect)
      */
-    flash(type: ReferrerKey): string[]
+    flash(type: RedirectToKey): string[]
 
     /**
      * Get temporary error messages from the session


### PR DESCRIPTION
This PR ensures the previous URL path is restored after your session expires

We'll only be handling the URL path so I've renamed the yar key from `referrer` (full URL) → `redirectTo`

