### PR TITLE
Surface error messages to the user when making an invalid form live

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -52,6 +52,7 @@
     "focus-trap-react": "^8.11.3",
     "govuk-frontend": "^5.4.0",
     "hapi-pino": "^12.1.0",
+    "http-status-codes": "^2.3.0",
     "i18next": "^23.11.5",
     "i18next-http-backend": "^2.5.2",
     "ioredis": "^5.4.1",

--- a/designer/server/src/common/constants/session-names.js
+++ b/designer/server/src/common/constants/session-names.js
@@ -4,5 +4,6 @@ export const sessionNames = {
   userAuthFailed: /** @type {const} */ ('userAuthFailed'),
   validationFailure: /** @type {const} */ ('validationFailure'),
   displayCreateLiveSuccess: /** @type {const} */ ('displayCreateLiveSuccess'),
-  displayCreateDraftSuccess: /** @type {const} */ ('displayCreateDraftSuccess')
+  displayCreateDraftSuccess: /** @type {const} */ ('displayCreateDraftSuccess'),
+  errorList: /** @type {const} */ ('errorList')
 }

--- a/designer/server/src/common/helpers/build-error-details.js
+++ b/designer/server/src/common/helpers/build-error-details.js
@@ -18,6 +18,15 @@ export function buildErrorDetails(error) {
 }
 
 /**
+ * @param {string[]} errorList
+ */
+export function buildSimpleErrorList(errorList) {
+  return errorList.map((message) => {
+    return { text: message }
+  })
+}
+
+/**
  * @param {ErrorDetails | undefined} errorDetails
  * @param {string[]} [names] - Field names to filter error list by
  */

--- a/designer/server/src/common/helpers/build-error-details.js
+++ b/designer/server/src/common/helpers/build-error-details.js
@@ -19,6 +19,7 @@ export function buildErrorDetails(error) {
 
 /**
  * @param {string[]} errorList
+ * @returns {ErrorDetailsItem[]}
  */
 export function buildSimpleErrorList(errorList) {
   return errorList.map((message) => {
@@ -42,7 +43,8 @@ export function buildErrorList(errorDetails, names) {
 
 /**
  * @typedef {import('joi').ValidationError} ValidationError
- * @typedef {Record<string, { text: string, href: string }>} ErrorDetails
+ * @typedef {{ text: string, href?: string }} ErrorDetailsItem
+ * @typedef {Record<string, ErrorDetailsItem>} ErrorDetails
  */
 
 /**

--- a/designer/server/src/lib/fetch.js
+++ b/designer/server/src/lib/fetch.js
@@ -15,7 +15,13 @@ export async function request(method, url, options) {
 
   if (response.statusCode !== 200) {
     const statusCode = response.statusCode
-    const err = new Error(`HTTP status code ${statusCode}`)
+    let err
+
+    if ('message' in body && typeof body.message === 'string' && body.message) {
+      err = new Error(body.message)
+    } else {
+      err = new Error(`HTTP status code ${statusCode}`)
+    }
 
     throw Boom.boomify(err, { statusCode, data: body })
   }

--- a/designer/server/src/models/forms/form-lifecycle.js
+++ b/designer/server/src/models/forms/form-lifecycle.js
@@ -5,7 +5,7 @@ import { render } from '~/src/common/nunjucks/index.js'
 /**
  * Model to represent confirmation page dialog for a given form.
  * @param {FormMetadata} form
- * @param {import('~/src/common/helpers/build-error-details.js').ErrorDetailsItem[]} errorList - list of errors to display to the user
+ * @param {ErrorDetailsItem[]} errorList - list of errors to display to the user
  */
 export function confirmationPageViewModel(form, errorList) {
   const pageTitle = 'Are you sure you want to make the draft live?'
@@ -47,4 +47,5 @@ export function confirmationPageViewModel(form, errorList) {
 
 /**
  * @typedef {import("./library.js").FormMetadata} FormMetadata
+ * @typedef {import('~/src/common/helpers/build-error-details.js').ErrorDetailsItem} ErrorDetailsItem
  */

--- a/designer/server/src/models/forms/form-lifecycle.js
+++ b/designer/server/src/models/forms/form-lifecycle.js
@@ -5,7 +5,7 @@ import { render } from '~/src/common/nunjucks/index.js'
 /**
  * Model to represent confirmation page dialog for a given form.
  * @param {FormMetadata} form
- * @param {string[]} errorList - list of errors to display to the user
+ * @param {import('~/src/common/helpers/build-error-details.js').ErrorDetailsItem[]} errorList - list of errors to display to the user
  */
 export function confirmationPageViewModel(form, errorList) {
   const pageTitle = 'Are you sure you want to make the draft live?'

--- a/designer/server/src/models/forms/form-lifecycle.js
+++ b/designer/server/src/models/forms/form-lifecycle.js
@@ -5,8 +5,9 @@ import { render } from '~/src/common/nunjucks/index.js'
 /**
  * Model to represent confirmation page dialog for a given form.
  * @param {FormMetadata} form
+ * @param {string[]} errorList - list of errors to display to the user
  */
-export function confirmationPageViewModel(form) {
+export function confirmationPageViewModel(form, errorList) {
   const pageTitle = 'Are you sure you want to make the draft live?'
 
   const formPath = `/library/${form.slug}`
@@ -19,6 +20,8 @@ export function confirmationPageViewModel(form) {
       text: pageTitle,
       caption: form.title
     },
+
+    errorList,
 
     warning: form.live
       ? { text: `It will replace the form that is currently live.` }

--- a/designer/server/src/routes/forms/form-lifecycle.js
+++ b/designer/server/src/routes/forms/form-lifecycle.js
@@ -56,11 +56,8 @@ export default [
         yar.flash(sessionNames.displayCreateLiveSuccess, true)
         return h.redirect(`/library/${form.slug}`)
       } catch (err) {
-        if (Boom.isBoom(err)) {
-          yar.flash(
-            sessionNames.errorList,
-            buildSimpleErrorList([err.data.message])
-          )
+        if (Boom.isBoom(err) && err.output.statusCode === 400) {
+          yar.flash(sessionNames.errorList, buildSimpleErrorList([err.message]))
 
           return h.redirect(`/library/${form.slug}/make-draft-live`)
         }

--- a/designer/server/src/routes/forms/form-lifecycle.js
+++ b/designer/server/src/routes/forms/form-lifecycle.js
@@ -1,4 +1,5 @@
 import Boom from '@hapi/boom'
+import { StatusCodes } from 'http-status-codes'
 
 import * as scopes from '~/src/common/constants/scopes.js'
 import { sessionNames } from '~/src/common/constants/session-names.js'
@@ -56,7 +57,10 @@ export default [
         yar.flash(sessionNames.displayCreateLiveSuccess, true)
         return h.redirect(`/library/${form.slug}`)
       } catch (err) {
-        if (Boom.isBoom(err) && err.output.statusCode === 400) {
+        if (
+          Boom.isBoom(err) &&
+          err.output.statusCode === StatusCodes.BAD_REQUEST.valueOf()
+        ) {
           yar.flash(sessionNames.errorList, buildSimpleErrorList([err.message]))
 
           return h.redirect(`/library/${form.slug}/make-draft-live`)

--- a/designer/server/src/routes/forms/form-lifecycle.js
+++ b/designer/server/src/routes/forms/form-lifecycle.js
@@ -1,5 +1,8 @@
+import Boom from '@hapi/boom'
+
 import * as scopes from '~/src/common/constants/scopes.js'
 import { sessionNames } from '~/src/common/constants/session-names.js'
+import { buildSimpleErrorList } from '~/src/common/helpers/build-error-details.js'
 import * as forms from '~/src/lib/forms.js'
 import * as formLifecycle from '~/src/models/forms/form-lifecycle.js'
 
@@ -11,12 +14,18 @@ export default [
     method: 'GET',
     path: '/library/{slug}/make-draft-live',
     async handler(request, h) {
+      const { yar } = request
       const { token } = request.auth.credentials
       const form = await forms.get(request.params.slug, token)
 
+      const formPromotionValidationFailure = yar.flash(sessionNames.errorList)
+
       return h.view(
         'forms/make-draft-live',
-        formLifecycle.confirmationPageViewModel(form)
+        formLifecycle.confirmationPageViewModel(
+          form,
+          formPromotionValidationFailure
+        )
       )
     },
     options: {
@@ -41,10 +50,23 @@ export default [
 
       const form = await forms.get(request.params.slug, token)
 
-      await forms.makeDraftFormLive(form.id, token)
+      try {
+        await forms.makeDraftFormLive(form.id, token)
 
-      yar.flash(sessionNames.displayCreateLiveSuccess, true)
-      return h.redirect(`/library/${form.slug}`)
+        yar.flash(sessionNames.displayCreateLiveSuccess, true)
+        return h.redirect(`/library/${form.slug}`)
+      } catch (err) {
+        if (Boom.isBoom(err)) {
+          yar.flash(
+            sessionNames.errorList,
+            buildSimpleErrorList([err.data.message])
+          )
+
+          return h.redirect(`/library/${form.slug}/make-draft-live`)
+        }
+
+        throw err
+      }
     },
     options: {
       auth: {

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -9,7 +9,10 @@ import {
   type Credentials,
   type UserProfile
 } from '~/src/common/helpers/auth/azure-oidc.js'
-import { type ValidationFailure } from '~/src/common/helpers/build-error-details.js'
+import {
+  type ErrorDetailsItem,
+  type ValidationFailure
+} from '~/src/common/helpers/build-error-details.js'
 
 interface SessionCache {
   drop: (key: string) => Promise<void>
@@ -109,7 +112,7 @@ declare module '@hapi/yar' {
     /**
      * Get temporary error messages relating to the current page.
      */
-    flash(type: ErrorListKey): string[]
+    flash(type: ErrorListKey): ErrorDetailsItem[]
 
     /**
      * Get temporary flag that user failed authorisation

--- a/designer/server/src/types.ts
+++ b/designer/server/src/types.ts
@@ -91,6 +91,7 @@ declare module '@hapi/yar' {
     (typeof sessionNames)['displayCreateLiveSuccess']
   type DisplayCreatDraftSuccessKey =
     (typeof sessionNames)['displayCreateDraftSuccess']
+  type ErrorListKey = (typeof sessionNames)['errorList']
 
   interface Yar {
     /**
@@ -104,6 +105,11 @@ declare module '@hapi/yar' {
      * (Deleted when read, e.g. after a redirect)
      */
     flash(type: ValidationKey): ValidationFailure<FormMetadataInput>[]
+
+    /**
+     * Get temporary error messages relating to the current page.
+     */
+    flash(type: ErrorListKey): string[]
 
     /**
      * Get temporary flag that user failed authorisation

--- a/designer/server/src/views/forms/make-draft-live.njk
+++ b/designer/server/src/views/forms/make-draft-live.njk
@@ -6,7 +6,8 @@
 {% block content %}
   <form method="post" novalidate>
     {% call appPageBody({
-      heading: pageHeading
+      heading: pageHeading,
+      errorList: errorList
     }) %}
       {% if warning %}
         {{ govukWarningText(warning) }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "focus-trap-react": "^8.11.3",
         "govuk-frontend": "^5.4.0",
         "hapi-pino": "^12.1.0",
+        "http-status-codes": "^2.3.0",
         "i18next": "^23.11.5",
         "i18next-http-backend": "^2.5.2",
         "ioredis": "^5.4.1",
@@ -10324,6 +10325,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",


### PR DESCRIPTION
Ticket: https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/401610

When a user tries to promote a draft form but it fails, display the error message to the user

Current, forms-manager reports back three errors for bad request:

- This form is already live. Create a new draft to change the form.
- The questions in this form are not all connected. Connect all pages within the form.
- The draft form does not contain an output email address. Add an output email address for forms to be sent to.

Dan will be reviewing wording for the latter, but won't be a blocker for this PR.

To be deployed after https://github.com/DEFRA/forms-manager/pull/200.

![image](https://github.com/DEFRA/forms-designer/assets/6862563/65ad7934-bc5f-4571-8447-be2d8af80728)
![image](https://github.com/DEFRA/forms-designer/assets/6862563/889f73eb-9a9e-4bef-80fc-b37016379070)
![image](https://github.com/DEFRA/forms-designer/assets/6862563/8e16bb6b-e8e8-431d-a57f-db474d1b530f)
