### PR TITLE
Set redis prefix at redis client level …

### DIFF
--- a/designer/server/src/common/helpers/redis-client.js
+++ b/designer/server/src/common/helpers/redis-client.js
@@ -25,7 +25,8 @@ function buildRedisClient() {
       password: config.redisPassword,
       port,
       host: config.redisHost,
-      db
+      db,
+      keyPrefix: config.redisKeyPrefix
     })
   } else {
     logger.info('Connecting to Redis using cluster')
@@ -38,6 +39,7 @@ function buildRedisClient() {
         }
       ],
       {
+        keyPrefix: config.redisKeyPrefix,
         slotsRefreshTimeout: 2000,
         dnsLookup: (address, callback) => callback(null, address),
         redisOptions: {

--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -48,7 +48,6 @@ const serverOptions = (): ServerOptions => {
         engine: config.isTest
           ? new CatboxMemory()
           : new CatboxRedis({
-              partition: config.redisKeyPrefix,
               client: buildRedisClient()
             })
       }
@@ -61,7 +60,7 @@ export async function createServer() {
 
   const cache = server.cache({
     cache: 'session',
-    segment: config.redisKeyPrefix,
+    segment: 'session',
     expiresIn: config.sessionTtl
   })
 


### PR DESCRIPTION
Sets redis prefix at redis client level to prevent errors in CDP environment.

Session cache segment has also been reset to a proper name rather than duplicating the prefix. Now the key will be `prefixSegment:name` e.g. `forms-designersession:name` instead of `forms-designerformsdesigner:name`.