### PR TITLE
Remove Docker compose `version` (obsolete)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   redis:
     image: redis:7.0.7


### PR DESCRIPTION
This PR makes the same change as:

* https://github.com/DEFRA/forms-manager/pull/186