### PR TITLE
Fix textarea "rows" option

### DIFF
--- a/designer/client/src/MultilineTextFieldEdit.tsx
+++ b/designer/client/src/MultilineTextFieldEdit.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 
 import { TextFieldEdit } from '~/src/components/FieldEditors/TextFieldEdit.jsx'
+import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
 import { Options } from '~/src/reducers/component/types.js'
 
@@ -11,20 +12,31 @@ export function MultilineTextFieldEdit({ context = ComponentContext }) {
 
   return (
     <TextFieldEdit>
-      <input
-        className="govuk-input govuk-input--width-3"
-        id="field-options-rows"
-        name="options.rows"
-        type="text"
-        data-cast="number"
-        value={options.rows || ''}
-        onChange={(e) =>
-          dispatch({
-            type: Options.EDIT_OPTIONS_ROWS,
-            payload: e.target.value
-          })
-        }
-      />
+      <div className="govuk-form-group">
+        <label
+          className="govuk-label govuk-label--s"
+          htmlFor="field-options-rows"
+        >
+          {i18n('multilineTextFieldEditComponent.rowsField.title')}
+        </label>
+        <div className="govuk-hint">
+          {i18n('multilineTextFieldEditComponent.rowsField.helpText')}
+        </div>
+        <input
+          className="govuk-input govuk-input--width-3"
+          id="field-options-rows"
+          name="options.rows"
+          type="text"
+          data-cast="number"
+          value={options.rows || ''}
+          onChange={(e) =>
+            dispatch({
+              type: Options.EDIT_OPTIONS_ROWS,
+              payload: e.target.value
+            })
+          }
+        />
+      </div>
     </TextFieldEdit>
   )
 }

--- a/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
@@ -24,59 +24,61 @@ export function DateFieldEdit({ context = ComponentContext }: Props) {
         </span>
       </summary>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-options-maxDaysInPast"
-        >
-          {i18n('dateFieldEditComponent.maxDaysInPastField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('dateFieldEditComponent.maxDaysInPastField.helpText')}
+      <div className="govuk-details__text">
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-options-maxDaysInPast"
+          >
+            {i18n('dateFieldEditComponent.maxDaysInPastField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('dateFieldEditComponent.maxDaysInPastField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-options-maxDaysInPast"
+            name="options.maxDaysInPast"
+            value={options.maxDaysInPast}
+            type="number"
+            onChange={(e) =>
+              dispatch({
+                type: Options.EDIT_OPTIONS_MAX_DAYS_IN_PAST,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-options-maxDaysInPast"
-          name="options.maxDaysInPast"
-          value={options.maxDaysInPast}
-          type="number"
-          onChange={(e) =>
-            dispatch({
-              type: Options.EDIT_OPTIONS_MAX_DAYS_IN_PAST,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-options-maxDaysInFuture"
-        >
-          {i18n('dateFieldEditComponent.maxDaysInFutureField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('dateFieldEditComponent.maxDaysInFutureField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-options-maxDaysInFuture"
+          >
+            {i18n('dateFieldEditComponent.maxDaysInFutureField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('dateFieldEditComponent.maxDaysInFutureField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-options-maxDaysInFuture"
+            name="options.maxDaysInFuture"
+            value={options.maxDaysInFuture}
+            type="number"
+            onChange={(e) =>
+              dispatch({
+                type: Options.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-options-maxDaysInFuture"
-          name="options.maxDaysInFuture"
-          value={options.maxDaysInFuture}
-          type="number"
-          onChange={(e) =>
-            dispatch({
-              type: Options.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <CssClasses />
+        <CssClasses />
+      </div>
     </details>
   )
 }

--- a/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
@@ -25,137 +25,139 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
         </span>
       </summary>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-schema-min"
-        >
-          {i18n('numberFieldEditComponent.minField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('numberFieldEditComponent.minField.helpText')}
+      <div className="govuk-details__text">
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-schema-min"
+          >
+            {i18n('numberFieldEditComponent.minField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('numberFieldEditComponent.minField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-schema-min"
+            name="schema.min"
+            value={schema.min}
+            type="number"
+            onChange={(e) =>
+              dispatch({
+                type: Schema.EDIT_SCHEMA_MIN,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-schema-min"
-          name="schema.min"
-          value={schema.min}
-          type="number"
-          onChange={(e) =>
-            dispatch({
-              type: Schema.EDIT_SCHEMA_MIN,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-options-prefix"
-        >
-          {i18n('numberFieldEditComponent.prefixField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('numberFieldEditComponent.prefixField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-options-prefix"
+          >
+            {i18n('numberFieldEditComponent.prefixField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('numberFieldEditComponent.prefixField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="string"
+            id="field-options-prefix"
+            name="opions.prefix"
+            value={options.prefix}
+            type="string"
+            onBlur={(e) =>
+              dispatch({
+                type: Options.EDIT_OPTIONS_PREFIX,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="string"
-          id="field-options-prefix"
-          name="opions.prefix"
-          value={options.prefix}
-          type="string"
-          onBlur={(e) =>
-            dispatch({
-              type: Options.EDIT_OPTIONS_PREFIX,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-opitions-suffix"
-        >
-          {i18n('numberFieldEditComponent.suffixField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('numberFieldEditComponent.suffixField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-opitions-suffix"
+          >
+            {i18n('numberFieldEditComponent.suffixField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('numberFieldEditComponent.suffixField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="string"
+            id="field-options-suffix"
+            name="options.suffix"
+            value={options.suffix}
+            type="string"
+            onBlur={(e) =>
+              dispatch({
+                type: Options.EDIT_OPTIONS_SUFFIX,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="string"
-          id="field-options-suffix"
-          name="options.suffix"
-          value={options.suffix}
-          type="string"
-          onBlur={(e) =>
-            dispatch({
-              type: Options.EDIT_OPTIONS_SUFFIX,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-schema-max"
-        >
-          {i18n('numberFieldEditComponent.maxField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('numberFieldEditComponent.maxField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-schema-max"
+          >
+            {i18n('numberFieldEditComponent.maxField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('numberFieldEditComponent.maxField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-schema-max"
+            name="schema.max"
+            value={schema.max}
+            type="number"
+            onBlur={(e) =>
+              dispatch({
+                type: Schema.EDIT_SCHEMA_MAX,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-schema-max"
-          name="schema.max"
-          value={schema.max}
-          type="number"
-          onBlur={(e) =>
-            dispatch({
-              type: Schema.EDIT_SCHEMA_MAX,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-schema-precision"
-        >
-          {i18n('numberFieldEditComponent.precisionField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('numberFieldEditComponent.precisionField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-schema-precision"
+          >
+            {i18n('numberFieldEditComponent.precisionField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('numberFieldEditComponent.precisionField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-schema-precision"
+            name="schema.precision"
+            value={schema.precision || 0}
+            type="number"
+            onBlur={(e) =>
+              dispatch({
+                type: Schema.EDIT_SCHEMA_PRECISION,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-schema-precision"
-          name="schema.precision"
-          value={schema.precision || 0}
-          type="number"
-          onBlur={(e) =>
-            dispatch({
-              type: Schema.EDIT_SCHEMA_PRECISION,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <CssClasses />
+        <CssClasses />
+      </div>
     </details>
   )
 }

--- a/designer/client/src/components/FieldEditors/SelectFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/SelectFieldEdit.tsx
@@ -18,7 +18,9 @@ export function SelectFieldEdit({ page }: Props) {
           </span>
         </summary>
 
-        <Autocomplete />
+        <div className="govuk-details__text">
+          <Autocomplete />
+        </div>
       </details>
     </ListFieldEdit>
   )

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -27,144 +27,146 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
         </span>
       </summary>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-schema-min"
-        >
-          {i18n('textFieldEditComponent.minLengthField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('textFieldEditComponent.minLengthField.helpText')}
+      <div className="govuk-details__text">
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-schema-min"
+          >
+            {i18n('textFieldEditComponent.minLengthField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('textFieldEditComponent.minLengthField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-schema-min"
+            name="schema.min"
+            value={schema.min || ''}
+            type="number"
+            onChange={(e) =>
+              dispatch({
+                type: Schema.EDIT_SCHEMA_MIN,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-schema-min"
-          name="schema.min"
-          value={schema.min || ''}
-          type="number"
-          onChange={(e) =>
-            dispatch({
-              type: Schema.EDIT_SCHEMA_MIN,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-schema-max"
-        >
-          {i18n('textFieldEditComponent.maxLengthField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('textFieldEditComponent.maxLengthField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-schema-max"
+          >
+            {i18n('textFieldEditComponent.maxLengthField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('textFieldEditComponent.maxLengthField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-schema-max"
+            name="schema.max"
+            value={schema.max || ''}
+            type="number"
+            onChange={(e) =>
+              dispatch({
+                type: Schema.EDIT_SCHEMA_MAX,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-schema-max"
-          name="schema.max"
-          value={schema.max || ''}
-          type="number"
-          onChange={(e) =>
-            dispatch({
-              type: Schema.EDIT_SCHEMA_MAX,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-schema-maxwords"
-        >
-          {i18n('textFieldEditComponent.maxWordField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('textFieldEditComponent.maxWordField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-schema-maxwords"
+          >
+            {i18n('textFieldEditComponent.maxWordField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('textFieldEditComponent.maxWordField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-schema-maxwords"
+            name="schema.maxwords"
+            value={options.maxWords || ''}
+            type="number"
+            onChange={(e) =>
+              dispatch({
+                type: Options.EDIT_OPTIONS_MAX_WORDS,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-schema-maxwords"
-          name="schema.maxwords"
-          value={options.maxWords || ''}
-          type="number"
-          onChange={(e) =>
-            dispatch({
-              type: Options.EDIT_OPTIONS_MAX_WORDS,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-schema-length"
-        >
-          {i18n('textFieldEditComponent.lengthField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('textFieldEditComponent.lengthField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-schema-length"
+          >
+            {i18n('textFieldEditComponent.lengthField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('textFieldEditComponent.lengthField.helpText')}
+          </div>
+          <input
+            className="govuk-input govuk-input--width-3"
+            data-cast="number"
+            id="field-schema-length"
+            name="schema.length"
+            value={schema.length || ''}
+            type="number"
+            onChange={(e) =>
+              dispatch({
+                type: Schema.EDIT_SCHEMA_LENGTH,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input govuk-input--width-3"
-          data-cast="number"
-          id="field-schema-length"
-          name="schema.length"
-          value={schema.length || ''}
-          type="number"
-          onChange={(e) =>
-            dispatch({
-              type: Schema.EDIT_SCHEMA_LENGTH,
-              payload: e.target.value
-            })
-          }
-        />
-      </div>
 
-      {children}
+        {children}
 
-      <div className="govuk-form-group">
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-schema-regex"
-        >
-          {i18n('textFieldEditComponent.regexField.title')}
-        </label>
-        <div className="govuk-hint">
-          {i18n('textFieldEditComponent.regexField.helpText')}
+        <div className="govuk-form-group">
+          <label
+            className="govuk-label govuk-label--s"
+            htmlFor="field-schema-regex"
+          >
+            {i18n('textFieldEditComponent.regexField.title')}
+          </label>
+          <div className="govuk-hint">
+            {i18n('textFieldEditComponent.regexField.helpText')}
+          </div>
+          <input
+            className="govuk-input"
+            id="field-schema-regex"
+            name="schema.regex"
+            value={schema.regex || ''}
+            onChange={(e) =>
+              dispatch({
+                type: Schema.EDIT_SCHEMA_REGEX,
+                payload: e.target.value
+              })
+            }
+          />
         </div>
-        <input
-          className="govuk-input"
-          id="field-schema-regex"
-          name="schema.regex"
-          value={schema.regex || ''}
-          onChange={(e) =>
-            dispatch({
-              type: Schema.EDIT_SCHEMA_REGEX,
-              payload: e.target.value
-            })
-          }
-        />
+
+        <Autocomplete />
+
+        <CssClasses />
+
+        {selectedComponent.type === 'TelephoneNumberField' && (
+          // Remove type check when fully integrated into all runner components
+          <CustomValidationMessage />
+        )}
       </div>
-
-      <Autocomplete />
-
-      <CssClasses />
-
-      {selectedComponent.type === 'TelephoneNumberField' && (
-        // Remove type check when fully integrated into all runner components
-        <CustomValidationMessage />
-      )}
     </details>
   )
 }

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -131,6 +131,8 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
         />
       </div>
 
+      {children}
+
       <div className="govuk-form-group">
         <label
           className="govuk-label govuk-label--s"
@@ -154,8 +156,6 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
           }
         />
       </div>
-
-      {children}
 
       <Autocomplete />
 

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -245,6 +245,12 @@
     "summary": "Summary",
     "summaryBehaviour": "Summary behaviour"
   },
+  "multilineTextFieldEditComponent": {
+    "rowsField": {
+      "helpText": "Specifies the number of textarea rows (default is 5 rows).",
+      "title": "Rows"
+    }
+  },
   "name": {
     "errors": {
       "whitespace": "Name must not contain spaces"


### PR DESCRIPTION
This PR fixes the "rows" option when editing a Textarea component (multi-line text)

# Rows option

The rows option was a single `<input>` without a label, resting on top of **Autocomplete**

## Before

<img width="194" alt="Rows option before" src="https://github.com/DEFRA/forms-designer/assets/415517/63f3f568-86bc-4c4c-a75e-210004c448d9">

## After

<img width="480" alt="Rows option after" src="https://github.com/DEFRA/forms-designer/assets/415517/dba778e1-9167-48fe-a0e5-76b811a14235">

# Additional settings

These settings were missing a wrapper so fixed them at the same time

## Before

<img width="562" alt="Additional settings before" src="https://github.com/DEFRA/forms-designer/assets/415517/58ba2679-279e-457c-8eeb-fceb31e44d65">

## After

<img width="594" alt="Additional settings after" src="https://github.com/DEFRA/forms-designer/assets/415517/96a9e621-9a40-4ea0-b1c1-ff73ac6aa902">
