### PR TITLE
Allow form definition with optional `startPage` and `phaseBanner`

### DIFF
--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -1,4 +1,4 @@
-import { clone, updateStartPage } from '@defra/forms-model'
+import { clone } from '@defra/forms-model'
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, { Component, createRef, type ContextType } from 'react'
 

--- a/designer/client/src/data/component/updateComponent.ts
+++ b/designer/client/src/data/component/updateComponent.ts
@@ -1,8 +1,4 @@
-import {
-  updateStartPage,
-  type FormDefinition,
-  type ComponentDef
-} from '@defra/forms-model'
+import { type FormDefinition, type ComponentDef } from '@defra/forms-model'
 
 import { findPage } from '~/src/data/page/findPage.js'
 import { type Path } from '~/src/data/types.js'

--- a/designer/client/src/data/page/deleteLink.ts
+++ b/designer/client/src/data/page/deleteLink.ts
@@ -1,4 +1,4 @@
-import { updateStartPage, type FormDefinition } from '@defra/forms-model'
+import { type FormDefinition } from '@defra/forms-model'
 
 import { findPage } from '~/src/data/page/findPage.js'
 import { type Path } from '~/src/data/types.js'

--- a/designer/client/src/data/page/updateLink.ts
+++ b/designer/client/src/data/page/updateLink.ts
@@ -1,8 +1,4 @@
-import {
-  updateStartPage,
-  type ConditionRawData,
-  type FormDefinition
-} from '@defra/forms-model'
+import { type ConditionRawData, type FormDefinition } from '@defra/forms-model'
 
 import { findPage } from '~/src/data/page/findPage.js'
 import { type Path } from '~/src/data/types.js'

--- a/designer/server/src/routes/forms/api.test.js
+++ b/designer/server/src/routes/forms/api.test.js
@@ -22,8 +22,9 @@ describe('Server API', () => {
       method: 'put',
       url: '/api/test-form-id/data',
       auth,
-      payload: /** @satisfies {FormDefinition} */ ({
-        pages: [],
+
+      // Allow missing missing `pages` property for test
+      payload: /** @satisfies {Omit<FormDefinition, 'pages'>} */ ({
         lists: [],
         sections: [],
         conditions: []
@@ -35,7 +36,7 @@ describe('Server API', () => {
     )
 
     expect(result.statusCode).toBe(500)
-    expect(result.result.err.message).toMatch('Schema validation failed')
+    expect(result.result?.err.message).toMatch('Schema validation failed')
   })
 
   test('persistence service errors should return 500', async () => {
@@ -82,7 +83,7 @@ describe('Server API', () => {
 
     // Then
     expect(result.statusCode).toBe(500)
-    expect(result.result.err.message).toBe('Error in persistence service')
+    expect(result.result?.err.message).toBe('Error in persistence service')
   })
 })
 

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -220,7 +220,7 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
     metadata: Joi.object({ a: Joi.any() }).unknown().optional(),
     declaration: Joi.string().allow('').optional(),
     skipSummary: Joi.boolean().optional().default(false),
-    phaseBanner: phaseBannerSchema,
+    phaseBanner: phaseBannerSchema.optional(),
     specialPages: specialPagesSchema.optional(),
     outputEmail: Joi.string()
       .email({ tlds: { allow: ['uk'] } })

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -204,7 +204,7 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
   .keys({
     name: localisedString.optional(),
     feedback: feedbackSchema.optional(),
-    startPage: Joi.string().required(),
+    startPage: Joi.string().optional(),
     pages: Joi.array<Page | RepeatingFieldPage>()
       .required()
       .items(pageSchema)


### PR DESCRIPTION
## What
This PR updates the form definition schema to make journey start pages optional and fixes a regression in:

* https://github.com/DEFRA/forms-designer/pull/269

Forms cannot currently be saved when pages are orphaned after:

1. Removing a page
2. Removing a link
3. Updating a page link
4. Updating a page path

The same applies following a JSON form definition upload with:

* Missing or null `startPage`
* Empty `startPage` like `''`
* Invalid `startPage` like `/error-404`
* Incorrect `startPage` like `/step-two`

Whilst start pages are mandatory for live forms, it's common for orphaned pages during development

## Why
JavaScript errors are logged in the form editor when deleting links between pages

The error comes from **forms-manager** during schema validation:

```console
[server]     err: {
[server]       "type": "Error",
[server]       "message": "Schema validation failed, reason: \"startPage\" is required: \"startPage\" is required",
[server]       "stack":
[server]           Error: Schema validation failed, reason: "startPage" is required
[server]               at handler (file:///path/to/project/forms-designer/designer/server/src/routes/forms/api.js:58:19)
```

## Done when

Forms can be saved with orphaned pages again after:

1. Removing a page
2. Removing a link
3. Updating a page link
4. Updating a page path

**Question:** How do we prevent an empty `startPage` being made live?