### PR TITLE
Render null for unsupported conditional fields

### DIFF
--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.tsx
@@ -5,8 +5,7 @@ import {
   relativeDateOrTimeOperatorNames,
   ComponentType,
   ConditionValue,
-  type OperatorName,
-  type ConditionalComponentType
+  type OperatorName
 } from '@defra/forms-model'
 import React from 'react'
 
@@ -17,10 +16,7 @@ import { SelectValues } from '~/src/conditions/SelectValues.jsx'
 import { TextValues } from '~/src/conditions/TextValues.jsx'
 import { tryParseInt } from '~/src/conditions/inline-condition-helpers.js'
 
-function DateTimeComponent(
-  fieldType: ConditionalComponentType,
-  operator: OperatorName
-) {
+function DateTimeComponent(fieldType: ComponentType, operator: OperatorName) {
   const operatorConfig = getOperatorConfig(fieldType, operator)
 
   let CustomRendering:
@@ -111,7 +107,7 @@ function DateTimeComponent(
 interface FieldDef {
   label: string
   name: string
-  type: ConditionalComponentType
+  type: ComponentType
   values?: any[]
 }
 

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.tsx
@@ -5,7 +5,8 @@ import {
   relativeDateOrTimeOperatorNames,
   ComponentType,
   ConditionValue,
-  type OperatorName
+  type OperatorName,
+  type ConditionalComponentType
 } from '@defra/forms-model'
 import React from 'react'
 
@@ -17,22 +18,34 @@ import { TextValues } from '~/src/conditions/TextValues.jsx'
 import { tryParseInt } from '~/src/conditions/inline-condition-helpers.js'
 
 function DateTimeComponent(
-  fieldType: ComponentType.DatePartsField | ComponentType.TimeField,
+  fieldType: ConditionalComponentType,
   operator: OperatorName
 ) {
   const operatorConfig = getOperatorConfig(fieldType, operator)
 
-  const absoluteDateTimeRenderFunctions = {
-    [ComponentType.DatePartsField]: AbsoluteDateValues,
-    [ComponentType.TimeField]: AbsoluteTimeValues
-  }
+  let CustomRendering:
+    | typeof AbsoluteDateValues
+    | typeof AbsoluteTimeValues
+    | undefined
 
-  const CustomRendering = absoluteDateTimeRenderFunctions[fieldType]
+  switch (fieldType) {
+    case ComponentType.DatePartsField:
+      CustomRendering = AbsoluteDateValues
+      break
+
+    case ComponentType.TimeField:
+      CustomRendering = AbsoluteTimeValues
+      break
+  }
 
   if (absoluteDateOrTimeOperatorNames.includes(operator)) {
     const pad = (num: number) => num.toString().padStart(2, '0')
 
     return function CustomRenderingWrapper({ value, updateValue }) {
+      if (!CustomRendering) {
+        return null
+      }
+
       const transformUpdatedValue = (value) => {
         let transformed
         switch (fieldType) {

--- a/model/src/components/component-types.ts
+++ b/model/src/components/component-types.ts
@@ -1,5 +1,4 @@
 import { ComponentSubType, ComponentType } from '~/src/components/enums.js'
-import { hasConditionSupport } from '~/src/components/helpers.js'
 import { type ComponentDef } from '~/src/components/types.js'
 
 export const ComponentTypes: ComponentDef[] = [
@@ -166,6 +165,3 @@ export const ComponentTypes: ComponentDef[] = [
     list: ''
   }
 ]
-
-export const ConditionalComponentTypes =
-  ComponentTypes.filter(hasConditionSupport)

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -3,6 +3,7 @@ import {
   type InputFieldsComponentsDef,
   type ComponentDef,
   type ConditionalComponentsDef,
+  type ConditionalComponentType,
   type ContentComponentsDef,
   type HtmlComponent,
   type InsetTextComponent,
@@ -17,6 +18,12 @@ import {
 export function hasConditionSupport(
   component?: Partial<ComponentDef>
 ): component is ConditionalComponentsDef {
+  return isConditionalType(component?.type)
+}
+
+export function isConditionalType(
+  type?: ComponentType
+): type is ConditionalComponentType {
   const allowedTypes = [
     ComponentType.CheckboxesField,
     ComponentType.DatePartsField,
@@ -28,7 +35,7 @@ export function hasConditionSupport(
     ComponentType.YesNoField
   ]
 
-  return !!component?.type && allowedTypes.includes(component.type)
+  return !!type && allowedTypes.includes(type)
 }
 
 /**

--- a/model/src/components/index.ts
+++ b/model/src/components/index.ts
@@ -1,7 +1,4 @@
-export {
-  ComponentTypes,
-  ConditionalComponentTypes
-} from '~/src/components/component-types.js'
+export { ComponentTypes } from '~/src/components/component-types.js'
 export {
   hasConditionSupport,
   hasContentField,

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -3,17 +3,15 @@ import {
   type ComponentType
 } from '~/src/components/enums.js'
 
-export type ConditionalComponentType = Extract<
-  ComponentType,
-  | typeof ComponentType.CheckboxesField
-  | typeof ComponentType.DatePartsField
-  | typeof ComponentType.EmailAddressField
-  | typeof ComponentType.MultilineTextField
-  | typeof ComponentType.NumberField
-  | typeof ComponentType.TextField
-  | typeof ComponentType.TimeField
-  | typeof ComponentType.YesNoField
->
+export type ConditionalComponentType =
+  | ComponentType.CheckboxesField
+  | ComponentType.DatePartsField
+  | ComponentType.EmailAddressField
+  | ComponentType.MultilineTextField
+  | ComponentType.NumberField
+  | ComponentType.TextField
+  | ComponentType.TimeField
+  | ComponentType.YesNoField
 
 export interface ContentOptions {
   condition?: string

--- a/model/src/conditions/condition-field.ts
+++ b/model/src/conditions/condition-field.ts
@@ -1,28 +1,18 @@
-import { ConditionalComponentTypes } from '~/src/components/component-types.js'
-import { type ConditionalComponentType } from '~/src/components/types.js'
+import { type ComponentType } from '~/src/components/enums.js'
+import { isConditionalType } from '~/src/components/helpers.js'
 
 export class ConditionField {
   name
   type
   display
 
-  constructor(
-    name?: string,
-    type?: ConditionalComponentType,
-    display?: string
-  ) {
+  constructor(name?: string, type?: ComponentType, display?: string) {
     if (!name || typeof name !== 'string') {
       throw new Error("ConditionField param 'name' must be a string")
     }
 
-    if (
-      !ConditionalComponentTypes.find(
-        (componentType) => componentType.type === type
-      )
-    ) {
-      throw new Error(
-        "ConditionField param 'type' must be from enum ConditionalComponentTypes"
-      )
+    if (!isConditionalType(type)) {
+      throw new Error("ConditionField param 'type' must support conditions")
     }
 
     if (!display || typeof display !== 'string') {
@@ -34,11 +24,7 @@ export class ConditionField {
     this.display = display
   }
 
-  static from(obj: {
-    name: string
-    type: ConditionalComponentType
-    display: string
-  }) {
+  static from(obj: { name: string; type: ComponentType; display: string }) {
     return new ConditionField(obj.name, obj.type, obj.display)
   }
 }

--- a/model/src/conditions/types.ts
+++ b/model/src/conditions/types.ts
@@ -1,4 +1,4 @@
-import { type ConditionalComponentsDef } from '~/src/components/types.js'
+import { type ComponentDef } from '~/src/components/types.js'
 import { type ConditionGroup } from '~/src/conditions/condition-group.js'
 import { type ConditionRef } from '~/src/conditions/condition-ref.js'
 import {
@@ -33,7 +33,7 @@ export interface TimeUnits {
 export interface OperatorDefinition {
   units?: DateUnits | TimeUnits
   expression: (
-    component: Pick<ConditionalComponentsDef, 'type' | 'name'>,
+    component: Pick<ComponentDef, 'type' | 'name'>,
     conditionValue: ConditionValue | RelativeTimeValue
   ) => string
 }


### PR DESCRIPTION
This fixes a bug where conditional date fields attempted to render for text inputs etc

I've added a new helper `isConditionalType()` since it's safer to assume other bugs exist (and can be avoided)