### PR TITLE
Fix bug affecting `hasValidated` state

### DIFF
--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -6,7 +6,7 @@ import { ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { updateComponent } from '~/src/data/component/updateComponent.js'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Meta } from '~/src/reducers/component/types.js'
 import { hasValidationErrors } from '~/src/validations.js'
 
 export function ComponentEdit(props) {
@@ -27,7 +27,7 @@ export function ComponentEdit(props) {
     e?.preventDefault()
 
     if (!hasValidated) {
-      dispatch({ type: Actions.VALIDATE })
+      dispatch({ type: Meta.VALIDATE })
       return
     }
 

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -5,7 +5,7 @@ import React, { useContext } from 'react'
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Fields, Options } from '~/src/reducers/component/types.js'
 
 interface Props {
   isContentField?: boolean
@@ -45,7 +45,7 @@ export function FieldEdit({
         value={title || ''}
         onChange={(e) => {
           dispatch({
-            type: Actions.EDIT_TITLE,
+            type: Fields.EDIT_TITLE,
             payload: e.target.value
           })
         }}
@@ -70,7 +70,7 @@ export function FieldEdit({
         value={hint}
         onChange={(e) => {
           dispatch({
-            type: Actions.EDIT_HELP,
+            type: Fields.EDIT_HELP,
             payload: e.target.value
           })
         }}
@@ -86,7 +86,7 @@ export function FieldEdit({
             checked={hideTitle}
             onChange={(e) =>
               dispatch({
-                type: Actions.EDIT_OPTIONS_HIDE_TITLE,
+                type: Options.EDIT_OPTIONS_HIDE_TITLE,
                 payload: e.target.checked
               })
             }
@@ -124,7 +124,7 @@ export function FieldEdit({
           value={name || ''}
           onChange={(e) => {
             dispatch({
-              type: Actions.EDIT_NAME,
+              type: Fields.EDIT_NAME,
               payload: e.target.value
             })
           }}
@@ -141,7 +141,7 @@ export function FieldEdit({
               checked={!required}
               onChange={(e) =>
                 dispatch({
-                  type: Actions.EDIT_OPTIONS_REQUIRED,
+                  type: Options.EDIT_OPTIONS_REQUIRED,
                   payload: !e.target.checked
                 })
               }
@@ -177,7 +177,7 @@ export function FieldEdit({
             checked={optionalText}
             onChange={(e) =>
               dispatch({
-                type: Actions.EDIT_OPTIONS_HIDE_OPTIONAL,
+                type: Options.EDIT_OPTIONS_HIDE_OPTIONAL,
                 payload: e.target.checked
               })
             }
@@ -206,7 +206,7 @@ export function FieldEdit({
             checked={exposeToContext}
             onChange={(e) =>
               dispatch({
-                type: Actions.EDIT_OPTIONS_EXPOSE_TO_CONTEXT,
+                type: Options.EDIT_OPTIONS_EXPOSE_TO_CONTEXT,
                 payload: e.target.checked
               })
             }
@@ -233,7 +233,7 @@ export function FieldEdit({
               checked={allowPrePopulation}
               onChange={(e) =>
                 dispatch({
-                  type: Actions.EDIT_OPTIONS_ALLOW_PRE_POPULATION,
+                  type: Options.EDIT_OPTIONS_ALLOW_PRE_POPULATION,
                   payload: e.target.checked
                 })
               }

--- a/designer/client/src/MultilineTextFieldEdit.tsx
+++ b/designer/client/src/MultilineTextFieldEdit.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 
 import { TextFieldEdit } from '~/src/components/FieldEditors/TextFieldEdit.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Options } from '~/src/reducers/component/types.js'
 
 export function MultilineTextFieldEdit({ context = ComponentContext }) {
   const { state, dispatch } = useContext(context)
@@ -20,7 +20,7 @@ export function MultilineTextFieldEdit({ context = ComponentContext }) {
         value={options.rows || ''}
         onChange={(e) =>
           dispatch({
-            type: Actions.EDIT_OPTIONS_ROWS,
+            type: Options.EDIT_OPTIONS_ROWS,
             payload: e.target.value
           })
         }

--- a/designer/client/src/components/Autocomplete/Autocomplete.tsx
+++ b/designer/client/src/components/Autocomplete/Autocomplete.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Options } from '~/src/reducers/component/types.js'
 
 export function Autocomplete() {
   const { state, dispatch } = useContext(ComponentContext)
@@ -26,7 +26,7 @@ export function Autocomplete() {
         value={options.autocomplete || ''}
         onChange={(e) =>
           dispatch({
-            type: Actions.EDIT_OPTIONS_AUTOCOMPLETE,
+            type: Options.EDIT_OPTIONS_AUTOCOMPLETE,
             payload: e.target.value
           })
         }

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -16,7 +16,7 @@ import { DataContext } from '~/src/context/DataContext.js'
 import { addComponent } from '~/src/data/component/addComponent.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Fields, Meta } from '~/src/reducers/component/types.js'
 import { hasValidationErrors } from '~/src/validations.js'
 
 function useComponentCreate(props) {
@@ -51,15 +51,15 @@ function useComponentCreate(props) {
   }, [selectedComponent?.type])
 
   useEffect(() => {
-    dispatch({ type: Actions.SET_PAGE, payload: page.path })
+    dispatch({ type: Meta.SET_PAGE, payload: page.path })
   }, [page.path])
 
   useLayoutEffect(() => {
     if (hasValidated && !hasErrors) {
       handleSubmit()
         .then()
-        .catch((err) => {
-          logger.error('ComponentCreate', err)
+        .catch((error: unknown) => {
+          logger.error(error, 'ComponentCreate')
         })
     }
   }, [hasValidated, hasErrors])
@@ -68,7 +68,7 @@ function useComponentCreate(props) {
     e?.preventDefault()
 
     if (!hasValidated) {
-      dispatch({ type: Actions.VALIDATE })
+      dispatch({ type: Meta.VALIDATE })
       return
     }
 
@@ -90,7 +90,7 @@ function useComponentCreate(props) {
 
   const handleTypeChange = (component: ComponentDef) => {
     dispatch({
-      type: Actions.EDIT_TYPE,
+      type: Fields.EDIT_TYPE,
       payload: {
         type: component.type
       }
@@ -99,7 +99,7 @@ function useComponentCreate(props) {
 
   const reset = (e) => {
     e.preventDefault()
-    dispatch({ type: Actions.SET_COMPONENT })
+    dispatch({ type: Meta.SET_COMPONENT })
   }
 
   return {

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -14,7 +14,7 @@ import { DataContext } from '~/src/context/DataContext.js'
 import { findList } from '~/src/data/list/findList.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions as ComponentActions } from '~/src/reducers/component/types.js'
+import { Meta } from '~/src/reducers/component/types.js'
 import {
   ListsEditorContext,
   ListsEditorStateActions
@@ -62,7 +62,7 @@ export function ComponentListSelect() {
   useEffect(() => {
     if (!listsEditorState.isEditingList && isAddingNew) {
       dispatch({
-        type: ComponentActions.SET_SELECTED_LIST,
+        type: Meta.SET_SELECTED_LIST,
         payload: selectedList.name
       })
       setIsAddingNew(false)
@@ -71,7 +71,7 @@ export function ComponentListSelect() {
 
   const editList = (e: ChangeEvent<HTMLSelectElement>) => {
     dispatch({
-      type: ComponentActions.SET_SELECTED_LIST,
+      type: Meta.SET_SELECTED_LIST,
       payload: e.target.value
     })
   }

--- a/designer/client/src/components/CssClasses/CssClasses.tsx
+++ b/designer/client/src/components/CssClasses/CssClasses.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Options } from '~/src/reducers/component/types.js'
 
 export function CssClasses() {
   const { state, dispatch } = useContext(ComponentContext)
@@ -26,7 +26,7 @@ export function CssClasses() {
         value={options.classes || ''}
         onChange={(e) =>
           dispatch({
-            type: Actions.EDIT_OPTIONS_CLASSES,
+            type: Options.EDIT_OPTIONS_CLASSES,
             payload: e.target.value
           })
         }

--- a/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.tsx
+++ b/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Options } from '~/src/reducers/component/types.js'
 
 export function CustomValidationMessage() {
   const { state, dispatch } = useContext(ComponentContext)
@@ -29,7 +29,7 @@ export function CustomValidationMessage() {
         value={options.customValidationMessage ?? ''}
         onChange={(e) =>
           dispatch({
-            type: Actions.EDIT_OPTIONS_CUSTOM_MESSAGE,
+            type: Options.EDIT_OPTIONS_CUSTOM_MESSAGE,
             payload: e.target.value
           })
         }

--- a/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Options } from '~/src/reducers/component/types.js'
 
 interface Props {
   context: any // TODO
@@ -43,7 +43,7 @@ export function DateFieldEdit({ context = ComponentContext }: Props) {
           type="number"
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_OPTIONS_MAX_DAYS_IN_PAST,
+              type: Options.EDIT_OPTIONS_MAX_DAYS_IN_PAST,
               payload: e.target.value
             })
           }
@@ -69,7 +69,7 @@ export function DateFieldEdit({ context = ComponentContext }: Props) {
           type="number"
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE,
+              type: Options.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE,
               payload: e.target.value
             })
           }

--- a/designer/client/src/components/FieldEditors/DetailsEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DetailsEdit.tsx
@@ -5,7 +5,7 @@ import React, { useContext } from 'react'
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Fields } from '~/src/reducers/component/types.js'
 
 interface Props {
   context: any // TODO
@@ -32,7 +32,7 @@ export function DetailsEdit({ context = ComponentContext }: Props) {
         value={selectedComponent.title}
         onChange={(e) =>
           dispatch({
-            type: Actions.EDIT_TITLE,
+            type: Fields.EDIT_TITLE,
             payload: e.target.value
           })
         }
@@ -64,7 +64,7 @@ export function DetailsEdit({ context = ComponentContext }: Props) {
           rows="10"
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_CONTENT,
+              type: Fields.EDIT_CONTENT,
               payload: e.target.value
             })
           }

--- a/designer/client/src/components/FieldEditors/ListContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Options } from '~/src/reducers/component/types.js'
 
 interface Props {
   context: any // TODO
@@ -26,7 +26,7 @@ export function ListContentEdit({ context = ComponentContext }: Props) {
           checked={options.type === 'numbered'}
           onChange={() =>
             dispatch({
-              type: Actions.EDIT_OPTIONS_TYPE,
+              type: Options.EDIT_OPTIONS_TYPE,
               payload: options.type === 'numbered' ? undefined : 'numbered'
             })
           }

--- a/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Options, Schema } from '~/src/reducers/component/types.js'
 
 interface Props {
   context: any // TODO
@@ -44,7 +44,7 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
           type="number"
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_SCHEMA_MIN,
+              type: Schema.EDIT_SCHEMA_MIN,
               payload: e.target.value
             })
           }
@@ -70,7 +70,7 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
           type="string"
           onBlur={(e) =>
             dispatch({
-              type: Actions.EDIT_OPTIONS_PREFIX,
+              type: Options.EDIT_OPTIONS_PREFIX,
               payload: e.target.value
             })
           }
@@ -96,7 +96,7 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
           type="string"
           onBlur={(e) =>
             dispatch({
-              type: Actions.EDIT_OPTIONS_SUFFIX,
+              type: Options.EDIT_OPTIONS_SUFFIX,
               payload: e.target.value
             })
           }
@@ -122,7 +122,7 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
           type="number"
           onBlur={(e) =>
             dispatch({
-              type: Actions.EDIT_SCHEMA_MAX,
+              type: Schema.EDIT_SCHEMA_MAX,
               payload: e.target.value
             })
           }
@@ -148,7 +148,7 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
           type="number"
           onBlur={(e) =>
             dispatch({
-              type: Actions.EDIT_SCHEMA_PRECISION,
+              type: Schema.EDIT_SCHEMA_PRECISION,
               payload: e.target.value
             })
           }

--- a/designer/client/src/components/FieldEditors/ParaEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ParaEdit.tsx
@@ -5,7 +5,7 @@ import { Editor } from '~/src/Editor.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Fields, Options } from '~/src/reducers/component/types.js'
 
 interface Props {
   context: any // TODO
@@ -33,7 +33,7 @@ export function ParaEdit({ context = ComponentContext }: Props) {
           value={selectedComponent.content}
           onValueChange={(content) => {
             dispatch({
-              type: Actions.EDIT_CONTENT,
+              type: Fields.EDIT_CONTENT,
               payload: content
             })
           }}
@@ -52,7 +52,7 @@ export function ParaEdit({ context = ComponentContext }: Props) {
             value={options.condition}
             onChange={(e) =>
               dispatch({
-                type: Actions.EDIT_OPTIONS_CONDITION,
+                type: Options.EDIT_OPTIONS_CONDITION,
                 payload: e.target.value
               })
             }

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -5,7 +5,7 @@ import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { CustomValidationMessage } from '~/src/components/CustomValidationMessage/CustomValidationMessage.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Actions } from '~/src/reducers/component/types.js'
+import { Options, Schema } from '~/src/reducers/component/types.js'
 
 interface Props {
   context: any // TODO
@@ -46,7 +46,7 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
           type="number"
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_SCHEMA_MIN,
+              type: Schema.EDIT_SCHEMA_MIN,
               payload: e.target.value
             })
           }
@@ -72,7 +72,7 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
           type="number"
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_SCHEMA_MAX,
+              type: Schema.EDIT_SCHEMA_MAX,
               payload: e.target.value
             })
           }
@@ -98,7 +98,7 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
           type="number"
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_OPTIONS_MAX_WORDS,
+              type: Options.EDIT_OPTIONS_MAX_WORDS,
               payload: e.target.value
             })
           }
@@ -124,7 +124,7 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
           type="number"
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_SCHEMA_LENGTH,
+              type: Schema.EDIT_SCHEMA_LENGTH,
               payload: e.target.value
             })
           }
@@ -148,7 +148,7 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
           value={schema.regex || ''}
           onChange={(e) =>
             dispatch({
-              type: Actions.EDIT_SCHEMA_REGEX,
+              type: Schema.EDIT_SCHEMA_REGEX,
               payload: e.target.value
             })
           }

--- a/designer/client/src/reducers/component/componentReducer.fields.ts
+++ b/designer/client/src/reducers/component/componentReducer.fields.ts
@@ -4,7 +4,7 @@ export function fieldsReducer(
   state,
   action: {
     type: Fields
-    payload: any
+    payload?: unknown
   }
 ) {
   const { type, payload } = action

--- a/designer/client/src/reducers/component/componentReducer.meta.ts
+++ b/designer/client/src/reducers/component/componentReducer.meta.ts
@@ -6,7 +6,7 @@ export function metaReducer(
   state,
   action: {
     type: Meta
-    payload: any
+    payload?: unknown
   }
 ) {
   const { type, payload } = action

--- a/designer/client/src/reducers/component/componentReducer.options.ts
+++ b/designer/client/src/reducers/component/componentReducer.options.ts
@@ -7,7 +7,7 @@ interface ConditionAction {
 
 interface AnyAction {
   type: Options
-  payload: any
+  payload?: unknown
 }
 
 type OptionsActions = ConditionAction | AnyAction

--- a/designer/client/src/reducers/component/componentReducer.schema.ts
+++ b/designer/client/src/reducers/component/componentReducer.schema.ts
@@ -4,7 +4,7 @@ export function schemaReducer(
   state,
   action: {
     type: Schema
-    payload: any
+    payload?: unknown
   }
 ) {
   const { type, payload } = action

--- a/designer/client/src/reducers/component/componentReducer.test.tsx
+++ b/designer/client/src/reducers/component/componentReducer.test.tsx
@@ -1,3 +1,5 @@
+import { ComponentType, type ComponentDef } from '@defra/forms-model'
+
 import { fieldsReducer } from '~/src/reducers/component/componentReducer.fields.js'
 import {
   componentReducer,
@@ -14,6 +16,14 @@ import {
 } from '~/src/reducers/component/types.js'
 
 describe('Component reducer', () => {
+  const component: ComponentDef = {
+    name: 'field',
+    title: 'Title',
+    type: ComponentType.TextField,
+    options: {},
+    schema: {}
+  }
+
   test('getSubReducer returns correct reducer', () => {
     const metaAction = Meta.NEW_COMPONENT
     const schemaAction = Schema.EDIT_SCHEMA_MIN
@@ -26,16 +36,39 @@ describe('Component reducer', () => {
     expect(getSubReducer(fieldsAction)).toEqual(fieldsReducer)
   })
 
-  test('componentReducer adds hasValidated flag correctly', () => {
-    expect(
-      componentReducer(
-        {},
-        { type: Fields.EDIT_TITLE, payload: 'changing title' }
-      )
-    ).toEqual(
-      expect.objectContaining({
-        hasValidated: false
-      })
-    )
+  test('componentReducer sets hasValidated: false', () => {
+    const title = 'Updated title'
+
+    const action = {
+      type: Fields.EDIT_TITLE,
+      payload: title
+    }
+
+    const state = {
+      selectedComponent: component,
+      hasValidated: true
+    }
+
+    expect(componentReducer(state, action)).toEqual({
+      selectedComponent: { ...component, title },
+      hasValidated: false
+    })
+  })
+
+  test('componentReducer sets hasValidated: true', () => {
+    const action = {
+      type: Meta.VALIDATE
+    }
+
+    const state = {
+      selectedComponent: component,
+      hasValidated: false
+    }
+
+    expect(componentReducer(state, action)).toEqual({
+      selectedComponent: component,
+      errors: expect.any(Object),
+      hasValidated: true
+    })
   })
 })

--- a/designer/client/src/reducers/component/componentReducer.test.tsx
+++ b/designer/client/src/reducers/component/componentReducer.test.tsx
@@ -6,14 +6,19 @@ import {
 import { metaReducer } from '~/src/reducers/component/componentReducer.meta.js'
 import { optionsReducer } from '~/src/reducers/component/componentReducer.options.js'
 import { schemaReducer } from '~/src/reducers/component/componentReducer.schema.js'
-import { Actions } from '~/src/reducers/component/types.js'
+import {
+  Fields,
+  Meta,
+  Options,
+  Schema
+} from '~/src/reducers/component/types.js'
 
 describe('Component reducer', () => {
   test('getSubReducer returns correct reducer', () => {
-    const metaAction = Actions.NEW_COMPONENT
-    const schemaAction = Actions.EDIT_SCHEMA_MIN
-    const fieldsAction = Actions.EDIT_TITLE
-    const optionsAction = Actions.EDIT_OPTIONS_HIDE_TITLE
+    const metaAction = Meta.NEW_COMPONENT
+    const schemaAction = Schema.EDIT_SCHEMA_MIN
+    const fieldsAction = Fields.EDIT_TITLE
+    const optionsAction = Options.EDIT_OPTIONS_HIDE_TITLE
 
     expect(getSubReducer(metaAction)).toEqual(metaReducer)
     expect(getSubReducer(schemaAction)).toEqual(schemaReducer)
@@ -25,7 +30,7 @@ describe('Component reducer', () => {
     expect(
       componentReducer(
         {},
-        { type: Actions.EDIT_TITLE, payload: 'changing title' }
+        { type: Fields.EDIT_TITLE, payload: 'changing title' }
       )
     ).toEqual(
       expect.objectContaining({

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -43,16 +43,6 @@ export const ComponentContext = createContext<{
 })
 
 /**
- * Action types combined
- */
-export const actionTypes = {
-  ...Meta,
-  ...Schema,
-  ...Fields,
-  ...Options
-}
-
-/**
  * Reducers mapped by action type
  */
 const reducerByActionType = [
@@ -73,10 +63,6 @@ export function getSubReducer(type: Action) {
   return reducerByActionType.find((a) => valueIsInEnum(type, a[0]))?.[1]
 }
 
-const isNotValidate = (type: Action) => {
-  return Object.values(actionTypes).includes(type)
-}
-
 export function componentReducer(
   state,
   action: {
@@ -87,7 +73,7 @@ export function componentReducer(
   const { type } = action
   const { selectedComponent } = state
 
-  if (isNotValidate(type)) {
+  if (type !== Meta.VALIDATE) {
     state.hasValidated = false
   }
 

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -8,12 +8,12 @@ import { metaReducer } from '~/src/reducers/component/componentReducer.meta.js'
 import { optionsReducer } from '~/src/reducers/component/componentReducer.options.js'
 import { schemaReducer } from '~/src/reducers/component/componentReducer.schema.js'
 import {
-  type ComponentActions,
-  Meta,
-  Schema,
   Fields,
+  Meta,
   Options,
-  Actions
+  Schema,
+  type Action,
+  type Actions
 } from '~/src/reducers/component/types.js'
 
 interface ComponentState {
@@ -27,13 +27,14 @@ interface ComponentState {
 const defaultValues = {
   selectedComponent: {}
 }
+
 /**
- * Context providing the {@link ComponentState} and {@link dispatch} for changing any values specified by {@link Actions}
+ * Context providing the {@link ComponentState} and {@link Dispatch} for changing any values specified by the enum type
  */
 export const ComponentContext = createContext<{
   state: ComponentState
   dispatch: Dispatch<{
-    type: string
+    type: Action
     payload?: string
   }>
 }>({
@@ -42,35 +43,45 @@ export const ComponentContext = createContext<{
 })
 
 /**
- * A map of the Actions and the associated reducer
+ * Action types combined
  */
-const ActionsReducerCollection = [
+export const actionTypes = {
+  ...Meta,
+  ...Schema,
+  ...Fields,
+  ...Options
+}
+
+/**
+ * Reducers mapped by action type
+ */
+const reducerByActionType = [
   [Meta, metaReducer],
   [Options, optionsReducer],
   [Fields, fieldsReducer],
   [Schema, schemaReducer]
-]
+] as const
 
-export function valueIsInEnum<T>(value: keyof ComponentActions, enumType: T) {
-  return Object.values(enumType).includes(value)
+export function valueIsInEnum(type: Action, collection: Actions) {
+  return Object.values(collection).includes(type)
 }
 
 /**
- * when an {@link Actions} is passed to getSubReducer, it will return the associated reducer defined in {@link ActionsReducerCollection}
+ * when an enum is passed to getSubReducer, it will return the associated reducer defined in {@link reducerByActionType}
  */
-export function getSubReducer(type) {
-  return ActionsReducerCollection.find((a) => valueIsInEnum(type, a[0]))?.[1]
+export function getSubReducer(type: Action) {
+  return reducerByActionType.find((a) => valueIsInEnum(type, a[0]))?.[1]
 }
 
-const isNotValidate = (type): type is Meta.VALIDATE => {
-  return Object.values(Actions).includes(type)
+const isNotValidate = (type: Action) => {
+  return Object.values(actionTypes).includes(type)
 }
 
 export function componentReducer(
   state,
   action: {
-    type: ComponentActions
-    payload: any
+    type: Action
+    payload?: unknown
   }
 ) {
   const { type } = action
@@ -80,7 +91,7 @@ export function componentReducer(
     state.hasValidated = false
   }
 
-  const subReducer: any = getSubReducer(type)
+  const subReducer = getSubReducer(type)
 
   if (subReducer) {
     return {
@@ -110,7 +121,7 @@ export const initComponentState = (props) => {
 }
 
 /**
- * Allows components to retrieve {@link ComponentState} and {@link dispatch} from any component nested within `<ComponentContextProvider>`
+ * Allows components to retrieve {@link ComponentState} and {@link Dispatch} from any component nested within `<ComponentContextProvider>`
  */
 export const ComponentContextProvider = (props) => {
   const { children, ...rest } = props

--- a/designer/client/src/reducers/component/types.ts
+++ b/designer/client/src/reducers/component/types.ts
@@ -53,10 +53,10 @@ export enum Options {
   EDIT_OPTIONS_ALLOW_PRE_POPULATION = 'EDIT_OPTIONS_ALLOW_PRE_POPULATION'
 }
 
-export const Actions = {
-  ...Meta,
-  ...Schema,
-  ...Fields,
-  ...Options
-}
-export type ComponentActions = typeof Actions
+export type Action = Fields | Meta | Options | Schema
+
+export type Actions =
+  | typeof Fields
+  | typeof Meta
+  | typeof Options
+  | typeof Schema

--- a/designer/client/src/reducers/listReducer.tsx
+++ b/designer/client/src/reducers/listReducer.tsx
@@ -38,7 +38,10 @@ export const ListContext = createContext<{
  */
 export function listReducer(
   state: ListState = {},
-  action: { type: ListActions; payload: any }
+  action: {
+    type: ListActions
+    payload?: unknown
+  }
 ): ListState {
   const { type, payload } = action
   const { selectedList, selectedItem, selectedItemIndex } = state
@@ -178,7 +181,7 @@ export function listReducer(
 }
 
 /**
- * Allows components to retrieve {@link ListState} and {@link dispatch} from any component nested within `<ListContextProvider>`
+ * Allows components to retrieve {@link ListState} and {@link Dispatch} from any component nested within `<ListContextProvider>`
  */
 export const ListContextProvider = (props: {
   children?: ReactNode


### PR DESCRIPTION
This PR fixes a bug where `hasValidated` was set for all component actions

I've switched to the original names as non-option `EDIT_*` and `SET_*` events would be great for auditing

```patch
  import {
-   Actions
+   Fields,
+   Meta,
+   Options,
+   Schema
  } from '~/src/reducers/component/types.js'
```