### PR TITLE
Add form metadata to info tabs, rename to "Form overview"

### DIFF
--- a/designer/client/src/Designer.tsx
+++ b/designer/client/src/Designer.tsx
@@ -20,16 +20,18 @@ interface Props {
 interface State {
   flyoutCount: number
   data: FormDefinition
+  meta: FormMetadata
 }
 
 export class Designer extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
 
-    const { definition } = this.props
+    const { definition, metadata } = this.props
 
     this.state = {
       data: definition,
+      meta: metadata,
       flyoutCount: 0
     }
   }
@@ -68,7 +70,7 @@ export class Designer extends Component<Props, State> {
 
   render() {
     const { metadata, previewUrl } = this.props
-    const { data, flyoutCount } = this.state
+    const { data, meta, flyoutCount } = this.state
 
     const flyoutContextProviderValue = {
       count: flyoutCount,
@@ -78,6 +80,7 @@ export class Designer extends Component<Props, State> {
 
     const dataContextProviderValue = {
       data,
+      meta,
       save: this.save
     }
 

--- a/designer/client/src/Editor.tsx
+++ b/designer/client/src/Editor.tsx
@@ -1,7 +1,6 @@
 import { highlight, languages } from 'prismjs'
 import React, { Component, type TextareaHTMLAttributes } from 'react'
 import SimpleEditor from 'react-simple-code-editor'
-import 'prismjs/components/prism-markup.js'
 
 type Props = {
   value?: string

--- a/designer/client/src/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/src/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -1,45 +1,11 @@
-import React, { useContext } from 'react'
+import React, { type HTMLAttributes, type FunctionComponent } from 'react'
 
-import { DataContext } from '~/src/context/DataContext.js'
-
-const listTypes = [
-  'SelectField',
-  'RadiosField',
-  'CheckboxesField',
-  'AutocompleteField'
-]
-
-export function componentToString(component) {
-  if (~listTypes.indexOf(component.type)) {
-    return `${component.type}<${component.options.list}>`
-  }
-  return `${component.type}`
-}
-
-export function DataPrettyPrint() {
-  const { data } = useContext(DataContext)
-  const { sections = [], pages = [] } = data
-
-  const model = {}
-
-  pages.forEach((page) => {
-    page.components.forEach((component) => {
-      if (component.name) {
-        if (page.section) {
-          const section = sections.find(
-            (section) => section.name === page.section
-          )
-          if (!model[section.name]) {
-            model[section.name] = {}
-          }
-
-          model[section.name][component.name] = component.type
-        } else {
-          model[component.name] = component.type
-        }
-      }
-    })
-  })
-
-  return <pre>{JSON.stringify(model, null, 2)}</pre>
+export const DataPrettyPrint: FunctionComponent<
+  HTMLAttributes<HTMLPreElement>
+> = ({ children, ...attr }) => {
+  return (
+    <pre {...attr}>
+      <code>{JSON.stringify(children, undefined, 2)}</code>
+    </pre>
+  )
 }

--- a/designer/client/src/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/src/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -4,8 +4,8 @@ export const DataPrettyPrint: FunctionComponent<
   HTMLAttributes<HTMLPreElement>
 > = ({ children, ...attr }) => {
   return (
-    <pre {...attr}>
-      <code>{JSON.stringify(children, undefined, 2)}</code>
+    <pre tabIndex={-1} {...attr}>
+      <code tabIndex={0}>{JSON.stringify(children, undefined, 2)}</code>
     </pre>
   )
 }

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -66,11 +66,13 @@ describe('Menu', () => {
     expect($tabs[0]).toBeVisible()
     expect($tabs[1]).toBeVisible()
     expect($tabs[2]).toBeVisible()
+    expect($tabs[3]).toBeVisible()
 
     // Only first tab panel (Data model) is visible
     expect($panels[0]).not.toHaveClass('govuk-tabs__panel--hidden')
     expect($panels[1]).toHaveClass('govuk-tabs__panel--hidden')
     expect($panels[2]).toHaveClass('govuk-tabs__panel--hidden')
+    expect($panels[3]).toHaveClass('govuk-tabs__panel--hidden')
 
     // Click JSON tab link
     await act(() => userEvent.click($tabs[1]))
@@ -79,6 +81,7 @@ describe('Menu', () => {
     expect($panels[0]).toHaveClass('govuk-tabs__panel--hidden')
     expect($panels[1]).not.toHaveClass('govuk-tabs__panel--hidden')
     expect($panels[2]).toHaveClass('govuk-tabs__panel--hidden')
+    expect($panels[3]).toHaveClass('govuk-tabs__panel--hidden')
   })
 
   it('flyouts close on Save', async () => {

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -1,3 +1,4 @@
+import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
@@ -7,11 +8,18 @@ import { Menu } from '~/src/components/Menu/Menu.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers'
 
 describe('Menu', () => {
+  const data = {
+    pages: [],
+    lists: [],
+    sections: [],
+    conditions: []
+  } satisfies FormDefinition
+
   afterEach(cleanup)
 
   it('Renders button strings correctly', () => {
     render(
-      <RenderWithContext>
+      <RenderWithContext data={data}>
         <Menu slug="example" />
       </RenderWithContext>
     )
@@ -27,7 +35,7 @@ describe('Menu', () => {
 
   it('Can open flyouts and close them', async () => {
     render(
-      <RenderWithContext>
+      <RenderWithContext data={data}>
         <Menu slug="example" />
       </RenderWithContext>
     )
@@ -43,7 +51,7 @@ describe('Menu', () => {
 
   it('clicking on a summary tab shows different tab content', async () => {
     render(
-      <RenderWithContext>
+      <RenderWithContext data={data}>
         <Menu slug="example" />
       </RenderWithContext>
     )
@@ -77,7 +85,7 @@ describe('Menu', () => {
     const save = jest.fn()
 
     render(
-      <RenderWithContext save={save}>
+      <RenderWithContext data={data} save={save}>
         <Menu slug="example" />
       </RenderWithContext>
     )

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -29,7 +29,6 @@ describe('Menu', () => {
     expect(screen.getByText('Sections')).toBeInTheDocument()
     expect(screen.getByText('Conditions')).toBeInTheDocument()
     expect(screen.getByText('Lists')).toBeInTheDocument()
-    expect(screen.getByText('Summary behaviour')).toBeInTheDocument()
     expect(screen.getByText('Summary')).toBeInTheDocument()
   })
 
@@ -42,21 +41,21 @@ describe('Menu', () => {
 
     expect(screen.queryByTestId('flyout-1')).not.toBeInTheDocument()
 
-    await act(() => userEvent.click(screen.getByText('Summary behaviour')))
+    await act(() => userEvent.click(screen.getByText('Summary')))
     expect(screen.queryByTestId('flyout-1')).toBeInTheDocument()
 
     await act(() => userEvent.click(screen.getByText('Close')))
     expect(screen.queryByTestId('flyout-1')).not.toBeInTheDocument()
   })
 
-  it('clicking on a summary tab shows different tab content', async () => {
+  it('clicking on a form overview tab shows different tab content', async () => {
     render(
       <RenderWithContext data={data}>
         <Menu slug="example" />
       </RenderWithContext>
     )
 
-    await act(() => userEvent.click(screen.getByText('Summary')))
+    await act(() => userEvent.click(screen.getByText('Form overview')))
     expect(screen.getByTestId('flyout-1')).toBeVisible()
 
     const $tabs = screen.queryAllByRole('tab')
@@ -93,7 +92,7 @@ describe('Menu', () => {
       </RenderWithContext>
     )
 
-    await act(() => userEvent.click(screen.getByText('Summary behaviour')))
+    await act(() => userEvent.click(screen.getByText('Summary')))
     expect(screen.queryByTestId('flyout-1')).toBeInTheDocument()
 
     await act(() => userEvent.click(screen.getByText('Save')))

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -1,3 +1,4 @@
+import { hasListField } from '@defra/forms-model'
 import React, { useContext } from 'react'
 
 import { DeclarationEdit } from '~/src/DeclarationEdit.jsx'
@@ -31,37 +32,46 @@ export function Menu({ slug }: Props) {
   const lists = useMenuItem()
   const summaryBehaviour = useMenuItem()
   const summary = useMenuItem()
+
   const summaryTabs = [
     {
-      label: 'Data model',
-      id: 'tab-model',
-      panel: {
-        children: <DataPrettyPrint />,
-        'data-testid': 'tab-model'
-      }
-    },
-    {
-      label: 'JSON',
-      id: 'tab-json',
-      panel: {
-        children: <pre>{JSON.stringify(data, null, 2)}</pre>,
-        'data-testid': 'tab-json'
-      }
-    },
-    {
-      label: 'Summary',
-      id: 'tab-summary',
+      label: 'Definition',
+      id: 'tab-definition',
       panel: {
         children: (
-          <pre>
-            {JSON.stringify(
-              'pages' in data ? data.pages.map((page) => page.path) : [],
-              null,
-              2
+          <DataPrettyPrint className="language-json">{data}</DataPrettyPrint>
+        )
+      }
+    },
+    {
+      label: 'Pages',
+      id: 'tab-pages',
+      panel: {
+        children: (
+          <DataPrettyPrint className="language-json">
+            {data.pages.map((page) => ({
+              path: page.path,
+              title: page.title
+            }))}
+          </DataPrettyPrint>
+        )
+      }
+    },
+    {
+      label: 'Components',
+      id: 'tab-components',
+      panel: {
+        children: (
+          <DataPrettyPrint className="language-json">
+            {data.pages.flatMap(({ components }) =>
+              components?.map((component) => ({
+                name: component.name,
+                type: component.type,
+                list: hasListField(component) ? component.list : undefined
+              }))
             )}
-          </pre>
-        ),
-        'data-testid': 'tab-summary'
+          </DataPrettyPrint>
+        )
       }
     }
   ]

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -40,7 +40,14 @@ export function Menu({ slug }: Props) {
       id: 'tab-definition',
       panel: {
         children: (
-          <DataPrettyPrint className="language-json">{data}</DataPrettyPrint>
+          <>
+            <h4 className="govuk-heading-m govuk-!-margin-bottom-2">
+              Definition
+            </h4>
+            <p className="govuk-body">Form definition JSON</p>
+
+            <DataPrettyPrint className="language-json">{data}</DataPrettyPrint>
+          </>
         )
       }
     },
@@ -49,9 +56,16 @@ export function Menu({ slug }: Props) {
       id: 'tab-metadata',
       panel: {
         children: (
-          <DataPrettyPrint className="language-json">
-            {meta ?? {}}
-          </DataPrettyPrint>
+          <>
+            <h4 className="govuk-heading-m govuk-!-margin-bottom-2">
+              Metadata
+            </h4>
+            <p className="govuk-body">Form metadata JSON</p>
+
+            <DataPrettyPrint className="language-json">
+              {meta ?? {}}
+            </DataPrettyPrint>
+          </>
         )
       }
     },
@@ -60,12 +74,19 @@ export function Menu({ slug }: Props) {
       id: 'tab-pages',
       panel: {
         children: (
-          <DataPrettyPrint className="language-json">
-            {data.pages.map((page) => ({
-              path: page.path,
-              title: page.title
-            }))}
-          </DataPrettyPrint>
+          <>
+            <h4 className="govuk-heading-m govuk-!-margin-bottom-2">Pages</h4>
+            <p className="govuk-body">
+              Form definition JSON <code>pages</code> showing paths and titles
+            </p>
+
+            <DataPrettyPrint className="language-json">
+              {data.pages.map((page) => ({
+                path: page.path,
+                title: page.title
+              }))}
+            </DataPrettyPrint>
+          </>
         )
       }
     },
@@ -74,15 +95,25 @@ export function Menu({ slug }: Props) {
       id: 'tab-components',
       panel: {
         children: (
-          <DataPrettyPrint className="language-json">
-            {data.pages.flatMap(({ components }) =>
-              components?.map((component) => ({
-                name: component.name,
-                type: component.type,
-                list: hasListField(component) ? component.list : undefined
-              }))
-            )}
-          </DataPrettyPrint>
+          <>
+            <h4 className="govuk-heading-m govuk-!-margin-bottom-2">
+              Components
+            </h4>
+            <p className="govuk-body">
+              Form definition JSON <code>components</code> showing name, type
+              and (optional) list
+            </p>
+
+            <DataPrettyPrint className="language-json">
+              {data.pages.flatMap(({ components }) =>
+                components?.map((component) => ({
+                  name: component.name,
+                  type: component.type,
+                  list: hasListField(component) ? component.list : undefined
+                }))
+              )}
+            </DataPrettyPrint>
+          </>
         )
       }
     }
@@ -172,11 +203,12 @@ export function Menu({ slug }: Props) {
 
       {overview.isVisible && (
         <RenderInPortal>
-          <Flyout title="Form overview" width="large" onHide={overview.hide}>
+          <Flyout width="xlarge" onHide={overview.hide}>
             <Tabs
               title="Form overview"
               items={overviewTabs}
               onInit={highlightAll}
+              className="app-tabs--overview"
             ></Tabs>
           </Flyout>
         </RenderInPortal>

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -1,4 +1,5 @@
 import { hasListField } from '@defra/forms-model'
+import { highlightAll } from 'prismjs'
 import React, { useContext } from 'react'
 
 import { DeclarationEdit } from '~/src/DeclarationEdit.jsx'
@@ -203,7 +204,11 @@ export function Menu({ slug }: Props) {
       {summary.isVisible && (
         <RenderInPortal>
           <Flyout title="Summary" width="large" onHide={summary.hide}>
-            <Tabs title="Summary" items={summaryTabs}></Tabs>
+            <Tabs
+              title="Summary"
+              items={summaryTabs}
+              onInit={highlightAll}
+            ></Tabs>
           </Flyout>
         </RenderInPortal>
       )}

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -31,10 +31,10 @@ export function Menu({ slug }: Props) {
   const sections = useMenuItem()
   const conditions = useMenuItem()
   const lists = useMenuItem()
-  const summaryBehaviour = useMenuItem()
   const summary = useMenuItem()
+  const overview = useMenuItem()
 
-  const summaryTabs = [
+  const overviewTabs = [
     {
       label: 'Definition',
       id: 'tab-definition',
@@ -91,58 +91,27 @@ export function Menu({ slug }: Props) {
   return (
     <>
       <nav className="menu">
-        <div className="menu__row">
-          <button
-            className="govuk-button"
-            data-testid="menu-page"
-            onClick={page.show}
-          >
+        <div className="govuk-button-group govuk-!-margin-bottom-0">
+          <button className="govuk-button" onClick={page.show}>
             {i18n('menu.addPage')}
           </button>
-          <button
-            className="govuk-button"
-            data-testid="menu-links"
-            onClick={link.show}
-          >
+          <button className="govuk-button" onClick={link.show}>
             {i18n('menu.links')}
           </button>
-          <button
-            className="govuk-button"
-            data-testid="menu-sections"
-            onClick={sections.show}
-          >
+          <button className="govuk-button" onClick={sections.show}>
             {i18n('menu.sections')}
           </button>
-          <button
-            className="govuk-button"
-            data-testid="menu-conditions"
-            onClick={conditions.show}
-          >
+          <button className="govuk-button" onClick={conditions.show}>
             {i18n('menu.conditions')}
           </button>
-          <button
-            className="govuk-button"
-            data-testid="menu-lists"
-            onClick={lists.show}
-          >
+          <button className="govuk-button" onClick={lists.show}>
             {i18n('menu.lists')}
           </button>
-          <button
-            className="govuk-button"
-            data-testid="menu-summary-behaviour"
-            onClick={summaryBehaviour.show}
-          >
-            {i18n('menu.summaryBehaviour')}
-          </button>
-          <button
-            className="govuk-button"
-            onClick={summary.show}
-            data-testid="menu-summary"
-          >
+          <button className="govuk-button" onClick={summary.show}>
             {i18n('menu.summary')}
           </button>
         </div>
-        <SubMenu slug={slug} />
+        <SubMenu slug={slug} overview={overview} />
       </nav>
 
       {page.isVisible && (
@@ -193,20 +162,20 @@ export function Menu({ slug }: Props) {
         </RenderInPortal>
       )}
 
-      {summaryBehaviour.isVisible && (
+      {summary.isVisible && (
         <RenderInPortal>
-          <Flyout title="Edit Summary behaviour" onHide={summaryBehaviour.hide}>
-            <DeclarationEdit onCreate={() => summaryBehaviour.hide()} />
+          <Flyout title="Edit Summary" onHide={summary.hide}>
+            <DeclarationEdit onCreate={() => summary.hide()} />
           </Flyout>
         </RenderInPortal>
       )}
 
-      {summary.isVisible && (
+      {overview.isVisible && (
         <RenderInPortal>
-          <Flyout title="Summary" width="large" onHide={summary.hide}>
+          <Flyout title="Form overview" width="large" onHide={overview.hide}>
             <Tabs
-              title="Summary"
-              items={summaryTabs}
+              title="Form overview"
+              items={overviewTabs}
               onInit={highlightAll}
             ></Tabs>
           </Flyout>

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export function Menu({ slug }: Props) {
-  const { data } = useContext(DataContext)
+  const { data, meta } = useContext(DataContext)
 
   const page = useMenuItem()
   const link = useMenuItem()
@@ -40,6 +40,17 @@ export function Menu({ slug }: Props) {
       panel: {
         children: (
           <DataPrettyPrint className="language-json">{data}</DataPrettyPrint>
+        )
+      }
+    },
+    {
+      label: 'Metadata',
+      id: 'tab-metadata',
+      panel: {
+        children: (
+          <DataPrettyPrint className="language-json">
+            {meta ?? {}}
+          </DataPrettyPrint>
         )
       }
     },

--- a/designer/client/src/components/Menu/SubMenu.tsx
+++ b/designer/client/src/components/Menu/SubMenu.tsx
@@ -7,13 +7,15 @@ import React, {
 } from 'react'
 
 import { logger } from '~/src/common/helpers/logging/logger.js'
+import { type MenuItemHook } from '~/src/components/Menu/useMenuItem.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 
 interface Props {
   slug: string
+  overview: MenuItemHook
 }
 
-export function SubMenu({ slug }: Props) {
+export function SubMenu({ slug, overview }: Props) {
   const { data, save } = useContext(DataContext)
   const fileInput = useRef<HTMLInputElement>(null)
 
@@ -82,19 +84,31 @@ export function SubMenu({ slug }: Props) {
   }
 
   return (
-    <div className="menu__row">
-      <button className="govuk-link submenu__link" onClick={onClickUpload}>
-        Import saved form
+    <div className="govuk-button-group">
+      <button
+        className="govuk-link govuk-!-font-size-16"
+        onClick={onClickUpload}
+      >
+        Upload form
       </button>
-      <button className="govuk-link submenu__link" onClick={onClickDownload}>
+      <button
+        className="govuk-link govuk-!-font-size-16"
+        onClick={onClickDownload}
+      >
         Download form
+      </button>
+      <button
+        className="govuk-link govuk-!-font-size-16"
+        onClick={overview.show}
+      >
+        Form overview
       </button>
       <input
         ref={fileInput}
         type="file"
         hidden
         onChange={onFileUpload}
-        aria-label="Import saved form"
+        aria-label="Upload form definition JSON"
       />
     </div>
   )

--- a/designer/client/src/components/Menu/useMenuItem.tsx
+++ b/designer/client/src/components/Menu/useMenuItem.tsx
@@ -1,7 +1,7 @@
 import { type MouseEvent, type KeyboardEvent } from 'react'
 import { useState } from 'react'
 
-interface MenuItemHook {
+export interface MenuItemHook {
   isVisible: boolean
   show: (
     e?: KeyboardEvent<HTMLButtonElement> | MouseEvent<HTMLButtonElement>

--- a/designer/client/src/components/Tabs/Tabs.tsx
+++ b/designer/client/src/components/Tabs/Tabs.tsx
@@ -20,10 +20,11 @@ interface Props extends HTMLAttributes<HTMLParagraphElement> {
     } & HTMLAttributes<HTMLDivElement>
   } & HTMLAttributes<HTMLAnchorElement>)[]
   title?: string
+  onInit?: () => void
 }
 
 export const Tabs: FunctionComponent<Props> = (props) => {
-  let { className, id, idPrefix, items, title, ...attributes } = props
+  let { className, id, idPrefix, items, title, onInit, ...attributes } = props
 
   idPrefix ??= ''
   title ??= 'Contents'
@@ -33,6 +34,7 @@ export const Tabs: FunctionComponent<Props> = (props) => {
   useEffect(() => {
     if (tabsRef.current) {
       new TabsJS(tabsRef.current)
+      onInit?.()
     }
   }, [tabsRef])
 

--- a/designer/client/src/context/DataContext.ts
+++ b/designer/client/src/context/DataContext.ts
@@ -1,8 +1,9 @@
-import { type FormDefinition } from '@defra/forms-model'
+import { type FormDefinition, type FormMetadata } from '@defra/forms-model'
 import { createContext } from 'react'
 
 export interface DataContextType {
   data: FormDefinition
+  meta?: FormMetadata
   save: (definition: FormDefinition) => Promise<FormDefinition>
 }
 

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -228,8 +228,7 @@
     "links": "Add link",
     "lists": "Lists",
     "sections": "Sections",
-    "summary": "Summary",
-    "summaryBehaviour": "Summary behaviour"
+    "summary": "Summary"
   },
   "multilineTextFieldEditComponent": {
     "rowsField": {

--- a/designer/client/src/index.tsx
+++ b/designer/client/src/index.tsx
@@ -6,6 +6,9 @@ import { Designer } from '~/src/Designer.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import { initI18n } from '~/src/i18n/i18n.jsx'
 
+import 'prismjs/components/prism-markup.js'
+import 'prismjs/components/prism-json.js'
+
 initI18n().catch((error: unknown) => {
   logger.error(error, 'I18n')
 })

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -89,6 +89,18 @@ p code {
   }
 }
 
+.app-tabs--overview {
+  @include govuk-responsive-margin(7, "top");
+
+  @include govuk-media-query($from: tablet) {
+    @include govuk-responsive-margin(6, "top");
+  }
+
+  @include govuk-media-query($from: desktop) {
+    @include govuk-responsive-margin(1, "top");
+  }
+}
+
 .component.govuk-link {
   display: block;
   width: 100%;

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -3,9 +3,16 @@ $govuk-assets-path: "/assets/";
 @import "govuk-frontend/dist/govuk/base";
 @import "prismjs/themes/prism.min.css";
 
+@import "variables/all";
+@import "helpers/all";
+
 @import "../components/ComponentCreate/ComponentCreate.scss";
 @import "../components/Flyout/Flyout.scss";
 @import "../components/Visualisation/visualisation.scss";
+
+$app-code-font: ui-monospace, menlo, "Cascadia Mono", "Segoe UI Mono", consolas, "Liberation Mono", monospace;
+$app-code-color: #d13118;
+$app-light-grey: #f8f8f8;
 
 %app-button-link {
   @include govuk-link-common;
@@ -42,6 +49,44 @@ button.govuk-link {
 
   .govuk-form-group & {
     display: block;
+  }
+}
+
+code
+pre,
+code[class],
+pre[class] {
+  @include govuk-typography-common($font-family: $app-code-font);
+  @include govuk-font-size($size: 16, $line-height: 1.5);
+}
+
+pre[class] {
+  padding: 0;
+  margin: 0;
+  background: none;
+  overflow: visible;
+}
+
+pre code {
+  display: block;
+  padding: govuk-spacing(4);
+  overflow-x: auto;
+  background-color: $app-light-grey;
+  border: $govuk-focus-width solid transparent;
+
+  &:focus {
+    border: $govuk-focus-width solid $govuk-input-border-colour;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
+}
+
+p code {
+  padding: 1px 3px;
+  color: $app-code-color;
+  background-color: $app-light-grey;
+  @include govuk-font-size($size: 16);
+  @include govuk-media-query($from: tablet) {
+    padding: 2px 4px;
   }
 }
 

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -52,8 +52,7 @@ button.govuk-link {
   }
 }
 
-code
-pre,
+code pre,
 code[class],
 pre[class] {
   @include govuk-typography-common($font-family: $app-code-font);
@@ -88,25 +87,6 @@ p code {
   @include govuk-media-query($from: tablet) {
     padding: 2px 4px;
   }
-}
-
-.menu {
-  @include govuk-responsive-margin(4, "bottom");
-
-  .govuk-button {
-    @include govuk-responsive-margin(1, "right");
-    @include govuk-responsive-margin(1, "bottom");
-    @include govuk-font-size($size: 16);
-  }
-
-  &__row:not(:first-child) {
-    @include govuk-responsive-margin(4, "top");
-  }
-}
-
-.submenu__link {
-  @include govuk-font-size($size: 16);
-  @include govuk-responsive-margin(4, "right");
 }
 
 .component.govuk-link {

--- a/designer/client/test/helpers/renderers.tsx
+++ b/designer/client/test/helpers/renderers.tsx
@@ -1,4 +1,3 @@
-import { type FormDefinition } from '@defra/forms-model'
 import React, { useReducer, type ReactElement } from 'react'
 
 import { DataContext, type DataContextType } from '~/src/context/DataContext.js'
@@ -14,6 +13,7 @@ export interface RenderWithContextProps {
   children?: ReactElement
   state?: Omit<ComponentContextType['state'], 'initialName'>
   data?: DataContextType['data']
+  meta?: DataContextType['meta']
   save?: DataContextType['save']
 }
 
@@ -23,10 +23,15 @@ export function RenderWithContext(props: RenderWithContextProps) {
     initComponentState(props.state)
   )
 
-  const { children, data = {} as FormDefinition, save = jest.fn() } = props
+  const {
+    children,
+    data = {} as DataContextType['data'],
+    meta,
+    save = jest.fn()
+  } = props
 
   return (
-    <DataContext.Provider value={{ data, save }}>
+    <DataContext.Provider value={{ data, meta, save }}>
       <FlyoutContext.Provider
         value={{
           count: 1,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strict": true,
-    "target": "es2022"
+    "strict": true
   }
 }


### PR DESCRIPTION
Rather than remove "Summary" this renamed it to "Form overview" and drops it into the sub navigation

## Navigation changes
* The button "Summary" is now for the actual check answers summary
* The form summary tabs have moved into the sub navigation as "Form overview"

<img width="723" alt="Navigation menu" src="https://github.com/DEFRA/forms-designer/assets/415517/aed47fb3-8697-4df3-ad5c-74362e1c92b7">

## Form overview tabs
Since this was a useful feature, I've added the "Form metadata" tab and turned on syntax highlighting

<img width="760" alt="New form overview tab layout" src="https://github.com/DEFRA/forms-designer/assets/415517/410d40cc-6700-4548-bc51-621273b02231">
