### PR TITLE
Fix ESLint warnings for Jest mock calls

### DIFF
--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -90,12 +90,27 @@ describe('ComponentCreate:', () => {
     await act(() => userEvent.click($button))
 
     await waitFor(() => expect(providerProps.save).toHaveBeenCalled())
-    const newDetailsComp = providerProps.save.mock.calls[0][0].pages[0]
-      .components?.[0] as DetailsComponent
 
-    expect(newDetailsComp.type).toBe('Details')
-    expect(newDetailsComp.title).toBe('Details')
-    expect(newDetailsComp.content).toBe('content')
+    expect(providerProps.save.mock.calls[0]).toEqual(
+      expect.arrayContaining([
+        {
+          ...data,
+          pages: [
+            expect.objectContaining({
+              components: [
+                {
+                  title: 'Details',
+                  type: 'Details',
+                  name: expect.any(String),
+                  content: 'content',
+                  options: {}
+                }
+              ]
+            })
+          ]
+        }
+      ])
+    )
   })
 
   test("Should have functioning 'Back to create component list' link", async () => {

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.enzyme.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.enzyme.test.tsx
@@ -42,15 +42,19 @@ describe('ComponentCreateList', () => {
     )
 
     expect(onSelectComponent.mock.calls).toHaveLength(listItems.length)
-    expect(onSelectComponent.mock.calls[0][0]).toEqual({
-      name: 'Details',
-      type: 'Details',
-      title: 'Details',
-      subType: 'content',
-      content: '',
-      options: {},
-      schema: {}
-    })
+    expect(onSelectComponent.mock.calls[0]).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'Details',
+          type: 'Details',
+          title: 'Details',
+          subType: 'content',
+          content: '',
+          options: {},
+          schema: {}
+        }
+      ])
+    )
   })
 
   test('it displays Input fields list correctly', () => {
@@ -99,15 +103,19 @@ describe('ComponentCreateList', () => {
     )
 
     expect(onSelectComponent.mock.calls).toHaveLength(listItems.length)
-    expect(onSelectComponent.mock.calls[0][0]).toEqual({
-      name: 'AutocompleteField',
-      type: 'AutocompleteField',
-      title: 'Autocomplete field',
-      subType: 'listField',
-      options: {},
-      schema: {},
-      list: ''
-    })
+    expect(onSelectComponent.mock.calls[0]).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'AutocompleteField',
+          type: 'AutocompleteField',
+          title: 'Autocomplete field',
+          subType: 'listField',
+          options: {},
+          schema: {},
+          list: ''
+        }
+      ])
+    )
   })
 
   test('it displays Selection fields list correctly', () => {
@@ -140,14 +148,18 @@ describe('ComponentCreateList', () => {
     )
 
     expect(onSelectComponent.mock.calls).toHaveLength(listItems.length)
-    expect(onSelectComponent.mock.calls[0][0]).toEqual({
-      name: 'CheckboxesField',
-      type: 'CheckboxesField',
-      title: 'Checkboxes field',
-      subType: 'listField',
-      options: {},
-      schema: {},
-      list: ''
-    })
+    expect(onSelectComponent.mock.calls[0]).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'CheckboxesField',
+          type: 'CheckboxesField',
+          title: 'Checkboxes field',
+          subType: 'listField',
+          options: {},
+          schema: {},
+          list: ''
+        }
+      ])
+    )
   })
 })

--- a/designer/client/src/link-create.test.tsx
+++ b/designer/client/src/link-create.test.tsx
@@ -154,20 +154,63 @@ describe('LinkCreate', () => {
     await act(() => userEvent.click($button))
 
     await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
-    expect(save.mock.calls[0][0].pages[0].next).toContainEqual({
-      path: '/summary',
-      condition: 'hasUKPassport'
-    })
+
+    expect(save.mock.calls[0]).toEqual(
+      expect.arrayContaining([
+        {
+          ...data,
+          pages: [
+            expect.objectContaining({
+              title: 'First page',
+              path: '/first-page',
+
+              // Paths and conditions are correctly generated
+              next: [{ path: '/summary', condition: 'hasUKPassport' }]
+            }),
+            expect.objectContaining({
+              title: 'Second page',
+              path: '/second-page'
+            }),
+            expect.objectContaining({
+              title: 'Summary',
+              path: '/summary'
+            })
+          ]
+        }
+      ])
+    )
 
     await act(() => userEvent.selectOptions($source, '/summary'))
     await act(() => userEvent.selectOptions($target, '/first-page'))
     await act(() => userEvent.selectOptions($condition, ''))
     await act(() => userEvent.click($button))
 
-    expect(save).toHaveBeenCalledTimes(2)
-    expect(save.mock.calls[1][0].pages[2].next).toContainEqual({
-      path: '/first-page'
-    })
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(2))
+
+    expect(save.mock.calls[1]).toEqual(
+      expect.arrayContaining([
+        {
+          ...data,
+          pages: [
+            expect.objectContaining({
+              title: 'First page',
+              path: '/first-page'
+            }),
+            expect.objectContaining({
+              title: 'Second page',
+              path: '/second-page'
+            }),
+            expect.objectContaining({
+              title: 'Summary',
+              path: '/summary',
+
+              // Paths are correctly generated
+              next: [{ path: '/first-page' }]
+            })
+          ]
+        }
+      ])
+    )
   })
 
   test('links are correctly generated when the form is submitted', async () => {
@@ -241,21 +284,64 @@ describe('LinkCreate', () => {
     await act(() => userEvent.selectOptions($condition, 'hasUKPassport'))
     await act(() => userEvent.click($button))
 
-    expect(save).toHaveBeenCalledTimes(1)
-    expect(save.mock.calls[0][0].pages[0].next).toContainEqual({
-      path: '/summary',
-      condition: 'hasUKPassport'
-    })
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+
+    expect(save.mock.calls[0]).toEqual(
+      expect.arrayContaining([
+        {
+          ...data,
+          pages: [
+            expect.objectContaining({
+              title: 'First page',
+              path: '/first-page',
+
+              // Paths and conditions are correctly generated
+              next: [{ path: '/summary', condition: 'hasUKPassport' }]
+            }),
+            expect.objectContaining({
+              title: 'Second page',
+              path: '/second-page'
+            }),
+            expect.objectContaining({
+              title: 'Summary',
+              path: '/summary'
+            })
+          ]
+        }
+      ])
+    )
 
     await act(() => userEvent.selectOptions($source, '/summary'))
     await act(() => userEvent.selectOptions($target, '/first-page'))
     await act(() => userEvent.selectOptions($condition, ''))
     await act(() => userEvent.click($button))
 
-    expect(save).toHaveBeenCalledTimes(2)
-    expect(save.mock.calls[1][0].pages[2].next).toContainEqual({
-      path: '/first-page'
-    })
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(2))
+
+    expect(save.mock.calls[1]).toEqual(
+      expect.arrayContaining([
+        {
+          ...data,
+          pages: [
+            expect.objectContaining({
+              title: 'First page',
+              path: '/first-page'
+            }),
+            expect.objectContaining({
+              title: 'Second page',
+              path: '/second-page'
+            }),
+            expect.objectContaining({
+              title: 'Summary',
+              path: '/summary',
+
+              // Paths are correctly generated
+              next: [{ path: '/first-page' }]
+            })
+          ]
+        }
+      ])
+    )
   })
 
   test('Submitting without selecting to/from options shows the user an error', async () => {
@@ -270,7 +356,8 @@ describe('LinkCreate', () => {
     })
 
     await act(() => userEvent.click(getByRole('button')))
-    expect(save).not.toHaveBeenCalled()
+
+    await waitFor(() => expect(save).not.toHaveBeenCalled())
 
     const summary = within(getByRole('alert'))
     expect(summary.getByText('Enter from')).toBeInTheDocument()

--- a/designer/client/src/outputs/output-edit.test.tsx
+++ b/designer/client/src/outputs/output-edit.test.tsx
@@ -13,7 +13,7 @@ describe('OutputEdit', () => {
   const { getByText, getByLabelText } = screen
 
   let mockData: FormDefinition
-  let mockSave: any
+  let mockSave: jest.Mock
 
   beforeEach(() => {
     mockSave = jest.fn().mockResolvedValue(mockData)
@@ -103,20 +103,27 @@ describe('OutputEdit', () => {
       await act(() => userEvent.click($button))
       await waitFor(() => expect(mockSave).toHaveBeenCalledTimes(1))
 
-      expect(mockSave.mock.calls[0][0].outputs).toEqual([
-        {
-          name: 'NewName',
-          title: 'NewTitle',
-          type: 'notify',
-          outputConfiguration: {
-            personalisation: [],
-            templateId: 'NewTemplateId',
-            apiKey: 'NewAPIKey',
-            emailField: '9WH4EX',
-            addReferencesToPersonalisation: true
+      expect(mockSave.mock.calls[0]).toEqual(
+        expect.arrayContaining([
+          {
+            ...mockData,
+            outputs: [
+              {
+                name: 'NewName',
+                title: 'NewTitle',
+                type: 'notify',
+                outputConfiguration: {
+                  personalisation: [],
+                  templateId: 'NewTemplateId',
+                  apiKey: 'NewAPIKey',
+                  emailField: '9WH4EX',
+                  addReferencesToPersonalisation: true
+                }
+              }
+            ]
           }
-        }
-      ])
+        ])
+      )
     })
   })
 })


### PR DESCRIPTION
Improves all our assertions on Jest mock calls where tests currently crash if mocks are _not_ called