### PR TITLE
Move API calls to Wreck

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -52,6 +52,7 @@
     "focus-trap-react": "^8.11.3",
     "govuk-frontend": "^5.4.0",
     "hapi-pino": "^12.1.0",
+    "http-status-codes": "^2.3.0",
     "i18next": "^23.11.5",
     "i18next-http-backend": "^2.5.2",
     "ioredis": "^5.4.1",

--- a/designer/server/src/common/helpers/auth/azure-oidc.js
+++ b/designer/server/src/common/helpers/auth/azure-oidc.js
@@ -1,6 +1,7 @@
 import Basic from '@hapi/basic'
 import Bell from '@hapi/bell'
 import { token } from '@hapi/jwt'
+import Wreck from '@hapi/wreck'
 import { DateTime } from 'luxon'
 
 import config from '~/src/config.js'
@@ -24,9 +25,9 @@ export const azureOidc = {
     async register(server) {
       await server.register(Bell)
 
-      const oidc = await fetch(config.oidcWellKnownConfigurationUrl).then(
-        (response) => /** @type {Promise<OidcMetadata>} */ (response.json())
-      )
+      const oidc = await Wreck.get(config.oidcWellKnownConfigurationUrl, {
+        json: true
+      }).then((response) => /** @type {OidcMetadata} */ (response.payload))
 
       server.auth.strategy(
         'azure-oidc',

--- a/designer/server/src/common/helpers/auth/refresh-token.js
+++ b/designer/server/src/common/helpers/auth/refresh-token.js
@@ -1,10 +1,10 @@
 import Boom from '@hapi/boom'
-import Wreck from '@hapi/wreck'
 
 import { scope } from '~/src/common/helpers/auth/azure-oidc.js'
 import { dropUserSession } from '~/src/common/helpers/auth/drop-user-session.js'
 import { hasAuthenticated } from '~/src/common/helpers/auth/get-user-session.js'
 import config from '~/src/config.js'
+import * as oidc from '~/src/lib/oidc.js'
 
 /**
  * @param {Request | Request<{ AuthArtifactsExtra: AuthArtifacts }>} request
@@ -33,28 +33,12 @@ export async function refreshAccessToken(request) {
   params.append('refresh_token', credentials.refreshToken)
   params.append('scope', scope.join(' '))
 
-  const oidc = await Wreck.get(config.oidcWellKnownConfigurationUrl, {
-    json: true
-  }).then((response) => /** @type {OidcMetadata} */ (response.payload))
-
-  const response = await Wreck.post(oidc.token_endpoint, {
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'Cache-Control': 'no-cache'
-    },
-    payload: params
-  })
-
-  if (!response.res.statusCode) {
+  try {
+    return oidc.getToken(params)
+  } catch (err) {
     await dropUserSession(request)
     throw Boom.unauthorized()
   }
-
-  const artifacts = await /** @type {Promise<AuthArtifacts>} */ (
-    response.payload
-  )
-
-  return artifacts
 }
 
 /**

--- a/designer/server/src/common/helpers/auth/refresh-token.js
+++ b/designer/server/src/common/helpers/auth/refresh-token.js
@@ -34,7 +34,7 @@ export async function refreshAccessToken(request) {
   params.append('scope', scope.join(' '))
 
   try {
-    return oidc.getToken(params)
+    return await oidc.getToken(params)
   } catch (err) {
     await dropUserSession(request)
     throw Boom.unauthorized()

--- a/designer/server/src/common/helpers/auth/session-cookie.js
+++ b/designer/server/src/common/helpers/auth/session-cookie.js
@@ -66,8 +66,8 @@ const sessionCookie = {
 
               // Refresh session when token has expired
               if (hasExpired(credentials)) {
-                const token = await refreshAccessToken(request)
-                credentials = await createUserSession(request, token)
+                const { body: artifacts } = await refreshAccessToken(request)
+                credentials = await createUserSession(request, artifacts)
               }
             }
 

--- a/designer/server/src/lib/fetch.js
+++ b/designer/server/src/lib/fetch.js
@@ -1,5 +1,6 @@
 import Boom from '@hapi/boom'
 import Wreck from '@hapi/wreck'
+import { StatusCodes } from 'http-status-codes'
 
 /**
  * @template {object} [BodyType=Buffer]
@@ -13,7 +14,7 @@ export async function request(method, url, options) {
   /** @type {BodyType} */
   const body = await Wreck.read(response, options)
 
-  if (response.statusCode !== 200) {
+  if (response.statusCode !== StatusCodes.OK) {
     const statusCode = response.statusCode
     const err = new Error(`HTTP status code ${statusCode}`)
 

--- a/designer/server/src/lib/oidc.js
+++ b/designer/server/src/lib/oidc.js
@@ -1,0 +1,44 @@
+import { getJson, postJson } from './fetch.js'
+
+import config from '~/src/config.js'
+
+/**
+ * Fetch the Well-Known Configuration for the OpenID Connect (OIDC) provider
+ */
+export async function getWellKnownConfiguration() {
+  const getJsonByType = /** @type {typeof getJson<OidcMetadata>} */ (getJson)
+
+  const requestUrl = new URL(config.oidcWellKnownConfigurationUrl)
+
+  const { body } = await getJsonByType(requestUrl)
+
+  return body
+}
+
+/**
+ * Get a token using the token endpoint from the Well-Known Configuration
+ * See {@link https://learn.microsoft.com/en-us/azure/active-directory-b2c/authorization-code-flow#4-refresh-the-token|Azure}'s documentation.
+ * @param {URLSearchParams} params
+ */
+export async function getToken(params) {
+  const wellKnownConfiguration = await getWellKnownConfiguration()
+
+  const requestUrl = new URL(wellKnownConfiguration.token_endpoint)
+
+  const postJsonByType = /** @type {typeof postJson<AuthArtifacts>} */ (
+    postJson
+  )
+
+  return postJsonByType(requestUrl, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Cache-Control': 'no-cache'
+    },
+    payload: params.toString()
+  })
+}
+
+/**
+ * @typedef {import('oidc-client-ts').OidcMetadata} OidcMetadata - OpenID Connect (OIDC) metadata
+ * @typedef {import('@hapi/hapi').AuthArtifacts} AuthArtifacts
+ */

--- a/designer/server/src/routes/account/sign-out.js
+++ b/designer/server/src/routes/account/sign-out.js
@@ -1,5 +1,7 @@
 import { URL } from 'node:url'
 
+import Wreck from '@hapi/wreck'
+
 import { dropUserSession } from '~/src/common/helpers/auth/drop-user-session.js'
 import { hasUser } from '~/src/common/helpers/auth/get-user-session.js'
 import config from '~/src/config.js'
@@ -18,9 +20,9 @@ export default /** @satisfies {ServerRoute} */ ({
       return h.redirect('/')
     }
 
-    const oidc = await fetch(config.oidcWellKnownConfigurationUrl).then(
-      (response) => /** @type {Promise<OidcMetadata>} */ (response.json())
-    )
+    const oidc = await Wreck.get(config.oidcWellKnownConfigurationUrl, {
+      json: true
+    }).then((response) => /** @type {OidcMetadata} */ (response.payload))
 
     // Build end session URL
     const endSessionUrl = new URL(oidc.end_session_endpoint)

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "focus-trap-react": "^8.11.3",
         "govuk-frontend": "^5.4.0",
         "hapi-pino": "^12.1.0",
+        "http-status-codes": "^2.3.0",
         "i18next": "^23.11.5",
         "i18next-http-backend": "^2.5.2",
         "ioredis": "^5.4.1",
@@ -10399,6 +10400,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",


### PR DESCRIPTION
- Adds support for proxied calls through https_proxy and http_proxy
- Reduces duplicaton, makes calling the external OIDC provider consistent with the forms-manager API's `forms.js` helpers.