### PR TITLE
Fix mismatch of `data` shared through props or context

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,6 @@
 /**
  * ESLint config
+ * @type {import('eslint').ESLint.ConfigData}
  */
 module.exports = {
   ignorePatterns: [
@@ -55,6 +56,16 @@ module.exports = {
           'error',
           {
             ignoreArrowShorthand: true
+          }
+        ],
+
+        // Allow void return in async JSX attributes
+        '@typescript-eslint/no-misused-promises': [
+          'error',
+          {
+            checksVoidReturn: {
+              attributes: false
+            }
           }
         ],
 

--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -1,6 +1,7 @@
 import {
   ComponentType,
   type ComponentDef,
+  type FormDefinition,
   type Page,
   type RepeatingFieldPage
 } from '@defra/forms-model'
@@ -218,12 +219,13 @@ export const componentTypes = {
 }
 
 export interface Props {
+  data: FormDefinition
   page: Page | RepeatingFieldPage
   component: ComponentDef
 }
 
 export const Component: FunctionComponent<Props> = (props) => {
-  const { page, component } = props
+  const { data, page, component } = props
 
   const [showEditor, setShowEditor] = useState<boolean>(false)
   const toggleShowEditor = () => setShowEditor(!showEditor)
@@ -240,7 +242,11 @@ export const Component: FunctionComponent<Props> = (props) => {
       </button>
       {showEditor && (
         <Flyout title={editFlyoutTitle} show={true} onHide={toggleShowEditor}>
-          <ComponentContextProvider pagePath={page.path} component={component}>
+          <ComponentContextProvider
+            pagePath={page.path}
+            component={component}
+            data={data}
+          >
             <ComponentEdit page={page} toggleShowEditor={toggleShowEditor} />
           </ComponentContextProvider>
         </Flyout>

--- a/designer/client/src/DeclarationEdit.tsx
+++ b/designer/client/src/DeclarationEdit.tsx
@@ -1,15 +1,17 @@
 import { clone } from '@defra/forms-model'
-import React, { Component } from 'react'
+import React, { Component, type ContextType } from 'react'
 
 import { Editor } from '~/src/Editor.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import { DataContext } from '~/src/context/DataContext.js'
 
 export class DeclarationEdit extends Component {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
-  constructor(props) {
-    super(props)
+  constructor(props, context) {
+    super(props, context)
+
     this.onSubmit = this.onSubmit.bind(this)
   }
 

--- a/designer/client/src/LinkCreate.tsx
+++ b/designer/client/src/LinkCreate.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { Component } from 'react'
+import React, { Component, type ContextType } from 'react'
 
 import { ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -10,7 +10,9 @@ import { addLink } from '~/src/data/page/addLink.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 
 export class LinkCreate extends Component {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
+
   state = { errors: {} }
 
   onSubmit = async (e) => {

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -76,9 +76,11 @@ export class LinkEdit extends Component {
   }
 
   render() {
-    const { data, edge } = this.props
-    const { pages } = data
+    const { edge } = this.props
+    const { data } = this.context
     const { selectedCondition } = this.state
+    const { pages } = data
+
     return (
       <form onSubmit={(e) => this.onSubmit(e)} autoComplete="off">
         <div className="govuk-form-group">

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, type ContextType } from 'react'
 
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import { SelectConditions } from '~/src/conditions/SelectConditions.jsx'
@@ -8,12 +8,15 @@ import { updateLink } from '~/src/data/page/updateLink.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 
 export class LinkEdit extends Component {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
-  constructor(props, context) {
+  constructor(props, context: typeof DataContext) {
     super(props, context)
-    const { data } = this.context
+
     const { edge } = this.props
+    const { data } = this.context
+
     const [page] = findPage(data, edge.source)
     const link = page.next.find((n) => n.path === edge.target)
 
@@ -26,8 +29,10 @@ export class LinkEdit extends Component {
 
   onSubmit = async (e) => {
     e.preventDefault()
+
     const { link, page, selectedCondition } = this.state
     const { data, save } = this.context
+
     const updatedData = updateLink(
       data,
       page.path,

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -1,5 +1,5 @@
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
-import React, { Component } from 'react'
+import React, { Component, type ContextType } from 'react'
 
 import { type ErrorList, ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -16,11 +16,14 @@ import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
 
 export class PageCreate extends Component {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
   constructor(props, context) {
     super(props, context)
+
     const { page } = this.props
+
     this.state = {
       path: '/',
       controller: page?.controller ?? '',

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -1,6 +1,6 @@
 import { clone } from '@defra/forms-model'
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
-import React, { Component, createRef } from 'react'
+import React, { Component, createRef, type ContextType } from 'react'
 
 import { type ErrorList, ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -16,11 +16,14 @@ import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
 
 export class PageEdit extends Component {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
-  constructor(props) {
-    super(props)
+  constructor(props, context) {
+    super(props, context)
+
     const { page } = this.props
+
     this.state = {
       path: page?.path ?? this.generatePath(page.title),
       controller: page?.controller ?? '',
@@ -29,6 +32,7 @@ export class PageEdit extends Component {
       isEditingSection: false,
       errors: {}
     }
+
     this.formEditSection = createRef()
   }
 

--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -19,6 +19,7 @@ interface State {
 }
 
 export class Lines extends Component<Props, State> {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
   state = {

--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -1,4 +1,3 @@
-import { type FormDefinition } from '@defra/forms-model'
 import React, { Component, type KeyboardEvent } from 'react'
 
 import { LinkEdit } from '~/src/LinkEdit.jsx'
@@ -11,7 +10,6 @@ import { DataContext } from '~/src/context/DataContext.js'
 
 interface Props {
   layout: Layout['pos']
-  data: FormDefinition
 }
 
 interface State {
@@ -40,7 +38,6 @@ export class Lines extends Component<Props, State> {
 
   render() {
     const { layout } = this.props
-    const { data } = this.context
 
     return (
       <>
@@ -93,7 +90,6 @@ export class Lines extends Component<Props, State> {
           >
             <LinkEdit
               edge={this.state.showEditor}
-              data={data}
               onEdit={() => this.setState({ showEditor: false })}
             />
           </Flyout>

--- a/designer/client/src/components/Visualisation/Visualisation.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.tsx
@@ -53,7 +53,7 @@ export function Visualisation(props: Props) {
               />
             ))}
 
-            {layout && <Lines layout={layout} data={data} />}
+            {layout && <Lines layout={layout} />}
           </div>
         </div>
       </div>

--- a/designer/client/src/conditions/InlineConditions.tsx
+++ b/designer/client/src/conditions/InlineConditions.tsx
@@ -1,6 +1,11 @@
 import { ConditionsModel, clone, type Item } from '@defra/forms-model'
 import classNames from 'classnames'
-import React, { Component, type MouseEvent, type ChangeEvent } from 'react'
+import React, {
+  Component,
+  type ChangeEvent,
+  type ContextType,
+  type MouseEvent
+} from 'react'
 
 import { ErrorSummary, type ErrorListItem } from '~/src/ErrorSummary.jsx'
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
@@ -42,10 +47,12 @@ const yesNoValues: Readonly<Item> = [
 ]
 
 export class InlineConditions extends Component<Props, State> {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
   constructor(props, context) {
     super(props, context)
+
     const { path, condition } = this.props
 
     const conditions =

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -4,7 +4,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { Select } from '@xgovformbuilder/govuk-react-jsx'
-import React, { Component, type ChangeEvent } from 'react'
+import React, { Component, type ChangeEvent, type ContextType } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
@@ -45,6 +45,7 @@ export interface ConditionData {
 }
 
 export class SelectConditions extends Component<Props, State> {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
   constructor(props, context) {

--- a/designer/client/src/section/SectionEdit.tsx
+++ b/designer/client/src/section/SectionEdit.tsx
@@ -1,5 +1,5 @@
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
-import React, { createRef, Component } from 'react'
+import React, { createRef, Component, type ContextType } from 'react'
 
 import { type ErrorList, ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -14,10 +14,12 @@ import {
 } from '~/src/validations.js'
 
 export class SectionEdit extends Component {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
-  constructor(props) {
-    super(props)
+  constructor(props, context) {
+    super(props, context)
+
     this.closeFlyout = props.closeFlyout
     const { section } = props
     this.isNewSection = !section?.name

--- a/designer/client/src/section/SectionEdit.tsx
+++ b/designer/client/src/section/SectionEdit.tsx
@@ -39,13 +39,14 @@ export class SectionEdit extends Component {
     if (hasValidationErrors(validationErrors)) return
 
     const { data, save } = this.context
+    const { section } = this.props
     const { name, title, hideTitle } = this.state
     let updated = { ...data }
 
     if (this.isNewSection) {
       updated = addSection(data, { name, title: title.trim(), hideTitle })
     } else {
-      const previousName = this.props.section?.name
+      const previousName = section?.name
       const nameChanged = previousName !== name
       const copySection = updated.sections.find(
         (section) => section.name === previousName
@@ -108,10 +109,11 @@ export class SectionEdit extends Component {
       return
     }
 
-    const { save } = this.context
-    const { data, section } = this.props
+    const { data, save } = this.context
+    const { section } = this.props
+
     const copy = { ...data }
-    const previousName = this.props.section?.name
+    const previousName = section?.name
 
     copy.sections.splice(copy.sections.indexOf(section), 1)
 

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -75,11 +75,7 @@ export class SectionsEdit extends Component {
               show={isEditingSection}
               onHide={this.closeFlyout}
             >
-              <SectionEdit
-                section={section}
-                data={data}
-                closeFlyout={this.closeFlyout}
-              />
+              <SectionEdit section={section} closeFlyout={this.closeFlyout} />
             </Flyout>
           </RenderInPortal>
         )}

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, type ContextType } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
@@ -6,7 +6,9 @@ import { DataContext } from '~/src/context/DataContext.js'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 
 export class SectionsEdit extends Component {
+  declare context: ContextType<typeof DataContext>
   static contextType = DataContext
+
   state = {}
 
   onClickSection = (e, section) => {


### PR DESCRIPTION
We use `this.context` data for form definitions but sometimes pass them via `this.props`

This can cause the two to get out of sync