### PR TITLE
Feature/library dates

### DIFF
--- a/designer/server/src/views/forms/library.njk
+++ b/designer/server/src/views/forms/library.njk
@@ -33,9 +33,11 @@
         </a>
       {% endset %}
 
+      {% set state = form.draft if form.draft else form.live %}
+
       {% set formUpdated %}
-        <span class="app-display-until-desktop">Updated </span>{{ (form.draft.updatedAt if form.draft.updatedAt else "2024-04-09") | formatDate }}<br>
-        by {{ form.draft.updatedBy.displayName | default("Enrique Chase", true) }}
+        <span class="app-display-until-desktop">Updated </span>{{ state.updatedAt | formatDate }}<br>
+        by {{ state.updatedBy.displayName }}
       {% endset %}
 
       {% set formNameUpdated %}

--- a/designer/server/src/views/forms/partials/overview-draft.njk
+++ b/designer/server/src/views/forms/partials/overview-draft.njk
@@ -5,13 +5,11 @@
 {% endset %}
 
 {% set formUpdated %}
-  {{ (form.draft.updatedAt if form.draft.updatedAt else "2024-04-09") | formatDate }}
-  by {{ form.draft.updatedBy.displayName | default("Enrique Chase", true) }}
+  {{ form.draft.updatedAt | formatDate }} by {{ form.draft.updatedBy.displayName }}
 {% endset %}
 
 {% set formCreated %}
-  {{ (form.draft.createdAt if form.draft.createdAt else "2024-03-01") | formatDate }}
-  by {{ form.draft.createdBy.displayName | default("Nathanael Booker", true) }}
+  {{ form.draft.createdAt | formatDate }} by {{ form.draft.createdBy.displayName }}
 {% endset %}
 
 {% set formPreviewLink %}

--- a/designer/server/src/views/forms/partials/overview-live.njk
+++ b/designer/server/src/views/forms/partials/overview-live.njk
@@ -5,8 +5,7 @@
 {% endset %}
 
 {% set formCreated %}
-  {{ (form.live.createdAt if form.live.createdAt else "2024-03-01") | formatDate }}
-  by {{ form.live.createdBy.displayName | default("Nathanael Booker", true) }}
+  {{ form.live.createdAt | formatDate }} by {{ form.live.createdBy.displayName }}
 {% endset %}
 
 {% set formPreviewLink %}


### PR DESCRIPTION
When a form is made live, the draft is removed from the metadata. The library page currently uses this draft date and author and without it, fallsback to "Enrique Chase".

This PR looks for the draft first, falling back to the live state in the metadata if it's not there.

Also, I've removed all the "Enrique Chase" fallbacks as we don't need this anymore.