### PR TITLE
Fix incorrect `<label>` for attribute for ‘Details’ edit field

### DIFF
--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -1,6 +1,12 @@
 import { type DetailsComponent, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import {
+  act,
+  cleanup,
+  render,
+  waitFor,
+  type RenderResult
+} from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -28,16 +34,13 @@ describe('ComponentCreate:', () => {
 
   const page = { path: '/1' }
 
-  const WrappingComponent = ({
-    dataValue = { data, save: jest.fn() },
-    componentValue,
-    children
-  }) => {
-    return (
-      <DataContext.Provider value={dataValue}>
-        <ComponentContextProvider {...componentValue}>
-          {children}
-        </ComponentContextProvider>
+  function customRender(
+    element: JSX.Element,
+    providerProps = { data, save: jest.fn() }
+  ): RenderResult {
+    return render(
+      <DataContext.Provider value={providerProps}>
+        <ComponentContextProvider>{element}</ComponentContextProvider>
       </DataContext.Provider>
     )
   }
@@ -45,29 +48,22 @@ describe('ComponentCreate:', () => {
   afterEach(cleanup)
 
   test('Selecting a component type should display the component edit form', async () => {
-    // - when
-    render(
-      <WrappingComponent componentValue={false}>
-        <ComponentCreate page={page} />
-      </WrappingComponent>
-    )
+    customRender(<ComponentCreate page={page} />)
 
     expect(queryByLabelText('Title')).not.toBeInTheDocument()
     await act(() => userEvent.click(getByText('Details')))
 
-    // - then
     const $input = await waitFor(() => findByLabelText('Title'))
     expect($input).toBeInTheDocument()
   })
 
   test('Should store the populated component and call callback on submit', async () => {
-    // - when
-    const spy = jest.fn()
-    const { container } = render(
-      <WrappingComponent dataValue={{ data, save: spy }} componentValue={false}>
-        <ComponentCreate page={page} />
-      </WrappingComponent>
-    )
+    const providerProps = {
+      data,
+      save: jest.fn()
+    }
+
+    customRender(<ComponentCreate page={page} />, providerProps)
 
     await act(() => userEvent.click(getByText('Details')))
 
@@ -79,9 +75,8 @@ describe('ComponentCreate:', () => {
     await act(() => userEvent.type($textarea, 'content'))
     await act(() => userEvent.click($button))
 
-    // - then
-    await waitFor(() => expect(spy).toHaveBeenCalled())
-    const newDetailsComp = spy.mock.calls[0][0].pages[0]
+    await waitFor(() => expect(providerProps.save).toHaveBeenCalled())
+    const newDetailsComp = providerProps.save.mock.calls[0][0].pages[0]
       .components?.[0] as DetailsComponent
 
     expect(newDetailsComp.type).toBe('Details')
@@ -90,19 +85,14 @@ describe('ComponentCreate:', () => {
   })
 
   test("Should have functioning 'Back to create component list' link", async () => {
-    // - when
-    render(
-      <WrappingComponent componentValue={false}>
-        <ComponentCreate page={page} />
-      </WrappingComponent>
-    )
+    customRender(<ComponentCreate page={page} />)
+
     const backBtnTxt = 'Back to create component list'
 
     expect(queryByTestId('component-create-list')).toBeInTheDocument()
 
     await act(() => userEvent.click(queryByText('Details')))
 
-    // - then
     expect(queryByTestId('component-create-list')).not.toBeInTheDocument()
     expect(queryByText(backBtnTxt)).toBeInTheDocument()
 
@@ -113,11 +103,7 @@ describe('ComponentCreate:', () => {
   })
 
   test('Should display ErrorSummary when validation fails', async () => {
-    // - when
-    const { container } = render(
-      <WrappingComponent componentValue={false}>
-        <ComponentCreate page={page} />
-      </WrappingComponent>
+    customRender(<ComponentCreate page={page} />)
     )
 
     expect(queryByRole('alert')).not.toBeInTheDocument()
@@ -126,7 +112,6 @@ describe('ComponentCreate:', () => {
     await waitFor(() => findByLabelText('Title'))
     await act(() => userEvent.click(container.querySelector('button')))
 
-    // - then
     expect(queryByRole('alert')).toBeInTheDocument()
   })
 })

--- a/designer/client/src/components/FieldEditors/details-edit.tsx
+++ b/designer/client/src/components/FieldEditors/details-edit.tsx
@@ -50,7 +50,7 @@ function DetailsEdit({ i18n, context = ComponentContext }: Props) {
           'govuk-form-group--error': errors?.content
         })}
       >
-        <label className="govuk-label govuk-label--s" htmlFor="details-content">
+        <label className="govuk-label govuk-label--s" htmlFor="field-content">
           Content
         </label>
         <div className="govuk-hint">{i18n('fieldEdit.details.hint')}</div>


### PR DESCRIPTION
This PR fixes the 'Details' edit field `<label>` so it matches the `<textarea>` by ID

To avoid this in future, I've updated some component create tests to use accessible text not IDs or selectors