### PR TITLE
Remove HMPO components (i.e. Flash card) from editor

### DIFF
--- a/designer/client/src/ComponentEdit.js
+++ b/designer/client/src/ComponentEdit.js
@@ -14,8 +14,7 @@ const LIST_TYPES = [
   Types.List,
   Types.RadiosField,
   Types.SelectField,
-  Types.YesNoField,
-  Types.FlashCard
+  Types.YesNoField
 ]
 
 export function ComponentEdit(props) {

--- a/designer/client/src/ComponentTypeEdit.tsx
+++ b/designer/client/src/ComponentTypeEdit.tsx
@@ -23,7 +23,6 @@ const componentTypeEditors = {
   SelectField: SelectFieldEdit,
   RadiosField: ListFieldEdit,
   CheckboxesField: ListFieldEdit,
-  FlashCard: ListFieldEdit,
   List: ListFieldEdit,
   Details: DetailsEdit,
   Para: ParaEdit,
@@ -45,8 +44,7 @@ function ComponentTypeEdit(props) {
     (t) => t.name === selectedComponent?.type ?? ''
   )
 
-  const needsFieldInputs =
-    type?.subType !== 'content' || ['FlashCard', 'List'].includes(type.name)
+  const needsFieldInputs = type?.subType !== 'content' || type.name === 'List'
 
   const TagName = componentTypeEditors[type?.name ?? '']
   return (

--- a/designer/client/src/component.js
+++ b/designer/client/src/component.js
@@ -29,7 +29,6 @@ export const componentTypes = {
   Details,
   Html,
   InsetText,
-  FlashCard,
   List,
   WarningText,
   WebsiteField: TextField
@@ -259,15 +258,6 @@ function Para() {
   return (
     <Base>
       <div className="line" />
-      <div className="line short govuk-!-margin-bottom-2 govuk-!-margin-top-2" />
-      <div className="line" />
-    </Base>
-  )
-}
-
-function FlashCard() {
-  return (
-    <Base>
       <div className="line short govuk-!-margin-bottom-2 govuk-!-margin-top-2" />
       <div className="line" />
     </Base>

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.enzyme.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.enzyme.test.tsx
@@ -18,7 +18,6 @@ describe('ComponentCreateList', () => {
 
     expect(listItems).toEqual([
       'Details',
-      'Flash card',
       'HTML',
       'Inset text',
       'List',

--- a/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
+++ b/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
@@ -55,23 +55,6 @@ exports[`ComponentCreateList should match snapshot 1`] = `
                 class="govuk-link"
                 href="#0"
               >
-                Flash card
-              </a>
-            </p>
-            <div
-              class="govuk-hint govuk-!-margin-top-2"
-            >
-              A panel of text that can include a list
-            </div>
-          </li>
-          <li>
-            <p
-              class="govuk-body govuk-!-margin-bottom-2"
-            >
-              <a
-                class="govuk-link"
-                href="#0"
-              >
                 HTML
               </a>
             </p>

--- a/designer/client/src/data/types.ts
+++ b/designer/client/src/data/types.ts
@@ -16,8 +16,7 @@ export const isNotContentType = (
     'Details',
     'Html',
     'InsetText',
-    'List',
-    'FlashCard'
+    'List'
   ]
   return !contentTypes.find((type) => type === obj.type)
 }

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -174,8 +174,6 @@
     "EmailAddressField_info": "A text box that users can enter an email address into",
     "FileUploadField": "File upload",
     "FileUploadField_info": "Allows users to upload files from the device they are using",
-    "FlashCard": "Flash card",
-    "FlashCard_info": "A panel of text that can include a list",
     "Html": "HTML",
     "Html_info": "A block of text that you can apply basic HTML to, such as text formatting and hyperlinks",
     "InsetText": "Inset text",

--- a/model/src/components/component-types.ts
+++ b/model/src/components/component-types.ts
@@ -200,15 +200,6 @@ export const ComponentTypes: ComponentDef[] = [
     schema: {}
   },
   {
-    name: 'FlashCard',
-    type: 'FlashCard',
-    title: 'Flash card',
-    subType: 'content',
-    options: {},
-    schema: {},
-    list: ''
-  },
-  {
     name: 'List',
     type: 'List',
     title: 'List',

--- a/model/src/components/enums.ts
+++ b/model/src/components/enums.ts
@@ -21,6 +21,5 @@ export enum ComponentTypeEnum {
   Html = 'Html',
   InsetText = 'InsetText',
   Details = 'Details',
-  FlashCard = 'FlashCard',
   List = 'List'
 }

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -21,7 +21,6 @@ export type ComponentType =
   | 'Html'
   | 'InsetText'
   | 'Details'
-  | 'FlashCard'
   | 'List'
   | 'WebsiteField'
 
@@ -253,10 +252,6 @@ export interface CheckboxesFieldComponent extends ListFieldBase {
   subType?: 'listField'
 }
 
-export interface FlashCardComponent extends ListFieldBase {
-  type: 'FlashCard'
-}
-
 export interface RadiosFieldComponent extends ListFieldBase {
   type: 'RadiosField'
   subType?: 'listField'
@@ -280,7 +275,6 @@ export type ComponentDef =
   | DetailsComponent
   | EmailAddressFieldComponent
   | FileUploadFieldComponent
-  | FlashCardComponent
   | HtmlComponent
   | ListComponent
   | MultilineTextFieldComponent
@@ -319,13 +313,11 @@ export type ContentComponentsDef =
   | HtmlComponent
   | InsetTextComponent
   | ListComponent
-  | FlashCardComponent
 
 // Components that render Lists
 export type ListComponentsDef =
   | ListComponent
   | AutocompleteFieldComponent
   | CheckboxesFieldComponent
-  | FlashCardComponent
   | RadiosFieldComponent
   | SelectFieldComponent


### PR DESCRIPTION
This PR removes the "Flash card" component from the editor now we've merged:

* https://github.com/DEFRA/forms-runner/pull/128