### PR TITLE
Preserve 100px × 30px safe space for condition tag

### DIFF
--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -47,8 +47,14 @@ export class Lines extends Component<Props, State> {
             const xs = edge.points.map((p) => p.x)
             const ys = edge.points.map((p) => p.y)
 
-            const textWidth = Math.max(...xs) - Math.min(...xs)
-            const textHeight = Math.max(...ys) - Math.min(...ys)
+            const xMax = Math.max(...xs)
+            const xMin = Math.min(...xs)
+            const yMax = Math.max(...ys)
+            const yMin = Math.min(...ys)
+
+            // Preserve 100px × 30px safe space for condition
+            const textWidth = Math.max(xMax - xMin, 100)
+            const textHeight = Math.max(yMax - yMin, 30)
 
             const textX = xs.reduce((a, b) => a + b, 0) / xs.length
             const textY = ys.reduce((a, b) => a + b, 0) / ys.length


### PR DESCRIPTION
Super quick fix to avoid confusion, see [story #409869](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/409869)

## Before
No condition in Chrome, Edge or Firefox (Safari works)

<img width="331" alt="Current line is missing the condition tag" src="https://github.com/DEFRA/forms-designer/assets/415517/3cbd4671-abf3-4320-9e21-21ce67f1d9ae">

## After
Condition tag is rendered correctly

<img width="329" alt="Condition line shows condition tag" src="https://github.com/DEFRA/forms-designer/assets/415517/79db7310-3200-4ebc-89dc-ff65585e64c8">
