### PR TITLE
Skip render when selected component is undefined

### DIFF
--- a/designer/client/jest.environment.js
+++ b/designer/client/jest.environment.js
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { initI18n } from './src/i18n/i18n.jsx'
+import { initI18n } from '~/src/i18n/i18n.jsx'
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,

--- a/designer/client/src/ComponentTypeEdit.tsx
+++ b/designer/client/src/ComponentTypeEdit.tsx
@@ -47,20 +47,23 @@ export const ComponentTypeEdit: FunctionComponent<Props> = (props) => {
     return componentType.type === selectedComponent?.type
   })
 
-  const needsFieldInputs =
-    component?.type === ComponentType.List ||
-    component?.subType !== ComponentSubType.Content
+  if (!selectedComponent) {
+    return null
+  }
 
-  const TagName = hasEditor(component)
-    ? componentTypeEditors[component.type]
+  const TagName = hasEditor(selectedComponent)
+    ? componentTypeEditors[selectedComponent.type]
     : undefined
+
+  const { type, subType } = component ?? {}
 
   return (
     <>
-      {needsFieldInputs && (
+      {(type === ComponentType.List ||
+        subType !== ComponentSubType.Content) && (
         <FieldEdit
-          isContentField={component?.subType === ComponentSubType.Content}
-          isListField={component?.subType === ComponentSubType.ListField}
+          isContentField={subType === ComponentSubType.Content}
+          isListField={subType === ComponentSubType.ListField}
         />
       )}
       {TagName && <TagName>{children}</TagName>}

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -18,9 +18,13 @@ export function FieldEdit({
   isListField = false
 }: Props) {
   const { state, dispatch } = useContext(ComponentContext)
-  const { selectedComponent = {}, errors = {} } = state
+  const { selectedComponent, errors = {} } = state
 
-  const { name, title, hint, attrs, type, options = {} } = selectedComponent
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { name, title, hint, attrs, type, options } = selectedComponent
   const {
     hideTitle = false,
     optionalText = false,
@@ -74,35 +78,34 @@ export function FieldEdit({
         }}
         {...attrs}
       />
-      {selectedComponent.type &&
-        [ComponentType.UkAddressField].includes(selectedComponent.type) && (
-          <div className="govuk-checkboxes govuk-form-group">
-            <div className="govuk-checkboxes__item">
-              <input
-                className="govuk-checkboxes__input"
-                id="field-options-hideTitle"
-                name="options.hideTitle"
-                type="checkbox"
-                checked={hideTitle}
-                onChange={(e) =>
-                  dispatch({
-                    type: Options.EDIT_OPTIONS_HIDE_TITLE,
-                    payload: e.target.checked
-                  })
-                }
-              />
-              <label
-                className="govuk-label govuk-checkboxes__label"
-                htmlFor="field-options-hideTitle"
-              >
-                {i18n('common.hideTitleOption.title')}
-              </label>
-              <div className="govuk-hint govuk-checkboxes__hint">
-                {i18n('common.hideTitleOption.helpText')}
-              </div>
+      {[ComponentType.UkAddressField].includes(selectedComponent.type) && (
+        <div className="govuk-checkboxes govuk-form-group">
+          <div className="govuk-checkboxes__item">
+            <input
+              className="govuk-checkboxes__input"
+              id="field-options-hideTitle"
+              name="options.hideTitle"
+              type="checkbox"
+              checked={hideTitle}
+              onChange={(e) =>
+                dispatch({
+                  type: Options.EDIT_OPTIONS_HIDE_TITLE,
+                  payload: e.target.checked
+                })
+              }
+            />
+            <label
+              className="govuk-label govuk-checkboxes__label"
+              htmlFor="field-options-hideTitle"
+            >
+              {i18n('common.hideTitleOption.title')}
+            </label>
+            <div className="govuk-hint govuk-checkboxes__hint">
+              {i18n('common.hideTitleOption.helpText')}
             </div>
           </div>
-        )}
+        </div>
+      )}
       <div
         className={classNames({
           'govuk-form-group': true,

--- a/designer/client/src/MultilineTextFieldEdit.enzyme.test.tsx
+++ b/designer/client/src/MultilineTextFieldEdit.enzyme.test.tsx
@@ -1,0 +1,40 @@
+import { ComponentSubType, ComponentType } from '@defra/forms-model'
+import { mount, type ReactWrapper } from 'enzyme'
+import React from 'react'
+
+import { MultilineTextFieldEdit } from '~/src/MultilineTextFieldEdit.jsx'
+import {
+  RenderWithContext,
+  type RenderWithContextProps
+} from '~/test/helpers/renderers.jsx'
+
+describe('MutlilineTextFieldEdit renders correctly when', () => {
+  let state: RenderWithContextProps['state']
+  let wrapper: ReactWrapper
+
+  beforeEach(() => {
+    state = {
+      selectedComponent: {
+        name: 'MultilineTextFieldEditClass',
+        title: 'Multiline text field edit class',
+        type: ComponentType.MultilineTextField,
+        subType: ComponentSubType.Field,
+        options: {},
+        schema: {}
+      }
+    }
+
+    wrapper = mount(
+      <RenderWithContext state={state}>
+        <MultilineTextFieldEdit />
+      </RenderWithContext>
+    )
+  })
+
+  test('schema rows changes', () => {
+    const field = () => wrapper.find('#field-options-rows')
+    const newRows = 42
+    field().simulate('change', { target: { value: newRows } })
+    expect(field().props().value).toBe(newRows)
+  })
+})

--- a/designer/client/src/MultilineTextFieldEdit.tsx
+++ b/designer/client/src/MultilineTextFieldEdit.tsx
@@ -7,8 +7,13 @@ import { Options } from '~/src/reducers/component/types.js'
 
 export function MultilineTextFieldEdit({ context = ComponentContext }) {
   const { state, dispatch } = useContext(context)
-  const { selectedComponent = {} } = state
-  const { options = {} } = selectedComponent
+  const { selectedComponent } = state
+
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { options } = selectedComponent
 
   return (
     <TextFieldEdit>

--- a/designer/client/src/components/Autocomplete/Autocomplete.tsx
+++ b/designer/client/src/components/Autocomplete/Autocomplete.tsx
@@ -6,8 +6,13 @@ import { Options } from '~/src/reducers/component/types.js'
 
 export function Autocomplete() {
   const { state, dispatch } = useContext(ComponentContext)
-  const { selectedComponent = {} } = state
-  const { options = {} } = selectedComponent
+  const { selectedComponent } = state
+
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { options } = selectedComponent
 
   return (
     <div className="govuk-form-group">

--- a/designer/client/src/components/CssClasses/CssClasses.tsx
+++ b/designer/client/src/components/CssClasses/CssClasses.tsx
@@ -6,8 +6,13 @@ import { Options } from '~/src/reducers/component/types.js'
 
 export function CssClasses() {
   const { state, dispatch } = useContext(ComponentContext)
-  const { selectedComponent = {} } = state
-  const { options = {} } = selectedComponent
+  const { selectedComponent } = state
+
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { options } = selectedComponent
 
   return (
     <div className="govuk-form-group">

--- a/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.tsx
+++ b/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.tsx
@@ -6,8 +6,13 @@ import { Options } from '~/src/reducers/component/types.js'
 
 export function CustomValidationMessage() {
   const { state, dispatch } = useContext(ComponentContext)
-  const { selectedComponent = {} } = state
-  const { options = {} } = selectedComponent
+  const { selectedComponent } = state
+
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { options } = selectedComponent
 
   return (
     <div className="govuk-form-group">

--- a/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
@@ -13,8 +13,13 @@ export function DateFieldEdit({ context = ComponentContext }: Props) {
   // If you are editing a component, the default context will be ComponentContext because props.context is undefined,
   // but if you editing a component which is a children of a list based component, then the props.context is the ListContext.
   const { state, dispatch } = useContext(context)
-  const { selectedComponent = {} } = state
-  const { options = {} } = selectedComponent
+  const { selectedComponent } = state
+
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { options } = selectedComponent
 
   return (
     <details className="govuk-details">

--- a/designer/client/src/components/FieldEditors/DetailsEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/DetailsEdit.test.tsx
@@ -1,27 +1,33 @@
+import { ComponentSubType, ComponentType } from '@defra/forms-model'
 import { cleanup, render } from '@testing-library/react'
-import React, { type ReactNode } from 'react'
+import React from 'react'
 
 import { DetailsEdit } from '~/src/components/FieldEditors/DetailsEdit.jsx'
-import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
+import {
+  RenderWithContext,
+  type RenderWithContextProps
+} from '~/test/helpers/renderers.jsx'
 
-describe('details-edit', () => {
-  afterEach(cleanup)
-
-  function TestComponentWithContext({ children }: { children: ReactNode }) {
-    return (
-      <ComponentContext.Provider
-        value={{ state: { selectedComponent: {} }, dispatch: jest.fn() }}
-      >
-        {children}
-      </ComponentContext.Provider>
-    )
+describe('Details edit', () => {
+  const state: RenderWithContextProps['state'] = {
+    selectedComponent: {
+      name: 'TextFieldEditClass',
+      title: 'Text field edit class',
+      type: ComponentType.Details,
+      subType: ComponentSubType.Content,
+      content: '',
+      options: {},
+      schema: {}
+    }
   }
+
+  afterEach(cleanup)
 
   it('Should render with correct screen text', () => {
     const { container } = render(
-      <TestComponentWithContext>
-        <DetailsEdit context={ComponentContext}></DetailsEdit>
-      </TestComponentWithContext>
+      <RenderWithContext state={state}>
+        <DetailsEdit />
+      </RenderWithContext>
     )
 
     expect(container).toHaveTextContent(

--- a/designer/client/src/components/FieldEditors/DetailsEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DetailsEdit.tsx
@@ -15,7 +15,11 @@ export function DetailsEdit({ context = ComponentContext }: Props) {
   // If you are editing a component, the default context will be ComponentContext because props.context is undefined,
   // but if you editing a component which is a children of a list based component, then the props.context is the ListContext.
   const { state, dispatch } = useContext(context)
-  const { selectedComponent = {}, errors = {} } = state
+  const { selectedComponent, errors = {} } = state
+
+  if (!selectedComponent) {
+    return null
+  }
 
   return (
     <>

--- a/designer/client/src/components/FieldEditors/ListContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.tsx
@@ -11,9 +11,13 @@ export function ListContentEdit({ context = ComponentContext }: Props) {
   // If you are editing a component, the default context will be ComponentContext because props.context is undefined,
   // but if you editing a component which is a children of a list based component, then the props.context is the ListContext.
   const { state, dispatch } = useContext(context)
-  const { selectedComponent = {} } = state
-  const { options = {} } = selectedComponent
+  const { selectedComponent } = state
 
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { options } = selectedComponent
   const checked = 'type' in options && options.type === 'numbered'
 
   return (

--- a/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
@@ -13,9 +13,13 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
   // If you are editing a component, the default context will be ComponentContext because props.context is undefined,
   // but if you editing a component which is a children of a list based component, then the props.context is the ListContext.
   const { state, dispatch } = useContext(context)
-  const { selectedComponent = {} } = state
-  const { schema = {} } = selectedComponent
-  const { options = {} } = selectedComponent
+  const { selectedComponent } = state
+
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { options, schema } = selectedComponent
 
   return (
     <details className="govuk-details">

--- a/designer/client/src/components/FieldEditors/ParaEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ParaEdit.tsx
@@ -15,11 +15,17 @@ interface Props {
 export function ParaEdit({ context = ComponentContext }: Props) {
   // If you are editing a component, the default context will be ComponentContext because props.context is undefined,
   // but if you editing a component which is a children of a list based component, then the props.context is the ListContext.
-  const { state, dispatch } = useContext(context)
-  const { selectedComponent = {}, errors = {} } = state
   const { data } = useContext(DataContext)
-  const { options = {} } = selectedComponent
+  const { state, dispatch } = useContext(context)
+
   const { conditions } = data
+  const { selectedComponent, errors = {} } = state
+
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { options } = selectedComponent
 
   return (
     <>

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.enzyme.test.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.enzyme.test.tsx
@@ -1,18 +1,37 @@
-import { mount } from 'enzyme'
+import { ComponentSubType, ComponentType } from '@defra/forms-model'
+import { mount, type ReactWrapper } from 'enzyme'
 import React from 'react'
 
-import { MultilineTextFieldEdit } from '~/src/MultilineTextFieldEdit.jsx'
 import { TextFieldEdit } from '~/src/components/FieldEditors/TextFieldEdit.jsx'
-import * as Component from '~/src/reducers/component/componentReducer.jsx'
+import {
+  RenderWithContext,
+  type RenderWithContextProps
+} from '~/test/helpers/renderers.jsx'
 
 describe('TextField renders correctly when', () => {
-  const wrapper = mount(
-    <Component.ComponentContextProvider>
-      <TextFieldEdit />
-    </Component.ComponentContextProvider>
-  )
+  let state: RenderWithContextProps['state']
+  let wrapper: ReactWrapper
 
-  test('schema max length changes', () => {
+  beforeEach(() => {
+    state = {
+      selectedComponent: {
+        name: 'TextFieldEditClass',
+        title: 'Text field edit class',
+        type: ComponentType.TextField,
+        subType: ComponentSubType.Field,
+        options: {},
+        schema: {}
+      }
+    }
+
+    wrapper = mount(
+      <RenderWithContext state={state}>
+        <TextFieldEdit />
+      </RenderWithContext>
+    )
+  })
+
+  test('schema length changes', () => {
     const field = () => wrapper.find('#field-schema-length').first()
     const length = 1337
     field().simulate('change', { target: { value: length } })
@@ -38,19 +57,5 @@ describe('TextField renders correctly when', () => {
     const regex = '/ab+c/'
     field().simulate('change', { target: { value: regex } })
     expect(field().props().value).toBe(regex)
-  })
-})
-
-describe('MutlilineTextFieldEdit renders correctly when', () => {
-  const wrapper = mount(
-    <Component.ComponentContextProvider>
-      <MultilineTextFieldEdit />
-    </Component.ComponentContextProvider>
-  )
-  test('schema rows changes', () => {
-    const field = () => wrapper.find('#field-options-rows')
-    const newRows = 42
-    field().simulate('change', { target: { value: newRows } })
-    expect(field().props().value).toBe(newRows)
   })
 })

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -17,8 +17,13 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
   // If you are editing a component, the default context will be ComponentContext because props.context is undefined,
   // but if you editing a component which is a children of a list based component, then the props.context is the ListContext.
   const { state, dispatch } = useContext(context)
-  const { selectedComponent = {} } = state
-  const { schema = {}, options = {} } = selectedComponent
+  const { selectedComponent } = state
+
+  if (!selectedComponent) {
+    return null
+  }
+
+  const { schema, options } = selectedComponent
 
   return (
     <details className="govuk-details">
@@ -163,15 +168,14 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
 
         <CssClasses />
 
-        {selectedComponent.type &&
-          [
-            ComponentType.EmailAddressField,
-            ComponentType.MonthYearField,
-            ComponentType.MultilineTextField,
-            ComponentType.NumberField,
-            ComponentType.TelephoneNumberField,
-            ComponentType.TextField
-          ].includes(selectedComponent.type) && <CustomValidationMessage />}
+        {[
+          ComponentType.EmailAddressField,
+          ComponentType.MonthYearField,
+          ComponentType.MultilineTextField,
+          ComponentType.NumberField,
+          ComponentType.TelephoneNumberField,
+          ComponentType.TextField
+        ].includes(selectedComponent.type) && <CustomValidationMessage />}
       </div>
     </details>
   )

--- a/designer/server/src/common/nunjucks/plugin.js
+++ b/designer/server/src/common/nunjucks/plugin.js
@@ -3,9 +3,8 @@ import { join } from 'node:path'
 import hapiVision from '@hapi/vision'
 import nunjucks from 'nunjucks'
 
-import { environment } from './environment.js'
-
 import { context } from '~/src/common/nunjucks/context/index.js'
+import { environment } from '~/src/common/nunjucks/environment.js'
 import config from '~/src/config.js'
 
 export const plugin = {

--- a/designer/server/src/lib/oidc.js
+++ b/designer/server/src/lib/oidc.js
@@ -1,6 +1,5 @@
-import { getJson, postJson } from './fetch.js'
-
 import config from '~/src/config.js'
+import { getJson, postJson } from '~/src/lib/fetch.js'
 
 /**
  * Fetch the Well-Known Configuration for the OpenID Connect (OIDC) provider

--- a/designer/server/src/models/forms/form-lifecycle.js
+++ b/designer/server/src/models/forms/form-lifecycle.js
@@ -1,6 +1,5 @@
-import { getFormSpecificNavigation } from './library.js'
-
 import { render } from '~/src/common/nunjucks/index.js'
+import { getFormSpecificNavigation } from '~/src/models/forms/library.js'
 
 /**
  * Model to represent confirmation page dialog for a given form.

--- a/designer/server/src/routes/account/index.js
+++ b/designer/server/src/routes/account/index.js
@@ -1,5 +1,5 @@
-import auth from './auth.js'
-import signOut from './sign-out.js'
-import signedOut from './signed-out.js'
+import auth from '~/src/routes/account/auth.js'
+import signOut from '~/src/routes/account/sign-out.js'
+import signedOut from '~/src/routes/account/signed-out.js'
 
 export default [auth, signOut, signedOut].flat()

--- a/designer/server/src/routes/forms/index.js
+++ b/designer/server/src/routes/forms/index.js
@@ -1,6 +1,6 @@
-import api from './api.js'
-import create from './create.js'
-import formLifecycle from './form-lifecycle.js'
-import library from './library.js'
+import api from '~/src/routes/forms/api.js'
+import create from '~/src/routes/forms/create.js'
+import formLifecycle from '~/src/routes/forms/form-lifecycle.js'
+import library from '~/src/routes/forms/library.js'
 
 export default [api, create, library, formLifecycle].flat()

--- a/designer/server/src/routes/index.js
+++ b/designer/server/src/routes/index.js
@@ -1,8 +1,8 @@
-import account from './account/index.js'
-import assets from './assets.js'
-import forms from './forms/index.js'
-import health from './health.js'
-import help from './help.js'
-import home from './home.js'
+import account from '~/src/routes/account/index.js'
+import assets from '~/src/routes/assets.js'
+import forms from '~/src/routes/forms/index.js'
+import health from '~/src/routes/health.js'
+import help from '~/src/routes/help.js'
+import home from '~/src/routes/home.js'
 
 export default [account, assets, forms, health, home, help].flat()


### PR DESCRIPTION
This PR ensures "edit component" pages only render when `selectedComponent` exists in state

Some of our tests relied on partly-broken pages to be rendered with no known component