### PR TITLE
Add horizontal scrolling to editor

### DIFF
--- a/designer/client/jest.environment.js
+++ b/designer/client/jest.environment.js
@@ -29,9 +29,6 @@ beforeAll(async () => {
 
 beforeEach(() => {
   document.body.innerHTML = `
-    <div>
-      <main id="root"></main>
-      <div id="portal-root"></div>
-    </div>
+    <div id="portal-root"></div>
   `
 })

--- a/designer/client/jest.environment.js
+++ b/designer/client/jest.environment.js
@@ -29,6 +29,6 @@ beforeAll(async () => {
 
 beforeEach(() => {
   document.body.innerHTML = `
-    <div id="portal-root"></div>
+    <div class="app-form-portal"></div>
   `
 })

--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -10,6 +10,7 @@ import React, { useState, type FunctionComponent } from 'react'
 import { ComponentEdit } from '~/src/ComponentEdit.jsx'
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { SearchIcon } from '~/src/components/Icons/SearchIcon.jsx'
+import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContextProvider } from '~/src/reducers/component/componentReducer.jsx'
 
@@ -241,15 +242,17 @@ export const Component: FunctionComponent<Props> = (props) => {
         <TagName />
       </button>
       {showEditor && (
-        <Flyout title={editFlyoutTitle} show={true} onHide={toggleShowEditor}>
-          <ComponentContextProvider
-            pagePath={page.path}
-            component={component}
-            data={data}
-          >
-            <ComponentEdit page={page} toggleShowEditor={toggleShowEditor} />
-          </ComponentContextProvider>
-        </Flyout>
+        <RenderInPortal>
+          <Flyout title={editFlyoutTitle} onHide={toggleShowEditor}>
+            <ComponentContextProvider
+              pagePath={page.path}
+              component={component}
+              data={data}
+            >
+              <ComponentEdit page={page} toggleShowEditor={toggleShowEditor} />
+            </ComponentContextProvider>
+          </Flyout>
+        </RenderInPortal>
       )}
     </>
   )

--- a/designer/client/src/Designer.tsx
+++ b/designer/client/src/Designer.tsx
@@ -79,10 +79,10 @@ export class Designer extends Component<Props, State> {
     return (
       <DataContext.Provider value={dataContextProviderValue}>
         <FlyoutContext.Provider value={flyoutContextProviderValue}>
-          <div id="designer">
+          <div className="govuk-width-container">
             <Menu slug={metadata.slug} />
-            <Visualisation slug={metadata.slug} previewUrl={previewUrl} />
           </div>
+          <Visualisation slug={metadata.slug} previewUrl={previewUrl} />
         </FlyoutContext.Provider>
       </DataContext.Provider>
     )

--- a/designer/client/src/LinkCreate.test.tsx
+++ b/designer/client/src/LinkCreate.test.tsx
@@ -60,10 +60,7 @@ function customRender(
   providerProps = dataValue
 ): RenderResult {
   return render(
-    <DataContext.Provider value={providerProps}>
-      {element}
-      <div id="portal-root" />
-    </DataContext.Provider>
+    <DataContext.Provider value={providerProps}>{element}</DataContext.Provider>
   )
 }
 

--- a/designer/client/src/LinkEdit.test.tsx
+++ b/designer/client/src/LinkEdit.test.tsx
@@ -35,10 +35,7 @@ function customRender(
   providerProps = dataValue
 ): RenderResult {
   return render(
-    <DataContext.Provider value={providerProps}>
-      {element}
-      <div id="portal-root" />
-    </DataContext.Provider>
+    <DataContext.Provider value={providerProps}>{element}</DataContext.Provider>
   )
 }
 

--- a/designer/client/src/PageCreate.test.tsx
+++ b/designer/client/src/PageCreate.test.tsx
@@ -1,24 +1,30 @@
+import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { cleanup, render } from '@testing-library/react'
 import React from 'react'
 
 import { PageCreate } from '~/src/PageCreate.jsx'
+import { RenderWithContextAndDataContext } from '~/test/helpers/renderers.jsx'
 
 describe('page create fields text', () => {
+  const data: FormDefinition = {
+    pages: [],
+    lists: [],
+    sections: [],
+    conditions: []
+  }
+
   afterEach(cleanup)
 
   const { getByText } = screen
 
   test('displays field titles and help texts', () => {
-    const props = {
-      path: '/some-path',
-      data: {
-        sections: [],
-        pages: []
-      }
-    }
+    render(
+      <RenderWithContextAndDataContext mockData={data}>
+        <PageCreate page={{ path: '/some-path' }} />
+      </RenderWithContextAndDataContext>
+    )
 
-    render(<PageCreate {...props} />)
     expect(getByText('Page type')).toBeInTheDocument()
     expect(
       getByText(

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -234,7 +234,7 @@ export class PageCreate extends Component {
               onChange={this.onChangeLinkFrom}
             >
               <option />
-              {pages?.map((page) => (
+              {pages.map((page) => (
                 <option key={page.path} value={page.path}>
                   {page.path}
                 </option>
@@ -292,7 +292,7 @@ export class PageCreate extends Component {
             <div className="govuk-hint">
               {i18n('addPage.sectionOption.helpText')}
             </div>
-            {sections?.length > 0 && (
+            {sections.length > 0 && (
               <select
                 className="govuk-select"
                 id="page-section"
@@ -339,7 +339,6 @@ export class PageCreate extends Component {
                 section?.name ? `Editing ${section.name}` : 'Add a new section'
               }
               onHide={this.closeFlyout}
-              show={true}
             >
               <SectionEdit
                 section={section}

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -36,7 +36,6 @@ describe('Menu', () => {
         <FlyoutContext.Provider value={flyoutValue}>
           {children}
         </FlyoutContext.Provider>
-        <div id="portal-root" />
       </DataContext.Provider>
     )
   }

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -7,6 +7,7 @@ import { DataPrettyPrint } from '~/src/components/DataPrettyPrint/DataPrettyPrin
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { SubMenu } from '~/src/components/Menu/SubMenu.jsx'
 import { useMenuItem } from '~/src/components/Menu/useMenuItem.jsx'
+import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
 import { Tabs } from '~/src/components/Tabs/Tabs.jsx'
 import { ConditionsEdit } from '~/src/conditions/ConditionsEdit.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
@@ -123,53 +124,67 @@ export function Menu({ slug }: Props) {
       </nav>
 
       {page.isVisible && (
-        <Flyout title="Add Page" onHide={page.hide}>
-          <PageCreate onCreate={() => page.hide()} />
-        </Flyout>
+        <RenderInPortal>
+          <Flyout title="Add Page" onHide={page.hide}>
+            <PageCreate onCreate={() => page.hide()} />
+          </Flyout>
+        </RenderInPortal>
       )}
 
       {link.isVisible && (
-        <Flyout title={i18n('menu.links')} onHide={link.hide}>
-          <LinkCreate onCreate={() => link.hide()} />
-        </Flyout>
+        <RenderInPortal>
+          <Flyout title={i18n('menu.links')} onHide={link.hide}>
+            <LinkCreate onCreate={() => link.hide()} />
+          </Flyout>
+        </RenderInPortal>
       )}
 
       {sections.isVisible && (
-        <Flyout title="Edit Sections" onHide={sections.hide}>
-          <SectionsEdit />
-        </Flyout>
+        <RenderInPortal>
+          <Flyout title="Edit Sections" onHide={sections.hide}>
+            <SectionsEdit />
+          </Flyout>
+        </RenderInPortal>
       )}
 
       {conditions.isVisible && (
-        <Flyout
-          title={i18n('conditions.addOrEdit')}
-          onHide={conditions.hide}
-          width="large"
-        >
-          <ConditionsEdit />
-        </Flyout>
+        <RenderInPortal>
+          <Flyout
+            title={i18n('conditions.addOrEdit')}
+            onHide={conditions.hide}
+            width="large"
+          >
+            <ConditionsEdit />
+          </Flyout>
+        </RenderInPortal>
       )}
 
       {lists.isVisible && (
-        <Flyout title="Edit Lists" onHide={lists.hide}>
-          <ListsEditorContextProvider>
-            <ListContextProvider>
-              <ListsEdit showEditLists={false} />
-            </ListContextProvider>
-          </ListsEditorContextProvider>
-        </Flyout>
+        <RenderInPortal>
+          <Flyout title="Edit Lists" onHide={lists.hide}>
+            <ListsEditorContextProvider>
+              <ListContextProvider>
+                <ListsEdit showEditLists={false} />
+              </ListContextProvider>
+            </ListsEditorContextProvider>
+          </Flyout>
+        </RenderInPortal>
       )}
 
       {summaryBehaviour.isVisible && (
-        <Flyout title="Edit Summary behaviour" onHide={summaryBehaviour.hide}>
-          <DeclarationEdit onCreate={() => summaryBehaviour.hide()} />
-        </Flyout>
+        <RenderInPortal>
+          <Flyout title="Edit Summary behaviour" onHide={summaryBehaviour.hide}>
+            <DeclarationEdit onCreate={() => summaryBehaviour.hide()} />
+          </Flyout>
+        </RenderInPortal>
       )}
 
       {summary.isVisible && (
-        <Flyout title="Summary" width="large" onHide={summary.hide}>
-          <Tabs title="Summary" items={summaryTabs}></Tabs>
-        </Flyout>
+        <RenderInPortal>
+          <Flyout title="Summary" width="large" onHide={summary.hide}>
+            <Tabs title="Summary" items={summaryTabs}></Tabs>
+          </Flyout>
+        </RenderInPortal>
       )}
     </>
   )

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -117,7 +117,7 @@ describe('Page', () => {
       providerProps
     )
 
-    await act(() => userEvent.click(getByText('Create component')))
+    await act(() => userEvent.click(getByText('Add component')))
     await waitFor(() => findByTestId('component-create'))
 
     await act(() => userEvent.click(getByText('Close')))
@@ -136,8 +136,8 @@ describe('Page', () => {
     )
 
     expect(getByText('Edit page')).toBeTruthy()
-    expect(getByText('Create component')).toBeTruthy()
-    expect(getByText('Preview')).toBeTruthy()
+    expect(getByText('Preview page')).toBeTruthy()
+    expect(getByText('Add component')).toBeTruthy()
   })
 
   test('Dragging component order saves successfully', async () => {
@@ -151,7 +151,7 @@ describe('Page', () => {
       providerProps
     )
 
-    await act(() => userEvent.click(getByText('Create component')))
+    await act(() => userEvent.click(getByText('Add component')))
     await waitFor(() => findByTestId('component-create'))
 
     await act(() => userEvent.click(getByText('Close')))

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -96,30 +96,24 @@ export const Page = (props: {
       <ComponentList page={page} data={data} />
 
       <div className="page__actions">
-        <button
-          title={i18n('Edit page')}
-          onClick={() => setIsEditingPage(true)}
-          className="govuk-link"
-        >
+        <button onClick={() => setIsEditingPage(true)} className="govuk-link">
           {i18n('Edit page')}
         </button>
-        <button
-          title={i18n('Create component')}
-          onClick={() => setIsCreatingComponent(true)}
-          className="govuk-link"
-        >
-          {i18n('Create component')}
-        </button>
         <a
-          title={i18n('Preview page')}
           href={new URL(`/preview/draft/${slug}${page.path}`, previewUrl).href}
           className="govuk-link"
           target="_blank"
           rel="noreferrer"
+          aria-label={`${i18n('Preview')} ${pageTitle}`}
         >
-          {i18n('Preview')}{' '}
-          <span className="govuk-visually-hidden">{pageTitle}</span>
+          {i18n('Preview page')}
         </a>
+        <button
+          onClick={() => setIsCreatingComponent(true)}
+          className="govuk-link"
+        >
+          {i18n('component.create')}
+        </button>
       </div>
       {isEditingPage && (
         <RenderInPortal>

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -11,6 +11,7 @@ import { Component } from '~/src/Component.jsx'
 import { PageEdit } from '~/src/PageEdit.jsx'
 import { ComponentCreate } from '~/src/components/ComponentCreate/ComponentCreate.jsx'
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
+import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContextProvider } from '~/src/reducers/component/componentReducer.jsx'
@@ -121,23 +122,27 @@ export const Page = (props: {
         </a>
       </div>
       {isEditingPage && (
-        <Flyout title="Edit Page" onHide={setIsEditingPage}>
-          <PageEdit page={page} onEdit={onEditEnd} />
-        </Flyout>
+        <RenderInPortal>
+          <Flyout title="Edit Page" onHide={setIsEditingPage}>
+            <PageEdit page={page} onEdit={onEditEnd} />
+          </Flyout>
+        </RenderInPortal>
       )}
 
       {isCreatingComponent && (
-        <Flyout show={true} onHide={setIsCreatingComponent}>
-          <ComponentContextProvider>
-            <ComponentCreate
-              renderInForm={true}
-              toggleAddComponent={() => {
-                setIsCreatingComponent(false)
-              }}
-              page={page}
-            />
-          </ComponentContextProvider>
-        </Flyout>
+        <RenderInPortal>
+          <Flyout onHide={setIsCreatingComponent}>
+            <ComponentContextProvider>
+              <ComponentCreate
+                renderInForm={true}
+                toggleAddComponent={() => {
+                  setIsCreatingComponent(false)
+                }}
+                page={page}
+              />
+            </ComponentContextProvider>
+          </Flyout>
+        </RenderInPortal>
       )}
     </div>
   )

--- a/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
+++ b/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
@@ -7,7 +7,7 @@ describe('RenderInPortal component', () => {
   let portalRoot: HTMLElement | null
 
   beforeEach(() => {
-    portalRoot = document.getElementById('portal-root')
+    portalRoot = document.querySelector('.app-form-portal')
   })
 
   test('renders paragraph inside portal', () => {

--- a/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
+++ b/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
@@ -4,9 +4,13 @@ import React from 'react'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
 
 describe('RenderInPortal component', () => {
-  test('renders paragraph inside portal', () => {
-    let portalRoot = document.getElementById('portal-root')
+  let portalRoot: HTMLElement | null
 
+  beforeEach(() => {
+    portalRoot = document.getElementById('portal-root')
+  })
+
+  test('renders paragraph inside portal', () => {
     expect(portalRoot?.innerHTML).toBe('')
 
     const wrapper = mount(
@@ -14,13 +18,13 @@ describe('RenderInPortal component', () => {
         <p id="test-paragraph">Test</p>
       </RenderInPortal>
     )
-    portalRoot = document.getElementById('portal-root')
+
     expect(portalRoot?.innerHTML).toBe(
       '<div><p id="test-paragraph">Test</p></div>'
     )
 
     wrapper.unmount()
-    portalRoot = document.getElementById('portal-root')
+
     expect(portalRoot?.innerHTML).toBe('')
   })
 
@@ -30,25 +34,25 @@ describe('RenderInPortal component', () => {
         <p id="test-paragraph1">Test 1</p>
       </RenderInPortal>
     )
+
     const wrapper2 = mount(
       <RenderInPortal>
         <p id="test-paragraph2">Test 2</p>
       </RenderInPortal>
     )
 
-    let portalRoot = document.getElementById('portal-root')
     expect(portalRoot?.innerHTML).toBe(
       '<div><p id="test-paragraph1">Test 1</p></div><div><p id="test-paragraph2">Test 2</p></div>'
     )
 
     wrapper1.unmount()
-    portalRoot = document.getElementById('portal-root')
+
     expect(portalRoot?.innerHTML).toBe(
       '<div><p id="test-paragraph2">Test 2</p></div>'
     )
 
     wrapper2.unmount()
-    portalRoot = document.getElementById('portal-root')
+
     expect(portalRoot?.innerHTML).toBe('')
   })
 })

--- a/designer/client/src/components/RenderInPortal/RenderInPortal.tsx
+++ b/designer/client/src/components/RenderInPortal/RenderInPortal.tsx
@@ -13,7 +13,7 @@ export class RenderInPortal extends Component<Props> {
     super(props)
 
     const $wrapper = document.createElement('div')
-    const $root = document.getElementById('portal-root')
+    const $root = document.querySelector('.app-form-portal')
 
     if (!($root instanceof HTMLElement)) {
       throw new Error('Missing portal root')

--- a/designer/client/src/components/RenderInPortal/RenderInPortal.tsx
+++ b/designer/client/src/components/RenderInPortal/RenderInPortal.tsx
@@ -1,19 +1,37 @@
-import { Component } from 'react'
-import ReactDOM from 'react-dom'
+import { Component, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 
-export class RenderInPortal extends Component {
-  wrapper = document.createElement('div')
-  portalRoot = document.getElementById('portal-root')
+interface Props {
+  children: ReactNode
+}
+
+export class RenderInPortal extends Component<Props> {
+  $root: HTMLElement
+  $wrapper: HTMLElement
+
+  constructor(props: Props) {
+    super(props)
+
+    const $wrapper = document.createElement('div')
+    const $root = document.getElementById('portal-root')
+
+    if (!($root instanceof HTMLElement)) {
+      throw new Error('Missing portal root')
+    }
+
+    this.$wrapper = $wrapper
+    this.$root = $root
+  }
 
   componentDidMount() {
-    this.portalRoot?.appendChild(this.wrapper)
+    this.$root.appendChild(this.$wrapper)
   }
 
   componentWillUnmount() {
-    this.portalRoot?.removeChild(this.wrapper)
+    this.$root.removeChild(this.$wrapper)
   }
 
   render() {
-    return ReactDOM.createPortal(this.props.children, this.wrapper)
+    return createPortal(this.props.children, this.$wrapper)
   }
 }

--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -37,16 +37,23 @@ export class Lines extends Component<Props, State> {
 
     return (
       <>
-        <svg height={layout.height} width={layout.width}>
+        <svg height={layout.height} width={layout.width} className="line">
           {layout.edges.map((edge) => {
             const { source, target, points, label } = edge
+
             const pointsString = points.map((p) => `${p.x},${p.y}`).join(' ')
 
             const xs = edge.points.map((p) => p.x)
             const ys = edge.points.map((p) => p.y)
 
+            const textWidth = Math.max(...xs) - Math.min(...xs)
+            const textHeight = Math.max(...ys) - Math.min(...ys)
+
             const textX = xs.reduce((a, b) => a + b, 0) / xs.length
-            const textY = ys.reduce((a, b) => a + b, 0) / ys.length - 5
+            const textY = ys.reduce((a, b) => a + b, 0) / ys.length
+
+            const translateX = Math.round(textX - textWidth / 2)
+            const translateY = Math.round(textY - textHeight / 2)
 
             return (
               <g key={pointsString}>
@@ -67,15 +74,22 @@ export class Lines extends Component<Props, State> {
                   </title>
                 </polyline>
                 {label && (
-                  <text
-                    textAnchor="middle"
-                    x={textX}
-                    y={textY}
-                    fill="black"
-                    pointerEvents="none"
+                  <foreignObject
+                    width={textWidth}
+                    height={textHeight}
+                    style={{
+                      overflow: 'auto',
+                      pointerEvents: 'none',
+                      textAlign: 'center'
+                    }}
+                    transform={`translate(${translateX}, ${translateY})`}
                   >
-                    {label}
-                  </text>
+                    <div className="line__condition">
+                      <strong className="govuk-tag govuk-tag--green">
+                        {label}
+                      </strong>
+                    </div>
+                  </foreignObject>
                 )}
               </g>
             )

--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -2,6 +2,7 @@ import React, { Component, type ContextType } from 'react'
 
 import { LinkEdit } from '~/src/LinkEdit.jsx'
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
+import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
 import {
   type Edge,
   type Pos
@@ -96,15 +97,17 @@ export class Lines extends Component<Props, State> {
           })}
         </svg>
         {this.state.edge && (
-          <Flyout
-            title="Edit Link"
-            onHide={() => this.setState({ edge: undefined })}
-          >
-            <LinkEdit
-              edge={this.state.edge}
-              onEdit={() => this.setState({ edge: undefined })}
-            />
-          </Flyout>
+          <RenderInPortal>
+            <Flyout
+              title="Edit Link"
+              onHide={() => this.setState({ edge: undefined })}
+            >
+              <LinkEdit
+                edge={this.state.edge}
+                onEdit={() => this.setState({ edge: undefined })}
+              />
+            </Flyout>
+          </RenderInPortal>
         )}
       </>
     )

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -35,8 +35,7 @@ function customRender(
 describe('Visualisation', () => {
   afterEach(cleanup)
 
-  const { findAllByText, findByText, getByText, queryByText, queryByTestId } =
-    screen
+  const { findByText, getByText, queryByText, queryByTestId } = screen
 
   test('Graph is rendered with correct number of pages and updates', async () => {
     const data: FormDefinition = {
@@ -61,16 +60,9 @@ describe('Visualisation', () => {
       providerProps
     )
 
-    await waitFor(() =>
-      expect(findAllByText('my first page')).resolves.toHaveLength(2)
-    )
-
-    await waitFor(() =>
-      expect(findAllByText('my second page')).resolves.toHaveLength(2)
-    )
-
-    const thirdPage = queryByText('my third page')
-    expect(thirdPage).not.toBeInTheDocument()
+    expect(queryByText('my first page')).toBeInTheDocument()
+    expect(queryByText('my second page')).toBeInTheDocument()
+    expect(queryByText('my third page')).not.toBeInTheDocument()
 
     const newPage = {
       title: 'my third page',
@@ -85,9 +77,7 @@ describe('Visualisation', () => {
       <Visualisation previewUrl={'http://localhost:3000'} slug={'aa'} />
     )
 
-    await waitFor(() =>
-      expect(findAllByText('my third page')).resolves.toHaveLength(2)
-    )
+    expect(queryByText('my third page')).toBeInTheDocument()
   })
 
   test('Links between pages are navigable via keyboard', async () => {
@@ -138,7 +128,7 @@ describe('Visualisation', () => {
     expect(queryByTestId('flyout-0')).not.toBeInTheDocument()
 
     await act(async () => {
-      $lineTitle.parentElement!.focus()
+      $lineTitle.parentElement?.focus()
       await userEvent.keyboard('[Space]')
     })
 

--- a/designer/client/src/components/Visualisation/getLayout.ts
+++ b/designer/client/src/components/Visualisation/getLayout.ts
@@ -30,8 +30,8 @@ export const getLayout = (data: FormDefinition, el: HTMLDivElement) => {
   g.setGraph({
     rankdir: 'LR',
     align: 'UL',
-    marginx: 50,
-    marginy: 100,
+    marginx: 30,
+    marginy: 0,
     edgesep: 80,
     nodesep: 80,
     ranksep: 80

--- a/designer/client/src/components/Visualisation/getLayout.ts
+++ b/designer/client/src/components/Visualisation/getLayout.ts
@@ -29,9 +29,12 @@ export const getLayout = (data: FormDefinition, el: HTMLDivElement) => {
   // Set an object for the graph label
   g.setGraph({
     rankdir: 'LR',
+    align: 'UL',
     marginx: 50,
     marginy: 100,
-    ranksep: 160
+    edgesep: 80,
+    nodesep: 80,
+    ranksep: 80
   })
 
   // Default to assigning a new object as a label for each new edge.
@@ -66,7 +69,8 @@ export const getLayout = (data: FormDefinition, el: HTMLDivElement) => {
       const condition = conditions.find(({ name }) => name === next.condition)
 
       g.setEdge(page.path, next.path, {
-        label: condition?.displayName
+        label: condition?.displayName,
+        width: condition?.displayName ? 270 : undefined
       })
     })
   })

--- a/designer/client/src/components/Visualisation/getLayout.ts
+++ b/designer/client/src/components/Visualisation/getLayout.ts
@@ -1,33 +1,16 @@
-import { graphlib, layout } from '@dagrejs/dagre'
+import { graphlib, layout, type GraphEdge, type Node } from '@dagrejs/dagre'
 import { type FormDefinition } from '@defra/forms-model'
 
 export interface Point {
-  node: {
-    x: number
-    y: number
-    width: number
-    height: number
-    class?: string | undefined
-    label?: string | undefined
-    padding?: number | undefined
-    paddingX?: number | undefined
-    paddingY?: number | undefined
-    rx?: number | undefined
-    ry?: number | undefined
-    shape?: string | undefined
-  }
+  node: Node
   top: string
   left: string
 }
 
-export interface Edge {
+export interface Edge extends GraphEdge {
   source: string
   target: string
   label: string
-  points: {
-    y: number
-    x: number
-  }[]
 }
 
 export interface Pos {

--- a/designer/client/src/components/Visualisation/visualisation.scss
+++ b/designer/client/src/components/Visualisation/visualisation.scss
@@ -1,10 +1,26 @@
 $govuk-assets-path: "/assets/";
 
+$govuk-breakpoints: (
+  mobile: 320px,
+  tablet: 641px,
+  desktop: 769px,
+  wide: 1020px
+);
+
 @import "govuk-frontend/dist/govuk/base";
 
 .visualisation {
   position: relative;
   flex: 1;
+
+  @include govuk-responsive-padding(6, "top");
+  @include govuk-responsive-padding(9, "bottom");
+  overflow-x: auto;
+
+  @include govuk-media-query($from: wide) {
+    margin-left: (calc($govuk-page-width / 2) + govuk-spacing(5)) * -1;
+    padding-left: 50%;
+  }
 
   &__pages-wrapper {
     position: relative;

--- a/designer/client/src/components/Visualisation/visualisation.scss
+++ b/designer/client/src/components/Visualisation/visualisation.scss
@@ -57,4 +57,40 @@ $govuk-assets-path: "/assets/";
       }
     }
   }
+
+  .line__condition {
+    display: flex;
+
+    height: 100%;
+    padding: 0 govuk-spacing(6);
+
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+
+    @include govuk-font-size($size: 16);
+
+    .govuk-tag {
+      max-width: 75%;
+      font-size: inherit;
+    }
+
+    :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  polyline {
+    cursor: pointer;
+
+    fill: none;
+    stroke-width: 4;
+    stroke: govuk-colour("black");
+    stroke-linecap: square;
+
+    &:hover,
+    &:focus {
+      outline: 6px solid $govuk-focus-colour;
+    }
+  }
 }

--- a/designer/client/src/conditions/ConditionsEdit.test.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.test.tsx
@@ -71,7 +71,6 @@ function customRender(
       <FlyoutContext.Provider value={flyoutValue}>
         {element}
       </FlyoutContext.Provider>
-      <div id="portal-root" />
     </DataContext.Provider>
   )
 }
@@ -130,14 +129,14 @@ describe('ConditionsEdit', () => {
       customRender(<ConditionsEdit />, providerProps)
       expect(getByText(condition.displayName)).toBeInTheDocument()
       expect(getByText(condition2.displayName)).toBeInTheDocument()
-      expect(queryByTestId('edit-conditions')).not.toBeInTheDocument()
+      expect(queryByTestId('flyout-0')).not.toBeInTheDocument()
     })
 
     test('Clicking an edit link causes the edit view to be rendered and all other elements hidden', async () => {
       customRender(<ConditionsEdit />, providerProps)
       const $link = getByText(condition.displayName)
       await act(() => userEvent.click($link))
-      expect(getByTestId('edit-conditions')).toBeTruthy()
+      expect(getByTestId('flyout-0')).toBeTruthy()
     })
   })
 

--- a/designer/client/src/conditions/ConditionsEdit.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.tsx
@@ -116,16 +116,14 @@ export function ConditionsEdit({ path }: Props) {
       )}
       {editingCondition && (
         <RenderInPortal>
-          <div id="edit-conditions" data-testid="edit-conditions">
-            <Flyout title={i18n('conditions.addOrEdit')} onHide={editFinished}>
-              <InlineConditions
-                path={path}
-                condition={editingCondition}
-                conditionsChange={editFinished}
-                cancelCallback={editFinished}
-              />
-            </Flyout>
-          </div>
+          <Flyout title={i18n('conditions.addOrEdit')} onHide={editFinished}>
+            <InlineConditions
+              path={path}
+              condition={editingCondition}
+              conditionsChange={editFinished}
+              cancelCallback={editFinished}
+            />
+          </Flyout>
         </RenderInPortal>
       )}
     </>

--- a/designer/client/src/conditions/SelectConditions.test.tsx
+++ b/designer/client/src/conditions/SelectConditions.test.tsx
@@ -33,7 +33,6 @@ describe('SelectConditions', () => {
     return render(
       <DataContext.Provider value={providerProps}>
         {element}
-        <div id="portal-root" />
       </DataContext.Provider>
     )
   }

--- a/designer/client/src/i18n/translations/cy.translation.json
+++ b/designer/client/src/i18n/translations/cy.translation.json
@@ -1,5 +1,4 @@
 {
-  "Create component": "Create component",
   "Edit page": "Golygu tudalen",
   "Persona": "Persona",
   "Preview": "Rhagolwg",

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -95,7 +95,7 @@
   "component": {
     "component": "component",
     "contentfields_info": "Content components allow you to add information to your page",
-    "create": "Create component",
+    "create": "Add component",
     "create_info": "Select a component to add to your page. If your page has only one component, the component title does not show on the page. To name or describe the component, use the page title instead.",
     "edit": "Edit {{name}} component",
     "inputfields_info": "Input fields allow you to ask users to enter information",

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -183,13 +183,23 @@ button.govuk-link {
   }
 
   .html {
-    &:before {
-      content: "⟨";
-      font-size: 20px;
-    }
+    width: 78%;
+    font-weight: bold;
+    font-size: 20px;
+
+    &:before,
     &:after {
+      position: relative;
+    }
+
+    &:before {
+      left: -1px;
+      content: "⟨";
+    }
+
+    &:after {
+      right: -1px;
       content: "⟩";
-      font-size: 20px;
     }
   }
 }

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -31,12 +31,6 @@ $govuk-assets-path: "/assets/";
   }
 }
 
-.app-editor {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
 button.govuk-link {
   @extend %app-button-link;
   @include govuk-font-size($size: 16);
@@ -52,6 +46,8 @@ button.govuk-link {
 }
 
 .menu {
+  @include govuk-responsive-margin(4, "bottom");
+
   .govuk-button {
     @include govuk-responsive-margin(1, "right");
     @include govuk-responsive-margin(1, "bottom");
@@ -204,6 +200,10 @@ button.govuk-link {
   outline: $govuk-focus-width solid $govuk-focus-colour;
   outline-offset: 0;
   box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+}
+
+.govuk-main-wrapper--editor {
+  padding-bottom: 0;
 }
 
 .govuk-input__input {

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -68,12 +68,15 @@ button.govuk-link {
   display: block;
   width: 100%;
   @include govuk-responsive-padding(2);
+
+  color: govuk-colour("black");
   text-decoration: none;
   text-align: left;
 
   &:hover,
   &:focus {
     background-color: govuk-colour("yellow");
+    color: govuk-colour("black");
     box-shadow: none;
     cursor: pointer;
   }

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -199,23 +199,6 @@ button.govuk-link {
   position: relative;
 }
 
-polyline {
-  cursor: pointer;
-
-  fill: none;
-  stroke-width: 4;
-  stroke: #000000;
-
-  &:hover,
-  &:focus {
-    outline: 6px solid $govuk-focus-colour;
-  }
-
-  :after {
-    content: "sada";
-  }
-}
-
 /* Syntax highlighting */
 .editor:focus-within {
   outline: $govuk-focus-width solid $govuk-focus-colour;

--- a/designer/client/test/helpers/renderers-lists.tsx
+++ b/designer/client/test/helpers/renderers-lists.tsx
@@ -48,7 +48,6 @@ export function customRenderForLists(
           </ListContext.Provider>
         </ListsEditorContext.Provider>
       </FlyoutContext.Provider>
-      <div id="portal-root" />
     </DataContext.Provider>,
     renderOptions
   )

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -20,6 +20,10 @@
       "data-preview-url": previewUrl
     }
   }) }}
+{% endblock %}
+
+{% block main %}
+  {{ super() }}
 
   <div id="portal-root"></div>
 {% endblock %}

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -25,7 +25,7 @@
 {% block main %}
   {{ super() }}
 
-  <div id="portal-root"></div>
+  <div class="app-form-portal"></div>
 {% endblock %}
 
 {% block bodyEnd %}

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/page.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "grid-layout/macro.njk" import appGridLayout %}
 {% from "page-body/macro.njk" import appPageBody %}
 
 {% block head %}
@@ -8,24 +9,23 @@
   <link href="{{ getAssetPath("editor.css") }}" rel="stylesheet">
 {% endblock %}
 
-{% block beforeContent %}
-  {{ govukBackLink(backLink) }}
-{% endblock %}
-
-{% block content %}
-  {{ appPageBody({
-    heading: pageHeading,
-    classes: "govuk-grid-column-full app-form-editor",
-    attributes: {
-      "data-preview-url": previewUrl
-    }
-  }) }}
-{% endblock %}
-
 {% block main %}
-  {{ super() }}
+  <div class="govuk-width-container">
+    {{ govukBackLink(backLink) }}
+  </div>
 
-  <div class="app-form-portal"></div>
+  <main class="govuk-main-wrapper govuk-main-wrapper--editor" id="main-content">
+    <div class="govuk-width-container">
+      {{ appPageBody({
+        heading: pageHeading,
+        classes: "govuk-grid-column-full"
+      }) }}
+    </div>
+
+    <!-- Form editor -->
+    <div class="app-form-editor" data-preview-url="{{ previewUrl }}"></div>
+    <div class="app-form-portal"></div>
+  </main>
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
This PR adds horizontal scrolling to the editor as part of [story #341960](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/341960)

Also included:

1. Open all "flyout" modals in `<RenderInPortal>` to avoid scroll overflow
2. Fix component icon colour and weight where link styles conflicted
3. Styled the condition captions that appear on the lines between pages
4. Renamed "Create component" → "Add component" buttons to match modals

<img width="1268" alt="Condition captions" src="https://github.com/DEFRA/forms-designer/assets/415517/e3d678e5-ef97-4c48-9b3a-b8a252f63ec3">

## Preview

https://github.com/DEFRA/forms-designer/assets/415517/6087cf82-3777-4e74-99a2-e92c50ab50a4

