### PR TITLE
Only allow option `hideTitle` to remove UK address title etc

### DIFF
--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -222,18 +222,18 @@ export const componentTypes = {
 export interface Props {
   data: FormDefinition
   page: Page | RepeatingFieldPage
-  component: ComponentDef
+  selectedComponent: ComponentDef
 }
 
 export const Component: FunctionComponent<Props> = (props) => {
-  const { page, component } = props
+  const { page, selectedComponent } = props
 
   const [showEditor, setShowEditor] = useState<boolean>(false)
   const toggleShowEditor = () => setShowEditor(!showEditor)
 
-  const TagName = componentTypes[component.type]
+  const TagName = componentTypes[selectedComponent.type]
   const editFlyoutTitle = i18n('component.edit', {
-    name: `$t(fieldTypeToName.${component.type})`
+    name: `$t(fieldTypeToName.${selectedComponent.type})`
   })
 
   return (
@@ -246,7 +246,7 @@ export const Component: FunctionComponent<Props> = (props) => {
           <Flyout title={editFlyoutTitle} onHide={toggleShowEditor}>
             <ComponentContextProvider
               pagePath={page.path}
-              component={component}
+              selectedComponent={selectedComponent}
             >
               <ComponentEdit page={page} toggleShowEditor={toggleShowEditor} />
             </ComponentContextProvider>

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -41,7 +41,7 @@ describe('ComponentTypeEdit', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'TestCheckboxes',
           title: 'Test checkboxes',
           list: 'TestList',
@@ -132,7 +132,7 @@ describe('ComponentTypeEdit', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'TestRadios',
           title: 'Test radios',
           list: 'TestList',
@@ -223,7 +223,7 @@ describe('ComponentTypeEdit', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'TestSelect',
           title: 'Test select',
           list: 'TestList',
@@ -314,7 +314,7 @@ describe('ComponentTypeEdit', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'TestYesNo',
           title: 'Test yes/no',
           type: ComponentType.YesNoField,

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -379,5 +379,20 @@ describe('ComponentTypeEdit', () => {
         'This is generated automatically and does not show on the page. Only change it if you are using an integration that requires you to, for example GOV.UK Notify. It must not contain spaces.'
       expect(getByText(text)).toBeInTheDocument()
     })
+
+    test('make yes/no field optional hint text is rendered correctly', () => {
+      render(
+        <RenderWithContext data={data} state={state}>
+          <ComponentTypeEdit />
+        </RenderWithContext>
+      )
+
+      const labelText = 'Make Yes/No field optional'
+      const hintText =
+        'Tick this box if users do not need to complete this field to progress through the form'
+
+      expect(getByText(labelText)).toBeInTheDocument()
+      expect(getByText(hintText)).toBeInTheDocument()
+    })
   })
 })

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -28,7 +28,17 @@ describe('ComponentTypeEdit', () => {
           section: 'home'
         }
       ],
-      lists: [],
+      lists: [
+        {
+          name: 'myList',
+          title: 'My list',
+          type: 'string',
+          items: [
+            { text: 'text a', description: 'desc a', value: 'value a' },
+            { text: 'text b', description: 'desc b', value: 'value b' }
+          ]
+        }
+      ],
       sections: [],
       conditions: []
     }
@@ -44,7 +54,7 @@ describe('ComponentTypeEdit', () => {
         selectedComponent: {
           name: 'TestCheckboxes',
           title: 'Test checkboxes',
-          list: 'TestList',
+          list: 'myList',
           type: ComponentType.CheckboxesField,
           subType: ComponentSubType.ListField,
           options: {},
@@ -135,7 +145,7 @@ describe('ComponentTypeEdit', () => {
         selectedComponent: {
           name: 'TestRadios',
           title: 'Test radios',
-          list: 'TestList',
+          list: 'myList',
           type: ComponentType.RadiosField,
           subType: ComponentSubType.ListField,
           options: {},
@@ -226,7 +236,7 @@ describe('ComponentTypeEdit', () => {
         selectedComponent: {
           name: 'TestSelect',
           title: 'Test select',
-          list: 'TestList',
+          list: 'myList',
           type: ComponentType.SelectField,
           subType: ComponentSubType.ListField,
           options: {},

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -190,7 +190,7 @@ describe('ComponentTypeEdit', () => {
       expect(getByText(text)).toBeInTheDocument()
     })
 
-    test('make checkbox field optional hint text is rendered correctly', () => {
+    test('make radios field optional hint text is rendered correctly', () => {
       render(
         <RenderWithContext data={data} state={state}>
           <ComponentTypeEdit />
@@ -281,7 +281,7 @@ describe('ComponentTypeEdit', () => {
       expect(getByText(text)).toBeInTheDocument()
     })
 
-    test('make checkbox field optional hint text is rendered correctly', () => {
+    test('make select field optional hint text is rendered correctly', () => {
       render(
         <RenderWithContext data={data} state={state}>
           <ComponentTypeEdit />

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -13,7 +13,7 @@ import { type ComponentState } from '~/src/reducers/component/componentReducer.j
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
 describe('ComponentTypeEdit', () => {
-  const { getByText } = screen
+  const { getByText, queryByText } = screen
 
   let data: FormDefinition
 
@@ -85,7 +85,7 @@ describe('ComponentTypeEdit', () => {
       expect(getByText(text)).toBeInTheDocument()
     })
 
-    test('hide title checkbox hint text is rendered correctly', () => {
+    test('hide title checkbox hint text is not rendered', () => {
       render(
         <RenderWithContext data={data} state={state}>
           <ComponentTypeEdit />
@@ -94,7 +94,7 @@ describe('ComponentTypeEdit', () => {
 
       const text =
         'Tick this box if you do not want the title to show on the page'
-      expect(getByText(text)).toBeInTheDocument()
+      expect(queryByText(text)).not.toBeInTheDocument()
     })
 
     test('component name input hint text is rendered correctly', () => {
@@ -176,7 +176,7 @@ describe('ComponentTypeEdit', () => {
       expect(getByText(text)).toBeInTheDocument()
     })
 
-    test('hide title checkbox hint text is rendered correctly', () => {
+    test('hide title checkbox hint text is not rendered', () => {
       render(
         <RenderWithContext data={data} state={state}>
           <ComponentTypeEdit />
@@ -185,7 +185,7 @@ describe('ComponentTypeEdit', () => {
 
       const text =
         'Tick this box if you do not want the title to show on the page'
-      expect(getByText(text)).toBeInTheDocument()
+      expect(queryByText(text)).not.toBeInTheDocument()
     })
 
     test('component name input hint text is rendered correctly', () => {
@@ -267,7 +267,7 @@ describe('ComponentTypeEdit', () => {
       expect(getByText(text)).toBeInTheDocument()
     })
 
-    test('hide title checkbox hint text is rendered correctly', () => {
+    test('hide title checkbox hint text is not rendered', () => {
       render(
         <RenderWithContext data={data} state={state}>
           <ComponentTypeEdit />
@@ -276,7 +276,7 @@ describe('ComponentTypeEdit', () => {
 
       const text =
         'Tick this box if you do not want the title to show on the page'
-      expect(getByText(text)).toBeInTheDocument()
+      expect(queryByText(text)).not.toBeInTheDocument()
     })
 
     test('component name input hint text is rendered correctly', () => {
@@ -356,6 +356,85 @@ describe('ComponentTypeEdit', () => {
       expect(getByText(text)).toBeInTheDocument()
     })
 
+    test('hide title checkbox hint text is not rendered', () => {
+      render(
+        <RenderWithContext data={data} state={state}>
+          <ComponentTypeEdit />
+        </RenderWithContext>
+      )
+
+      const text =
+        'Tick this box if you do not want the title to show on the page'
+      expect(queryByText(text)).not.toBeInTheDocument()
+    })
+
+    test('component name input hint text is rendered correctly', () => {
+      render(
+        <RenderWithContext data={data} state={state}>
+          <ComponentTypeEdit />
+        </RenderWithContext>
+      )
+
+      const text =
+        'This is generated automatically and does not show on the page. Only change it if you are using an integration that requires you to, for example GOV.UK Notify. It must not contain spaces.'
+      expect(getByText(text)).toBeInTheDocument()
+    })
+
+    test('make yes/no field optional hint text is rendered correctly', () => {
+      render(
+        <RenderWithContext data={data} state={state}>
+          <ComponentTypeEdit />
+        </RenderWithContext>
+      )
+
+      const labelText = 'Make Yes/No field optional'
+      const hintText =
+        'Tick this box if users do not need to complete this field to progress through the form'
+
+      expect(getByText(labelText)).toBeInTheDocument()
+      expect(getByText(hintText)).toBeInTheDocument()
+    })
+  })
+
+  describe('UK address', () => {
+    let state: ComponentState
+
+    beforeEach(() => {
+      state = {
+        selectedComponent: {
+          name: 'TestUkAddress',
+          title: 'Test UK address',
+          type: ComponentType.UkAddressField,
+          subType: ComponentSubType.Field,
+          hint: '',
+          options: {},
+          schema: {}
+        } satisfies ComponentDef
+      }
+    })
+
+    test('title input hint text is rendered correctly', () => {
+      render(
+        <RenderWithContext data={data} state={state}>
+          <ComponentTypeEdit />
+        </RenderWithContext>
+      )
+
+      const text = 'Enter the name to show for this field'
+      expect(getByText(text)).toBeInTheDocument()
+    })
+
+    test('help text input hint text is rendered correctly', () => {
+      render(
+        <RenderWithContext data={data} state={state}>
+          <ComponentTypeEdit />
+        </RenderWithContext>
+      )
+
+      const text = 'Enter the description to show for this field'
+      expect(getByText(text)).toBeInTheDocument()
+    })
+
     test('hide title checkbox hint text is rendered correctly', () => {
       render(
         <RenderWithContext data={data} state={state}>
@@ -380,14 +459,14 @@ describe('ComponentTypeEdit', () => {
       expect(getByText(text)).toBeInTheDocument()
     })
 
-    test('make yes/no field optional hint text is rendered correctly', () => {
+    test('make UK address field optional hint text is rendered correctly', () => {
       render(
         <RenderWithContext data={data} state={state}>
           <ComponentTypeEdit />
         </RenderWithContext>
       )
 
-      const labelText = 'Make Yes/No field optional'
+      const labelText = 'Make UK address field optional'
       const hintText =
         'Tick this box if users do not need to complete this field to progress through the form'
 

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -1,4 +1,9 @@
-import { ComponentType, type FormDefinition } from '@defra/forms-model'
+import {
+  ComponentSubType,
+  ComponentType,
+  type ComponentDef,
+  type FormDefinition
+} from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { cleanup, render } from '@testing-library/react'
 import React from 'react'
@@ -9,23 +14,22 @@ import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 describe('Field Edit', () => {
   const { getByText } = screen
 
+  const selectedComponent: ComponentDef = {
+    name: 'IDDQl4',
+    type: ComponentType.UkAddressField,
+    title: 'UK address field',
+    subType: ComponentSubType.Field,
+    hint: '',
+    options: {},
+    schema: {}
+  }
+
   const data: FormDefinition = {
     pages: [
       {
         title: 'First page',
         path: '/first-page',
-        components: [
-          {
-            name: 'IDDQl4',
-            title: 'abc',
-            list: 'myList',
-            type: ComponentType.List,
-            options: {
-              required: true
-            },
-            schema: {}
-          }
-        ]
+        components: [selectedComponent]
       }
     ],
     lists: [],
@@ -37,7 +41,7 @@ describe('Field Edit', () => {
 
   test('Help text changes', () => {
     const { container } = render(
-      <RenderWithContext data={data}>
+      <RenderWithContext data={data} state={{ selectedComponent }}>
         <FieldEdit />
       </RenderWithContext>
     )
@@ -65,7 +69,7 @@ describe('Field Edit', () => {
 
   test('Content fields should not have optional checkbox', () => {
     const { container } = render(
-      <RenderWithContext data={data}>
+      <RenderWithContext data={data} state={{ selectedComponent }}>
         <FieldEdit isContentField={true} />
       </RenderWithContext>
     )

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -1,4 +1,4 @@
-import { ComponentTypes } from '@defra/forms-model'
+import { ComponentType, ComponentTypes } from '@defra/forms-model'
 import { Input, Textarea } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
 import React, { useContext } from 'react'
@@ -74,32 +74,35 @@ export function FieldEdit({
         }}
         {...attrs}
       />
-      <div className="govuk-checkboxes govuk-form-group">
-        <div className="govuk-checkboxes__item">
-          <input
-            className="govuk-checkboxes__input"
-            id="field-options-hideTitle"
-            name="options.hideTitle"
-            type="checkbox"
-            checked={hideTitle}
-            onChange={(e) =>
-              dispatch({
-                type: Options.EDIT_OPTIONS_HIDE_TITLE,
-                payload: e.target.checked
-              })
-            }
-          />
-          <label
-            className="govuk-label govuk-checkboxes__label"
-            htmlFor="field-options-hideTitle"
-          >
-            {i18n('common.hideTitleOption.title')}
-          </label>
-          <div className="govuk-hint govuk-checkboxes__hint">
-            {i18n('common.hideTitleOption.helpText')}
+      {selectedComponent.type &&
+        [ComponentType.UkAddressField].includes(selectedComponent.type) && (
+          <div className="govuk-checkboxes govuk-form-group">
+            <div className="govuk-checkboxes__item">
+              <input
+                className="govuk-checkboxes__input"
+                id="field-options-hideTitle"
+                name="options.hideTitle"
+                type="checkbox"
+                checked={hideTitle}
+                onChange={(e) =>
+                  dispatch({
+                    type: Options.EDIT_OPTIONS_HIDE_TITLE,
+                    payload: e.target.checked
+                  })
+                }
+              />
+              <label
+                className="govuk-label govuk-checkboxes__label"
+                htmlFor="field-options-hideTitle"
+              >
+                {i18n('common.hideTitleOption.title')}
+              </label>
+              <div className="govuk-hint govuk-checkboxes__hint">
+                {i18n('common.hideTitleOption.helpText')}
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
+        )}
       <div
         className={classNames({
           'govuk-form-group': true,

--- a/designer/client/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/designer/client/src/components/Autocomplete/Autocomplete.test.tsx
@@ -17,7 +17,7 @@ describe('AutocompleteField', () => {
 
   beforeEach(() => {
     state = {
-      component: {
+      selectedComponent: {
         name: 'TestCssClass',
         title: 'Test CSS class',
         list: 'Test list',

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
@@ -77,10 +77,10 @@ describe('ComponentListSelect', () => {
   })
 
   test('Selecting a different list changes the edit link', async () => {
-    const component = data.pages[0].components[0]
+    const selectedComponent = data.pages[0].components[0]
 
     render(
-      <RenderListEditorWithContext data={data} state={{ component }}>
+      <RenderListEditorWithContext data={data} state={{ selectedComponent }}>
         <ComponentListSelect />
       </RenderListEditorWithContext>
     )
@@ -109,11 +109,14 @@ describe('ComponentListSelect', () => {
   })
 
   test('should display list error when state has errors', async () => {
-    const component = data.pages[0].components[0]
+    const selectedComponent = data.pages[0].components[0]
     const errors = { list: { children: 'Select a list' } }
 
     const { container } = render(
-      <RenderListEditorWithContext data={data} state={{ component, errors }}>
+      <RenderListEditorWithContext
+        data={data}
+        state={{ selectedComponent, errors }}
+      >
         <ComponentListSelect />
       </RenderListEditorWithContext>
     )

--- a/designer/client/src/components/CssClasses/CssClasses.test.tsx
+++ b/designer/client/src/components/CssClasses/CssClasses.test.tsx
@@ -16,7 +16,7 @@ describe('CssClasses', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'TestCssClass',
           title: 'Test CSS class',
           type: ComponentType.TextField,

--- a/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.test.tsx
+++ b/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.test.tsx
@@ -17,7 +17,7 @@ describe('CssClasses', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'TelephoneNumberField',
           title: 'Telephone number field',
           type: ComponentType.TelephoneNumberField,

--- a/designer/client/src/components/FieldEditors/DateFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/DateFieldEdit.test.tsx
@@ -16,7 +16,7 @@ describe('date field edit', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'DateFieldEditClass',
           title: 'Date field edit class',
           hint: 'Date field hint',

--- a/designer/client/src/components/FieldEditors/NumberFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/NumberFieldEdit.test.tsx
@@ -16,7 +16,7 @@ describe('Number field edit', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'NumberFieldEditClass',
           title: 'Number field edit class',
           hint: 'Number field hint',

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.test.tsx
@@ -14,7 +14,7 @@ describe('Text field edit', () => {
 
     beforeEach(() => {
       state = {
-        component: {
+        selectedComponent: {
           name: 'TextFieldEditClass',
           title: 'Text field edit class',
           type: ComponentType.TextField,

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -9,8 +9,8 @@ import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
 import { Options, Schema } from '~/src/reducers/component/types.js'
 
 interface Props {
-  context: any // TODO
-  children: ReactNode
+  context?: typeof ComponentContext
+  children?: ReactNode
 }
 
 export function TextFieldEdit({ children, context = ComponentContext }: Props) {
@@ -163,10 +163,15 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
 
         <CssClasses />
 
-        {selectedComponent.type === ComponentType.TelephoneNumberField && (
-          // Remove type check when fully integrated into all runner components
-          <CustomValidationMessage />
-        )}
+        {selectedComponent.type &&
+          [
+            ComponentType.EmailAddressField,
+            ComponentType.MonthYearField,
+            ComponentType.MultilineTextField,
+            ComponentType.NumberField,
+            ComponentType.TelephoneNumberField,
+            ComponentType.TextField
+          ].includes(selectedComponent.type) && <CustomValidationMessage />}
       </div>
     </details>
   )

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -96,7 +96,7 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
             data-cast="number"
             id="field-schema-maxwords"
             name="schema.maxwords"
-            value={'maxwords' in options ? options.maxwords : undefined}
+            value={'maxWords' in options ? options.maxWords : undefined}
             type="number"
             onChange={(e) =>
               dispatch({

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -20,14 +20,19 @@ import { ComponentContextProvider } from '~/src/reducers/component/componentRedu
 const ComponentItem = (props: {
   index: number
   page: PageType | RepeatingFieldPage
-  component: ComponentDef
+  selectedComponent: ComponentDef
   data: FormDefinition
 }) => {
-  const { index, page, component, data } = props
+  const { index, page, selectedComponent, data } = props
 
   return (
     <div className="component-item">
-      <Component key={index} page={page} component={component} data={data} />
+      <Component
+        key={index}
+        page={page}
+        data={data}
+        selectedComponent={selectedComponent}
+      />
     </div>
   )
 }
@@ -46,8 +51,8 @@ const ComponentList = (props: {
           key={index}
           index={index}
           page={page}
-          component={component}
           data={data}
+          selectedComponent={component}
         />
       ))}
     </div>

--- a/designer/client/src/reducers/component/componentReducer.test.tsx
+++ b/designer/client/src/reducers/component/componentReducer.test.tsx
@@ -3,7 +3,8 @@ import { ComponentType, type ComponentDef } from '@defra/forms-model'
 import { fieldsReducer } from '~/src/reducers/component/componentReducer.fields.js'
 import {
   componentReducer,
-  getSubReducer
+  getSubReducer,
+  type ComponentState
 } from '~/src/reducers/component/componentReducer.jsx'
 import { metaReducer } from '~/src/reducers/component/componentReducer.meta.js'
 import { optionsReducer } from '~/src/reducers/component/componentReducer.options.js'
@@ -44,7 +45,7 @@ describe('Component reducer', () => {
       payload: title
     }
 
-    const state = {
+    const state: ComponentState = {
       selectedComponent: component,
       hasValidated: true
     }
@@ -60,7 +61,7 @@ describe('Component reducer', () => {
       type: Meta.VALIDATE
     }
 
-    const state = {
+    const state: ComponentState = {
       selectedComponent: component,
       hasValidated: false
     }

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -26,6 +26,8 @@ export interface ComponentState {
   selectedComponent?: Partial<ComponentDef>
   isNew?: boolean
   initialName?: ComponentDef['name']
+  hasValidated?: boolean
+  showDeleteWarning?: boolean
   pagePath?: string
   errors?: Partial<ErrorList<'title' | 'name' | 'content' | 'list'>>
   listItemErrors?: Partial<ErrorList<'title' | 'value'>>

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -1,5 +1,10 @@
 import { type ComponentDef } from '@defra/forms-model'
-import React, { useReducer, createContext, type Dispatch } from 'react'
+import React, {
+  useReducer,
+  createContext,
+  type Dispatch,
+  type ReactNode
+} from 'react'
 
 import { type ErrorList } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -17,7 +22,7 @@ import {
   type Actions
 } from '~/src/reducers/component/types.js'
 
-interface ComponentState {
+export interface ComponentState {
   selectedComponent?: Partial<ComponentDef>
   isNew?: boolean
   initialName?: ComponentDef['name']
@@ -95,17 +100,21 @@ export function componentReducer(
 }
 
 export const initComponentState = (props?: ComponentState): ComponentState => {
-  const selectedComponent = props?.component
   const newName = randomId()
-  return {
-    selectedComponent: selectedComponent ?? {
+
+  const {
+    selectedComponent = {
       name: newName,
       options: {},
       schema: {}
-    },
-    initialName: selectedComponent?.name ?? newName,
+    }
+  } = props ?? {}
+
+  return {
+    selectedComponent,
+    initialName: selectedComponent.name ?? newName,
     pagePath: props?.pagePath,
-    isNew: props?.isNew ?? !selectedComponent?.name,
+    isNew: props?.isNew ?? !selectedComponent.name,
     errors: props?.errors ?? {},
     listItemErrors: {}
   }

--- a/designer/client/src/section/SectionEdit.test.tsx
+++ b/designer/client/src/section/SectionEdit.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/dom'
 import { cleanup, render } from '@testing-library/react'
 import React from 'react'
 
+import { type ComponentState } from '~/src/reducers/component/componentReducer.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
@@ -11,8 +12,8 @@ describe('Section edit fields', () => {
   const { getByText } = screen
 
   test('should display titles and help texts', () => {
-    const state = {
-      component: {
+    const state: ComponentState = {
+      selectedComponent: {
         type: 'sectionFieldEdit',
         name: 'sectionFieldEditClass',
         options: {}

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -14,10 +14,6 @@ export type ConditionalComponentType =
   | ComponentType.TimeField
   | ComponentType.YesNoField
 
-export interface ContentOptions {
-  condition?: string
-}
-
 /**
  * Types for Components JSON structure which are expected by engine and turned into actual form input/content/lists
  */
@@ -101,7 +97,9 @@ interface ContentFieldBase {
   name: string
   title: string
   content: string
-  options: ContentOptions
+  options: {
+    condition?: string
+  }
   schema?: object
 }
 
@@ -129,16 +127,23 @@ interface DateFieldBase {
 export interface TextFieldComponent extends TextFieldBase {
   type: ComponentType.TextField
   options: TextFieldBase['options'] & {
+    condition?: string
     customValidationMessage?: string
   }
 }
 
 export interface EmailAddressFieldComponent extends TextFieldBase {
   type: ComponentType.EmailAddressField
+  options: TextFieldBase['options'] & {
+    condition?: string
+  }
 }
 
 export interface NumberFieldComponent extends NumberFieldBase {
   type: ComponentType.NumberField
+  options: NumberFieldBase['options'] & {
+    condition?: string
+  }
 }
 
 export interface TelephoneNumberFieldComponent extends TextFieldBase {
@@ -150,11 +155,15 @@ export interface TelephoneNumberFieldComponent extends TextFieldBase {
 
 export interface YesNoFieldComponent extends TextFieldBase {
   type: ComponentType.YesNoField
+  options: TextFieldBase['options'] & {
+    condition?: string
+  }
 }
 
 export interface MultilineTextFieldComponent extends TextFieldBase {
   type: ComponentType.MultilineTextField
   options: TextFieldBase['options'] & {
+    condition?: string
     customValidationMessage?: string
     rows?: number
     maxWords?: number
@@ -172,6 +181,9 @@ export interface UkAddressFieldComponent extends TextFieldBase {
 // Date Fields
 export interface DatePartsFieldFieldComponent extends DateFieldBase {
   type: ComponentType.DatePartsField
+  options: DateFieldBase['options'] & {
+    condition?: string
+  }
 }
 
 export interface MonthYearFieldComponent extends DateFieldBase {
@@ -180,6 +192,9 @@ export interface MonthYearFieldComponent extends DateFieldBase {
 
 export interface TimeFieldComponent extends DateFieldBase {
   type: ComponentType.TimeField
+  options: DateFieldBase['options'] & {
+    condition?: string
+  }
 }
 
 // Content Fields
@@ -208,11 +223,17 @@ export interface AutocompleteFieldComponent extends ListFieldBase {
 export interface CheckboxesFieldComponent extends ListFieldBase {
   type: ComponentType.CheckboxesField
   subType?: ComponentSubType.ListField
+  options: ListFieldBase['options'] & {
+    condition?: string
+  }
 }
 
 export interface RadiosFieldComponent extends ListFieldBase {
   type: ComponentType.RadiosField
   subType?: ComponentSubType.ListField
+  options: ListFieldBase['options'] & {
+    condition?: string
+  }
 }
 
 export interface SelectFieldComponent extends ListFieldBase {

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -31,7 +31,6 @@ interface TextFieldBase {
   title: string
   hint?: string
   options: {
-    hideTitle?: boolean
     required?: boolean
     optionalText?: boolean
     classes?: string
@@ -81,7 +80,6 @@ interface ListFieldBase {
   title: string
   options: {
     type?: string
-    hideTitle?: boolean
     required?: boolean
     optionalText?: boolean
     classes?: string
@@ -115,7 +113,6 @@ interface DateFieldBase {
   title: string
   hint?: string
   options: {
-    hideTitle?: boolean
     required?: boolean
     optionalText?: boolean
     maxDaysInFuture?: number
@@ -180,6 +177,9 @@ export interface MultilineTextFieldComponent extends TextFieldBase {
 
 export interface UkAddressFieldComponent extends TextFieldBase {
   type: ComponentType.UkAddressField
+  options: TextFieldBase['options'] & {
+    hideTitle?: boolean
+  }
 }
 
 // Date Fields

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -59,6 +59,7 @@ interface NumberFieldBase {
   title: string
   hint: string
   options: {
+    required?: boolean
     prefix?: string
     suffix?: string
     exposeToContext?: boolean

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -136,6 +136,7 @@ export interface EmailAddressFieldComponent extends TextFieldBase {
   type: ComponentType.EmailAddressField
   options: TextFieldBase['options'] & {
     condition?: string
+    customValidationMessage?: string
   }
 }
 
@@ -143,6 +144,7 @@ export interface NumberFieldComponent extends NumberFieldBase {
   type: ComponentType.NumberField
   options: NumberFieldBase['options'] & {
     condition?: string
+    customValidationMessage?: string
   }
 }
 
@@ -188,6 +190,9 @@ export interface DatePartsFieldFieldComponent extends DateFieldBase {
 
 export interface MonthYearFieldComponent extends DateFieldBase {
   type: ComponentType.MonthYearField
+  options: DateFieldBase['options'] & {
+    customValidationMessage?: string
+  }
 }
 
 export interface TimeFieldComponent extends DateFieldBase {

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -53,7 +53,7 @@ interface NumberFieldBase {
   subType?: ComponentSubType.Field
   name: string
   title: string
-  hint: string
+  hint?: string
   options: {
     required?: boolean
     optionalText?: boolean
@@ -113,7 +113,7 @@ interface DateFieldBase {
   subType?: ComponentSubType.Field
   name: string
   title: string
-  hint: string
+  hint?: string
   options: {
     hideTitle?: boolean
     required?: boolean

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -56,6 +56,8 @@ interface NumberFieldBase {
   hint: string
   options: {
     required?: boolean
+    optionalText?: boolean
+    classes?: string
     prefix?: string
     suffix?: string
     exposeToContext?: boolean


### PR DESCRIPTION
This PR disables the option `hideTitle` for components with a mandatory `<label>` or `<legend>`

Page titles will continue to automatically replace form legends or labels on single-question pages

For more information see the related **forms-runner** PR:

* https://github.com/DEFRA/forms-runner/pull/209

## Mismatched options
I've also fixed a few mismatched component options so they match their **forms-runner** usage, for example:

1. Missing option `required` on number component
2. Missing option `condition` on conditional components
3. Incorrect mandatory option `hint` on number and date components

## Custom validation messages
I've also enabled `customValidationMessage` for more components:

* Email address component
* Month and year component
* Multiline text component
* Number component
* Text input component

These were supported by **forms-runner** but only telephone number was enabled in **forms-designer**