### PR TITLE
Remove `subType` from component defaults

### DIFF
--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -20,12 +20,7 @@ const ComponentTypesSorted = ComponentTypes.sort(
   ({ type: typeA }, { type: typeB }) => typeA.localeCompare(typeB)
 )
 
-for (const defaults of ComponentTypesSorted) {
-  const component = structuredClone(defaults)
-
-  // Remove subType from component definition
-  delete component.subType
-
+for (const component of ComponentTypesSorted) {
   // Ensure the list component is grouped with other content fields
   if (hasContentField(component) || component.type === ComponentType.List) {
     contentFields.push(component)

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -1,6 +1,4 @@
 import {
-  ComponentSubType,
-  getComponentDefaults,
   type ComponentDef,
   type Page as PageType,
   type RepeatingFieldPage,
@@ -77,18 +75,6 @@ export const Page = (props: {
 
   const section = data.sections.find((section) => section.name === page.section)
 
-  const formComponents =
-    page.components?.filter((component) => {
-      const { subType } = getComponentDefaults(component) ?? {}
-      return subType === ComponentSubType.Field
-    }) ?? []
-
-  const pageTitle =
-    page.title ||
-    (formComponents.length === 1 && page.components?.[0] === formComponents[0]
-      ? formComponents[0].title
-      : page.title)
-
   return (
     <div id={page.path} title={page.path} className={'page'} style={layout}>
       <div className="page__heading">
@@ -109,7 +95,7 @@ export const Page = (props: {
           className="govuk-link"
           target="_blank"
           rel="noreferrer"
-          aria-label={`${i18n('Preview')} ${pageTitle}`}
+          aria-label={`${i18n('Preview')} ${page.title}`}
         >
           {i18n('Preview page')}
         </a>

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -112,7 +112,9 @@ export const initComponentState = (
  * Allows components to retrieve {@link ComponentState} and {@link Dispatch} from any component nested within `<ComponentContextProvider>`
  */
 export const ComponentContextProvider = (
-  props: ComponentState & { children: ReactNode }
+  props: Parameters<typeof initComponentState>[0] & {
+    children: ReactNode
+  }
 ) => {
   const { children, ...rest } = props
   const [state, dispatch] = useReducer(

--- a/model/src/components/component-types.ts
+++ b/model/src/components/component-types.ts
@@ -1,17 +1,14 @@
-import { ComponentSubType, ComponentType } from '~/src/components/enums.js'
+import { ComponentType } from '~/src/components/enums.js'
 import { type ComponentDef } from '~/src/components/types.js'
 
 /**
  * Defaults for creating new components
  */
-export const ComponentTypes: (ComponentDef & {
-  subType?: ComponentSubType
-})[] = [
+export const ComponentTypes: ComponentDef[] = [
   {
     name: 'TextField',
     title: 'Text field',
     type: ComponentType.TextField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -20,7 +17,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'MultilineTextField',
     title: 'Multiline text field',
     type: ComponentType.MultilineTextField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -29,7 +25,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'YesNoField',
     title: 'Yes/No field',
     type: ComponentType.YesNoField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -38,7 +33,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'TimeField',
     title: 'Time field',
     type: ComponentType.TimeField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -47,7 +41,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'DatePartsField',
     title: 'Date field',
     type: ComponentType.DatePartsField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -56,7 +49,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'MonthYearField',
     title: 'Month & year field',
     type: ComponentType.MonthYearField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -65,7 +57,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'SelectField',
     title: 'Select field',
     type: ComponentType.SelectField,
-    subType: ComponentSubType.ListField,
     options: {},
     schema: {},
     list: ''
@@ -74,7 +65,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'AutocompleteField',
     title: 'Autocomplete field',
     type: ComponentType.AutocompleteField,
-    subType: ComponentSubType.ListField,
     options: {},
     schema: {},
     list: ''
@@ -83,7 +73,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'RadiosField',
     title: 'Radios field',
     type: ComponentType.RadiosField,
-    subType: ComponentSubType.ListField,
     options: {},
     schema: {},
     list: ''
@@ -92,7 +81,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'CheckboxesField',
     title: 'Checkboxes field',
     type: ComponentType.CheckboxesField,
-    subType: ComponentSubType.ListField,
     options: {},
     schema: {},
     list: ''
@@ -101,7 +89,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'NumberField',
     title: 'Number field',
     type: ComponentType.NumberField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -110,7 +97,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'UkAddressField',
     title: 'UK address field',
     type: ComponentType.UkAddressField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -119,7 +105,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'TelephoneNumberField',
     title: 'Telephone number field',
     type: ComponentType.TelephoneNumberField,
-    subType: ComponentSubType.Field,
     hint: '',
     options: {},
     schema: {}
@@ -128,7 +113,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'EmailAddressField',
     title: 'Email address field',
     type: ComponentType.EmailAddressField,
-    subType: ComponentSubType.Field,
     hint: 'For example, ‘name@example.com’',
     options: {},
     schema: {}
@@ -137,7 +121,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'Html',
     title: 'Html',
     type: ComponentType.Html,
-    subType: ComponentSubType.Content,
     content: '',
     options: {},
     schema: {}
@@ -146,7 +129,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'InsetText',
     title: 'Inset text',
     type: ComponentType.InsetText,
-    subType: ComponentSubType.Content,
     content: '',
     options: {},
     schema: {}
@@ -155,7 +137,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'Details',
     title: 'Details',
     type: ComponentType.Details,
-    subType: ComponentSubType.Content,
     content: '',
     options: {},
     schema: {}
@@ -164,7 +145,6 @@ export const ComponentTypes: (ComponentDef & {
     name: 'List',
     title: 'List',
     type: ComponentType.List,
-    subType: ComponentSubType.Content,
     options: {},
     schema: {},
     list: ''

--- a/model/src/components/enums.ts
+++ b/model/src/components/enums.ts
@@ -18,9 +18,3 @@ export enum ComponentType {
   Details = 'Details',
   List = 'List'
 }
-
-export enum ComponentSubType {
-  Content = 'content',
-  Field = 'field',
-  ListField = 'listField'
-}

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -107,6 +107,7 @@ export function hasInputField(
     ComponentType.YesNoField,
     ComponentType.MonthYearField,
     ComponentType.TimeField,
+    ComponentType.DatePartsField,
     ComponentType.UkAddressField
   ]
 

--- a/model/src/components/index.ts
+++ b/model/src/components/index.ts
@@ -10,4 +10,4 @@ export {
   hasTitle
 } from '~/src/components/helpers.js'
 
-export { ComponentType, ComponentSubType } from '~/src/components/enums.js'
+export { ComponentType } from '~/src/components/enums.js'

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -262,6 +262,7 @@ export type InputFieldsComponentsDef =
   | YesNoFieldComponent
   | MonthYearFieldComponent
   | TimeFieldComponent
+  | DatePartsFieldFieldComponent
   | UkAddressFieldComponent
 
 // Components that render content


### PR DESCRIPTION
This PR removes `subType` from internal usage, it's no longer needed

We previously removed it from all form definition fixtures but it was still used to build a page title

* https://github.com/DEFRA/forms-designer/pull/317