### PR TITLE
Prevent docker services from restarting when stopped

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   redis:
     image: redis:7.0.7
-    restart: always
+    restart: unless-stopped
     ports:
       - '6379:6379'
     environment:


### PR DESCRIPTION
This PR prevents our Docker services restarting automatically (e.g. after a reboot)

When following the README you'll currently see `docker compose up` reconnects rather than starts

```patch
-   restart: always
+   restart: unless-stopped
```

>Similar to `always`, except that when the container is stopped (manually or otherwise), it isn't restarted even after Docker daemon restarts.