### PR TITLE
Add screen reader announcements for page visualisation

### DIFF
--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -231,15 +231,21 @@ export const Component: FunctionComponent<Props> = (props) => {
   const [showEditor, setShowEditor] = useState<boolean>(false)
   const toggleShowEditor = () => setShowEditor(!showEditor)
 
-  const TagName = componentTypes[selectedComponent.type]
+  const { title, type } = selectedComponent
+  const ComponentIcon = componentTypes[type]
+
   const editFlyoutTitle = i18n('component.edit', {
-    name: `$t(fieldTypeToName.${selectedComponent.type})`
+    name: `$t(fieldTypeToName.${type})`
   })
 
   return (
     <>
-      <button className="component govuk-link" onClick={toggleShowEditor}>
-        <TagName />
+      <button
+        className="component govuk-link"
+        onClick={toggleShowEditor}
+        aria-label={`${editFlyoutTitle}: ${title}`}
+      >
+        <ComponentIcon />
       </button>
       {showEditor && (
         <RenderInPortal>

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -75,10 +75,14 @@ export const Page = (props: {
 
   const section = data.sections.find((section) => section.name === page.section)
 
+  // Remove slashes from IDs
+  const pageId = page.path.replace(/\//g, '')
+  const headingId = `${pageId}-heading`
+
   return (
-    <div id={page.path} title={page.path} className={'page'} style={layout}>
+    <div id={pageId} title={page.path} className={'page'} style={layout}>
       <div className="page__heading">
-        <h3 className="govuk-heading-m">
+        <h3 className="govuk-heading-m" id={headingId}>
           {section && <span className="govuk-caption-m">{section.title}</span>}
           {page.title}
         </h3>
@@ -87,7 +91,11 @@ export const Page = (props: {
       <ComponentList page={page} data={data} />
 
       <div className="page__actions">
-        <button onClick={() => setIsEditingPage(true)} className="govuk-link">
+        <button
+          onClick={() => setIsEditingPage(true)}
+          className="govuk-link"
+          aria-describedby={headingId}
+        >
           {i18n('Edit page')}
         </button>
         <a
@@ -95,13 +103,14 @@ export const Page = (props: {
           className="govuk-link"
           target="_blank"
           rel="noreferrer"
-          aria-label={`${i18n('Preview')} ${page.title}`}
+          aria-describedby={headingId}
         >
           {i18n('Preview page')}
         </a>
         <button
           onClick={() => setIsCreatingComponent(true)}
           className="govuk-link"
+          aria-describedby={headingId}
         >
           {i18n('component.create')}
         </button>

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -5,7 +5,6 @@
   "Edit page": "Edit page",
   "Enter form name": "Enter form name",
   "Enter the name for your form, for example Applying for visitors pass": "Enter the name for your form, for example Applying for visitors pass",
-  "Preview": "Preview",
   "Preview page": "Preview page",
   "Select an existing form to edit": "Select an existing form to edit",
   "Start": "Start",


### PR DESCRIPTION
Just realised we don't have screen reader announcements for:

1. Edit page
1. Add component
2. Preview icons for components

Let me know if you'd like a demo, they're now added

<img width="298" alt="Page visualisation" src="https://github.com/DEFRA/forms-designer/assets/415517/9149e24d-1faa-49c9-a1c1-cf5ccae85ea1">
