### PR TITLE
Remove component assertions for missing imports

### DIFF
--- a/designer/client/src/reducers/component/componentReducer.test.tsx
+++ b/designer/client/src/reducers/component/componentReducer.test.tsx
@@ -6,9 +6,7 @@ import {
   metaReducer,
   optionsReducer,
   fieldsReducer,
-  schemaReducer,
-  componentListReducer,
-  componentListItemReducer
+  schemaReducer
 } from '~/src/reducers/component/index.js'
 import { Actions } from '~/src/reducers/component/types.js'
 
@@ -18,15 +16,11 @@ describe('Component reducer', () => {
     const schemaAction = Actions.EDIT_SCHEMA_MIN
     const fieldsAction = Actions.EDIT_TITLE
     const optionsAction = Actions.EDIT_OPTIONS_HIDE_TITLE
-    const listAction = Actions.EDIT_LIST
-    const listItemAction = Actions.STATIC_LIST_ITEM_EDIT_VALUE
 
     expect(getSubReducer(metaAction)).toEqual(metaReducer)
     expect(getSubReducer(schemaAction)).toEqual(schemaReducer)
     expect(getSubReducer(optionsAction)).toEqual(optionsReducer)
     expect(getSubReducer(fieldsAction)).toEqual(fieldsReducer)
-    expect(getSubReducer(listAction)).toEqual(componentListReducer)
-    expect(getSubReducer(listItemAction)).toEqual(componentListItemReducer)
   })
 
   test('componentReducer adds hasValidated flag correctly', () => {

--- a/designer/server/src/common/nunjucks/filters/format-date.test.js
+++ b/designer/server/src/common/nunjucks/filters/format-date.test.js
@@ -2,8 +2,9 @@ import { formatDate } from '~/src/common/nunjucks/filters/index.js'
 
 describe('#formatDate', () => {
   beforeAll(() => {
-    jest.useFakeTimers('modern')
-    jest.setSystemTime(new Date('2023-04-01'))
+    jest.useFakeTimers({
+      now: new Date('2023-04-01')
+    })
   })
 
   afterAll(() => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ export const defaults = {
  * @type {Partial<import('@jest/types').Config.InitialProjectOptions>}
  */
 export const projectDefaults = {
+  extensionsToTreatAsEsm: ['.jsx', '.ts', '.tsx'],
   clearMocks: true,
   coverageDirectory: '<rootDir>/coverage',
   modulePathIgnorePatterns: ['<rootDir>/coverage/', '<rootDir>/dist/'],


### PR DESCRIPTION
Couple of test fixes and strangely some React component assertions for imports that never existed