### PR TITLE
Remove unnecessary `BABEL_ENV` switching

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -16,7 +16,7 @@
     "audit": "npm audit --audit-level=high",
     "build": "npm run build:server && npm run build:client",
     "build:client": "NODE_ENV=${NODE_ENV:-production} webpack",
-    "build:server": "BABEL_ENV=node babel --delete-dir-on-start --extensions \".js\",\".ts\" --ignore \"**/*.test.*\" --copy-files --no-copy-ignored --source-maps --out-dir ./server/dist ./server/src",
+    "build:server": "babel --delete-dir-on-start --extensions \".js\",\".ts\" --ignore \"**/*.test.*\" --copy-files --no-copy-ignored --source-maps --out-dir ./server/dist ./server/src",
     "dev": "concurrently \"npm run client:watch\" \"npm run server:watch\" --kill-others --names \"client,server\" --prefix-colors \"red.dim,blue.dim\"",
     "dev:debug": "concurrently \"npm run client:watch\" \"npm run server:debug\" --kill-others --names \"client,server\" --prefix-colors \"red.dim,blue.dim\"",
     "symlink-env": "./bin/symlink-config",

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -65,10 +65,7 @@ export default /** @type {import('webpack').Configuration} */ ({
         },
 
         // Fix missing file extensions in React components
-        resolve: {
-          fullySpecified: false,
-          symlinks: false
-        },
+        resolve: { fullySpecified: false },
 
         // Flag loaded modules as side effect free
         sideEffects: false

--- a/model/babel.config.cjs
+++ b/model/babel.config.cjs
@@ -1,11 +1,11 @@
-const { BABEL_ENV = 'node', NODE_ENV } = process.env
+const { NODE_ENV } = process.env
 
 /**
  * Babel config
  * @type {import('@babel/core').TransformOptions}
  */
 module.exports = {
-  browserslistEnv: BABEL_ENV,
+  browserslistEnv: 'node',
   plugins: [
     [
       'module-resolver',

--- a/model/package.json
+++ b/model/package.json
@@ -15,7 +15,7 @@
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "npm run build:types && npm run build:node",
-    "build:node": "BABEL_ENV=node babel --delete-dir-on-start --extensions \".ts\" --ignore \"**/*.test.*\" --copy-files --no-copy-ignored --source-maps --out-dir ./dist/module ./src",
+    "build:node": "babel --delete-dir-on-start --extensions \".ts\" --ignore \"**/*.test.*\" --copy-files --no-copy-ignored --source-maps --out-dir ./dist/module ./src",
     "build:types": "tsc --build --force tsconfig.build.json && tsc-alias --project tsconfig.build.json",
     "test": "jest --color --coverage --verbose",
     "test:watch": "jest --color --watch"


### PR DESCRIPTION
Just some old code tidy up since we no longer compile to CommonJS

Since we're removing lots of designer client code I've also reverted https://github.com/DEFRA/forms-designer/commit/6541796f62b6310343cde81ed8c6055c6979ace6

This re-includes `@defra/forms-model` so important Babel polyfills or transforms aren't missed