### PR TITLE
Show editor 404 when definition is missing

### DIFF
--- a/designer/client/src/Designer.tsx
+++ b/designer/client/src/Designer.tsx
@@ -1,4 +1,4 @@
-import { type FormDefinition } from '@defra/forms-model'
+import { type FormDefinition, type FormMetadata } from '@defra/forms-model'
 import React, { Component } from 'react'
 
 import { Menu } from '~/src/components/Menu/Menu.jsx'
@@ -8,8 +8,8 @@ import { FlyoutContext } from '~/src/context/FlyoutContext.js'
 import * as form from '~/src/lib/form.js'
 
 interface Props {
-  id: string
-  slug: string
+  metadata: FormMetadata
+  definition: FormDefinition
   previewUrl: string
 }
 
@@ -19,18 +19,15 @@ interface State {
 }
 
 export class Designer extends Component<Props, State> {
-  state: State = { flyoutCount: 0 }
+  constructor(props: Props) {
+    super(props)
 
-  get id() {
-    return this.props.id
-  }
+    const { definition } = this.props
 
-  get slug() {
-    return this.props.slug
-  }
-
-  get previewUrl() {
-    return this.props.previewUrl
+    this.state = {
+      data: definition,
+      flyoutCount: 0
+    }
   }
 
   incrementFlyoutCounter = () => {
@@ -44,7 +41,8 @@ export class Designer extends Component<Props, State> {
   }
 
   get = async () => {
-    const definition = await form.get(this.id)
+    const { metadata } = this.props
+    const definition = await form.get(metadata.id)
 
     this.setState({
       data: definition
@@ -54,16 +52,15 @@ export class Designer extends Component<Props, State> {
   }
 
   save = async (definition: FormDefinition) => {
-    await form.save(this.id, definition)
+    const { metadata } = this.props
+
+    await form.save(metadata.id, definition)
     return this.get()
   }
 
-  async componentDidMount() {
-    await this.get()
-  }
-
   render() {
-    const { flyoutCount, data } = this.state
+    const { metadata, previewUrl } = this.props
+    const { data, flyoutCount } = this.state
 
     const flyoutContextProviderValue = {
       count: flyoutCount,
@@ -75,8 +72,8 @@ export class Designer extends Component<Props, State> {
       <DataContext.Provider value={dataContextProviderValue}>
         <FlyoutContext.Provider value={flyoutContextProviderValue}>
           <div id="designer">
-            <Menu id={this.id} />
-            <Visualisation slug={this.slug} previewUrl={this.previewUrl} />
+            <Menu id={metadata.id} />
+            <Visualisation slug={metadata.slug} previewUrl={previewUrl} />
           </div>
         </FlyoutContext.Provider>
       </DataContext.Provider>

--- a/designer/client/src/Designer.tsx
+++ b/designer/client/src/Designer.tsx
@@ -84,11 +84,7 @@ export class Designer extends Component<Props, State> {
         <FlyoutContext.Provider value={flyoutContextProviderValue}>
           <div id="designer">
             <Menu id={this.id} />
-            <Visualisation
-              id={this.id}
-              slug={this.slug}
-              previewUrl={this.previewUrl}
-            />
+            <Visualisation slug={this.slug} previewUrl={this.previewUrl} />
           </div>
         </FlyoutContext.Provider>
       </DataContext.Provider>

--- a/designer/client/src/Designer.tsx
+++ b/designer/client/src/Designer.tsx
@@ -15,12 +15,11 @@ interface Props {
 
 interface State {
   flyoutCount?: number
-  loading?: boolean
   data?: FormDefinition
 }
 
 export class Designer extends Component<Props, State> {
-  state: State = { loading: true, flyoutCount: 0 }
+  state: State = { flyoutCount: 0 }
 
   get id() {
     return this.props.id
@@ -61,17 +60,10 @@ export class Designer extends Component<Props, State> {
 
   async componentDidMount() {
     await this.get()
-
-    this.setState({
-      loading: false
-    })
   }
 
   render() {
-    const { flyoutCount, data, loading } = this.state
-    if (loading) {
-      return <p className="govuk-body">Loading ...</p>
-    }
+    const { flyoutCount, data } = this.state
 
     const flyoutContextProviderValue = {
       count: flyoutCount,

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -44,7 +44,7 @@ describe('Menu', () => {
   afterEach(cleanup)
 
   it('Renders button strings correctly', () => {
-    customRender(<Menu />)
+    customRender(<Menu id="1234" />)
 
     expect(getByText('Add page')).toBeInTheDocument()
     expect(getByText('Add link')).toBeInTheDocument()
@@ -56,7 +56,7 @@ describe('Menu', () => {
   })
 
   it('Can open flyouts and close them', async () => {
-    customRender(<Menu />)
+    customRender(<Menu id="1234" />)
     expect(queryByTestId('flyout-1')).not.toBeInTheDocument()
 
     await act(() => userEvent.click(getByText('Summary behaviour')))
@@ -67,7 +67,7 @@ describe('Menu', () => {
   })
 
   it('clicking on a summary tab shows different tab content', async () => {
-    customRender(<Menu />)
+    customRender(<Menu id="1234" />)
 
     await act(() => userEvent.click(getByText('Summary')))
     expect(getByTestId('flyout-1')).toBeVisible()
@@ -95,7 +95,7 @@ describe('Menu', () => {
   })
 
   it('flyouts close on Save', async () => {
-    customRender(<Menu />)
+    customRender(<Menu id="1234" />)
 
     await act(() => userEvent.click(getByText('Summary behaviour')))
     expect(queryByTestId('flyout-1')).toBeInTheDocument()

--- a/designer/client/src/components/Menu/SubMenu.tsx
+++ b/designer/client/src/components/Menu/SubMenu.tsx
@@ -3,7 +3,7 @@ import React, { useContext, useRef } from 'react'
 import { DataContext } from '~/src/context/DataContext.js'
 
 interface Props {
-  id?: string
+  id: string
 }
 
 export function SubMenu({ id }: Props) {

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -87,7 +87,7 @@ describe('Page', () => {
       <Page
         page={data.pages[0]}
         previewUrl={'https://localhost:3009'}
-        id={'aa'}
+        slug={'aa'}
         layout={{}}
       />,
       providerProps
@@ -111,7 +111,7 @@ describe('Page', () => {
       <Page
         page={data.pages[0]}
         previewUrl={'https://localhost:3009'}
-        id={'aa'}
+        slug={'aa'}
         layout={{}}
       />,
       providerProps
@@ -129,7 +129,7 @@ describe('Page', () => {
       <Page
         page={data.pages[0]}
         previewUrl={'https://localhost:3009'}
-        id={'aa'}
+        slug={'aa'}
         layout={{}}
       />,
       providerProps
@@ -145,7 +145,7 @@ describe('Page', () => {
       <Page
         page={data.pages[0]}
         previewUrl={'https://localhost:3009'}
-        id={'aa'}
+        slug={'aa'}
         layout={{}}
       />,
       providerProps

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -56,7 +56,6 @@ const ComponentList = (props: {
 export const Page = (props: {
   page: PageType | RepeatingFieldPage
   previewUrl: string
-  id: string
   slug: string
   layout?: CSSProperties
 }) => {

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -57,7 +57,7 @@ describe('Visualisation', () => {
     }
 
     const { rerender } = customRender(
-      <Visualisation previewUrl={'http://localhost:3000'} id={'aa'} />,
+      <Visualisation previewUrl={'http://localhost:3000'} slug={'aa'} />,
       providerProps
     )
 
@@ -77,12 +77,12 @@ describe('Visualisation', () => {
       path: '/3'
     }
 
-    await rerender.call(
+    rerender.call(
       {
         data: { ...data, pages: [...data.pages, newPage] },
         save: jest.fn()
       },
-      <Visualisation previewUrl={'http://localhost:3000'} id={'aa'} />
+      <Visualisation previewUrl={'http://localhost:3000'} slug={'aa'} />
     )
 
     await waitFor(() =>
@@ -113,7 +113,7 @@ describe('Visualisation', () => {
     }
 
     customRender(
-      <Visualisation previewUrl={'http://localhost:3000'} id={'aa'} />,
+      <Visualisation previewUrl={'http://localhost:3000'} slug={'aa'} />,
       providerProps
     )
 
@@ -126,7 +126,7 @@ describe('Visualisation', () => {
     expect(queryByTestId('flyout-0')).not.toBeInTheDocument()
 
     await act(async () => {
-      $lineTitle.parentElement!.focus()
+      $lineTitle.parentElement?.focus()
       await userEvent.keyboard('[Enter]')
     })
 

--- a/designer/client/src/components/Visualisation/Visualisation.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.tsx
@@ -9,7 +9,6 @@ import {
 import { DataContext } from '~/src/context/DataContext.js'
 
 interface Props {
-  id: string
   slug: string
   previewUrl: string
 }
@@ -31,7 +30,7 @@ export function Visualisation(props: Props) {
   const { layout } = useVisualisation(ref)
   const { data } = useContext(DataContext)
 
-  const { previewUrl, id, slug } = props
+  const { previewUrl, slug } = props
   const { pages } = data
 
   const wrapperStyle = layout && {
@@ -50,7 +49,6 @@ export function Visualisation(props: Props) {
                 page={page}
                 previewUrl={previewUrl}
                 layout={layout?.nodes[index]}
-                id={id}
                 slug={slug}
               />
             ))}

--- a/designer/client/src/index.tsx
+++ b/designer/client/src/index.tsx
@@ -1,3 +1,4 @@
+import { type FormMetadata, type FormDefinition } from '@defra/forms-model'
 import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 
@@ -9,23 +10,44 @@ initI18n().catch((error: unknown) => {
   logger.error(error, 'I18n')
 })
 
-const container = document.querySelector('.app-editor')
+const $container = document.querySelector('.app-form-editor')
+const $definition = document.querySelector('.app-form-definition')
+const $metadata = document.querySelector('.app-form-metadata')
 
 export class App extends Component {
   render() {
     if (
-      !(container instanceof HTMLElement) ||
-      !container.dataset.id ||
-      !container.dataset.slug ||
-      !container.dataset.previewUrl
+      !($container instanceof HTMLElement) ||
+      !($metadata instanceof HTMLScriptElement) ||
+      !($definition instanceof HTMLScriptElement) ||
+      !$container.dataset.previewUrl ||
+      !$definition.textContent ||
+      !$metadata.textContent
     ) {
-      throw new Error('Missing form data attributes')
+      throw new Error('Missing form data')
+    }
+
+    let definition: FormDefinition | undefined
+    let metadata: FormMetadata | undefined
+
+    try {
+      definition = JSON.parse($definition.textContent) as FormDefinition
+      metadata = JSON.parse($metadata.textContent) as FormMetadata
+    } catch (error) {
+      logger.error(error, 'App')
+      throw error
     }
 
     // Extract from HTML data-* attributes
-    const { id, slug, previewUrl } = container.dataset
-    return <Designer id={id} slug={slug} previewUrl={previewUrl} />
+    const { previewUrl } = $container.dataset
+    return (
+      <Designer
+        metadata={metadata}
+        definition={definition}
+        previewUrl={previewUrl}
+      />
+    )
   }
 }
 
-ReactDOM.render(<App />, container)
+ReactDOM.render(<App />, $container)

--- a/designer/package.json
+++ b/designer/package.json
@@ -65,7 +65,8 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-simple-code-editor": "^0.13.1",
-    "resolve": "^1.22.8"
+    "resolve": "^1.22.8",
+    "serialize-javascript": "^6.0.2"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.3.4",

--- a/designer/server/src/common/nunjucks/filters/format-json.js
+++ b/designer/server/src/common/nunjucks/filters/format-json.js
@@ -1,0 +1,8 @@
+import serialize from 'serialize-javascript'
+
+/**
+ * @param {object} value
+ */
+export function formatJSON(value) {
+  return serialize(value, { isJSON: true })
+}

--- a/designer/server/src/common/nunjucks/filters/index.js
+++ b/designer/server/src/common/nunjucks/filters/index.js
@@ -1,4 +1,3 @@
-import { formatCurrency } from '~/src/common/nunjucks/filters/format-currency.js'
-import { formatDate } from '~/src/common/nunjucks/filters/format-date.js'
-
-export { formatDate, formatCurrency }
+export { formatCurrency } from '~/src/common/nunjucks/filters/format-currency.js'
+export { formatDate } from '~/src/common/nunjucks/filters/format-date.js'
+export { formatJSON } from '~/src/common/nunjucks/filters/format-json.js'

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -108,8 +108,9 @@ function getFormOverviewNotification(
 
 /**
  * @param {FormMetadata} metadata
+ * @param {FormDefinition} definition
  */
-export function editorViewModel(metadata) {
+export function editorViewModel(metadata, definition) {
   const pageTitle = metadata.title
   const formPath = `/library/${metadata.slug}`
 
@@ -127,6 +128,7 @@ export function editorViewModel(metadata) {
       size: 'large'
     },
     form: metadata,
+    formDefinition: definition,
     previewUrl: config.previewUrl
   }
 }
@@ -149,4 +151,5 @@ export function getFormSpecificNavigation(formPath, activePage = '') {
 
 /**
  * @typedef {import('@defra/forms-model').FormMetadata} FormMetadata
+ * @typedef {import('@defra/forms-model').FormDefinition} FormDefinition
  */

--- a/designer/server/src/routes/forms/library.js
+++ b/designer/server/src/routes/forms/library.js
@@ -72,8 +72,11 @@ export default [
 
         // Retrieve form by slug
         const form = await forms.get(params.slug, token)
-        const model = library.editorViewModel(form)
 
+        // Retrieve definition by ID
+        await forms.getDraftFormDefinition(form.id, token)
+
+        const model = library.editorViewModel(form)
         return h.view('forms/editor', model)
       },
       auth: {

--- a/designer/server/src/routes/forms/library.js
+++ b/designer/server/src/routes/forms/library.js
@@ -74,9 +74,9 @@ export default [
         const form = await forms.get(params.slug, token)
 
         // Retrieve definition by ID
-        await forms.getDraftFormDefinition(form.id, token)
+        const definition = await forms.getDraftFormDefinition(form.id, token)
 
-        const model = library.editorViewModel(form)
+        const model = library.editorViewModel(form, definition)
         return h.view('forms/editor', model)
       },
       auth: {

--- a/designer/server/src/routes/forms/library.test.js
+++ b/designer/server/src/routes/forms/library.test.js
@@ -22,28 +22,33 @@ describe('Forms library routes', () => {
   /**
    * @satisfies {FormMetadataAuthor}
    */
-  const author = { id: authorId, displayName: authorDisplayName }
+  const author = {
+    id: authorId,
+    displayName: authorDisplayName
+  }
+
+  /**
+   * @satisfies {FormMetadata}
+   */
+  const formMetadata = {
+    id: '661e4ca5039739ef2902b214',
+    slug: 'my-form-slug',
+    title: 'Test form',
+    organisation: 'Defra',
+    teamName: 'Defra Forms',
+    teamEmail: 'defraforms@defra.gov.uk',
+    draft: {
+      createdAt: now,
+      createdBy: author,
+      updatedAt: now,
+      updatedBy: author
+    }
+  }
 
   test('Forms library list page', async () => {
-    const title = 'My form slug'
+    const { title } = formMetadata
 
-    // Mock the api call to forms-manager
-    jest.mocked(forms.list).mockResolvedValueOnce([
-      {
-        id: '661e4ca5039739ef2902b214',
-        title,
-        slug: 'my-form-slug',
-        organisation: 'Defra',
-        teamName: 'Forms',
-        teamEmail: 'defraforms@defra.gov.uk',
-        draft: {
-          createdAt: now,
-          createdBy: author,
-          updatedAt: now,
-          updatedBy: author
-        }
-      }
-    ])
+    jest.mocked(forms.list).mockResolvedValueOnce([formMetadata])
 
     const options = {
       method: 'GET',
@@ -62,24 +67,9 @@ describe('Forms library routes', () => {
   })
 
   test('Form editor page', async () => {
-    const id = '661e4ca5039739ef2902b214'
-    const slug = 'my-form-slug'
+    const { id, slug } = formMetadata
 
-    // Mock the api call to forms-manager
-    jest.mocked(forms.get).mockResolvedValueOnce({
-      id,
-      slug,
-      title: 'My form slug',
-      organisation: 'Defra',
-      teamName: 'Forms',
-      teamEmail: 'defraforms@defra.gov.uk',
-      draft: {
-        createdAt: now,
-        createdBy: author,
-        updatedAt: now,
-        updatedBy: author
-      }
-    })
+    jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
 
     const options = {
       method: 'get',
@@ -96,29 +86,12 @@ describe('Forms library routes', () => {
   })
 
   test('Form overview has draft buttons in side bar', async () => {
-    const id = '661e4ca5039739ef2902b214'
-    const slug = 'my-form-slug'
-
-    // Mock the api call to forms-manager
     jest.mocked(forms.get).mockResolvedValueOnce({
-      id,
-      slug,
-      title: 'My form slug',
-      organisation: 'Defra',
-      teamName: 'Forms',
-      teamEmail: 'defraforms@defra.gov.uk',
-      live: {
-        createdAt: new Date(),
-        createdBy: {
-          displayName: 'Joe Bloggs',
-          id: '1234'
-        },
-        updatedAt: new Date(),
-        updatedBy: {
-          displayName: 'Joe Bloggs',
-          id: '1234'
-        }
-      }
+      ...formMetadata,
+
+      // Switch draft with live for test
+      live: formMetadata.draft,
+      draft: undefined
     })
 
     const options = {
@@ -137,30 +110,7 @@ describe('Forms library routes', () => {
   })
 
   test('Form overview has live buttons in side bar', async () => {
-    const id = '661e4ca5039739ef2902b214'
-    const slug = 'my-form-slug'
-
-    // Mock the api call to forms-manager
-    jest.mocked(forms.get).mockResolvedValueOnce({
-      id,
-      slug,
-      title: 'My form slug',
-      organisation: 'Defra',
-      teamName: 'Forms',
-      teamEmail: 'defraforms@defra.gov.uk',
-      draft: {
-        createdAt: new Date(),
-        createdBy: {
-          displayName: 'Joe Bloggs',
-          id: '1234'
-        },
-        updatedAt: new Date(),
-        updatedBy: {
-          displayName: 'Joe Bloggs',
-          id: '1234'
-        }
-      }
-    })
+    jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
 
     const options = {
       method: 'get',
@@ -180,5 +130,6 @@ describe('Forms library routes', () => {
 })
 
 /**
+ * @typedef {import('@defra/forms-model').FormMetadata} FormMetadata
  * @typedef {import('@defra/forms-model').FormMetadataAuthor} FormMetadataAuthor
  */

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -15,10 +15,8 @@
 {% block content %}
   {{ appPageBody({
     heading: pageHeading,
-    classes: "govuk-grid-column-full app-editor",
+    classes: "govuk-grid-column-full app-form-editor",
     attributes: {
-      "data-id": form.id,
-      "data-slug": form.slug,
       "data-preview-url": previewUrl
     }
   }) }}
@@ -29,4 +27,14 @@
 {% block bodyEnd %}
   {{ super() }}
   <script type="module" src="{{ getAssetPath("editor.js") }}"></script>
+
+  <!-- Form metadata JSON -->
+  <script type="application/json" class="app-form-metadata">
+    {{ form | formatJSON | safe | indent(4) }}
+  </script>
+
+  <!-- Form definition JSON -->
+  <script type="application/json" class="app-form-definition">
+    {{ formDefinition | formatJSON | safe | indent(4) }}
+  </script>
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "@types/react": "^17.0.76",
         "@types/react-dom": "^17.0.25",
         "@types/resolve": "^1.20.6",
+        "@types/serialize-javascript": "^5.0.4",
         "@types/slug": "^5.0.8",
         "@types/uuid": "^9.0.8",
         "@types/webpack-assets-manifest": "^5.1.4",
@@ -115,7 +116,8 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-simple-code-editor": "^0.13.1",
-        "resolve": "^1.22.8"
+        "resolve": "^1.22.8",
+        "serialize-javascript": "^6.0.2"
       },
       "devDependencies": {
         "@testing-library/dom": "^9.3.4",
@@ -5104,6 +5106,12 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
+    },
+    "node_modules/@types/serialize-javascript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/serialize-javascript/-/serialize-javascript-5.0.4.tgz",
+      "integrity": "sha512-Z2R7UKFuNWCP8eoa2o9e5rkD3hmWxx/1L0CYz0k2BZzGh0PhEVMp9kfGiqEml/0IglwNERXZ2hwNzIrSz/KHTA==",
+      "optional": true
     },
     "node_modules/@types/slug": {
       "version": "5.0.8",
@@ -15795,7 +15803,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "devOptional": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -16943,7 +16950,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "devOptional": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/react": "^17.0.76",
     "@types/react-dom": "^17.0.25",
     "@types/resolve": "^1.20.6",
+    "@types/serialize-javascript": "^5.0.4",
     "@types/slug": "^5.0.8",
     "@types/uuid": "^9.0.8",
     "@types/webpack-assets-manifest": "^5.1.4",


### PR DESCRIPTION
This PR ensures the editor page shows a 404 error when the form definition is missing

The editor loads the JSON from `<script type="application/json">` to avoid hitting **forms-manager** twice

```js
<Designer
  metadata={metadata}
  definition={definition}
  previewUrl={previewUrl}
/>
```

Previously the editor would get stuck whilst loading via the browser API