### PR TITLE
Feature/custom error messages

### DIFF
--- a/designer/client/src/MultilineTextFieldEdit.tsx
+++ b/designer/client/src/MultilineTextFieldEdit.tsx
@@ -20,6 +20,33 @@ export function MultilineTextFieldEdit({ context = ComponentContext }) {
       <div className="govuk-form-group">
         <label
           className="govuk-label govuk-label--s"
+          htmlFor="field-schema-maxwords"
+        >
+          {i18n('multilineTextFieldEditComponent.maxWordField.title')}
+        </label>
+        <div className="govuk-hint" id="field-schema-maxwords-hint">
+          {i18n('multilineTextFieldEditComponent.maxWordField.helpText')}
+        </div>
+        <input
+          className="govuk-input govuk-input--width-3"
+          data-cast="number"
+          id="field-schema-maxwords"
+          aria-describedby="field-schema-maxwords-hint"
+          name="schema.maxwords"
+          value={'maxWords' in options ? options.maxWords : undefined}
+          type="number"
+          onChange={(e) =>
+            dispatch({
+              type: Options.EDIT_OPTIONS_MAX_WORDS,
+              payload: e.target.value
+            })
+          }
+        />
+      </div>
+
+      <div className="govuk-form-group">
+        <label
+          className="govuk-label govuk-label--s"
           htmlFor="field-options-rows"
         >
           {i18n('multilineTextFieldEditComponent.rowsField.title')}

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -6,7 +6,7 @@ import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { CustomValidationMessage } from '~/src/components/CustomValidationMessage/CustomValidationMessage.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Options, Schema } from '~/src/reducers/component/types.js'
+import { Schema } from '~/src/reducers/component/types.js'
 
 interface Props {
   context?: typeof ComponentContext
@@ -23,7 +23,11 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
     return null
   }
 
-  const { schema, options } = selectedComponent
+  const { schema } = selectedComponent
+  const showSchemaFields = [
+    ComponentType.TextField,
+    ComponentType.MultilineTextField
+  ].includes(selectedComponent.type)
 
   return (
     <details className="govuk-details">
@@ -34,140 +38,119 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
       </summary>
 
       <div className="govuk-details__text">
-        <div className="govuk-form-group">
-          <label
-            className="govuk-label govuk-label--s"
-            htmlFor="field-schema-min"
-          >
-            {i18n('textFieldEditComponent.minLengthField.title')}
-          </label>
-          <div className="govuk-hint" id="field-schema-min-hint">
-            {i18n('textFieldEditComponent.minLengthField.helpText')}
-          </div>
-          <input
-            className="govuk-input govuk-input--width-3"
-            data-cast="number"
-            id="field-schema-min"
-            aria-describedby="field-schema-min-hint"
-            name="schema.min"
-            value={'min' in schema ? schema.min : undefined}
-            type="number"
-            onChange={(e) =>
-              dispatch({
-                type: Schema.EDIT_SCHEMA_MIN,
-                payload: e.target.value
-              })
-            }
-          />
-        </div>
+        {showSchemaFields && (
+          <>
+            <div className="govuk-form-group">
+              <label
+                className="govuk-label govuk-label--s"
+                htmlFor="field-schema-min"
+              >
+                {i18n('textFieldEditComponent.minLengthField.title')}
+              </label>
+              <div className="govuk-hint" id="field-schema-min-hint">
+                {i18n('textFieldEditComponent.minLengthField.helpText')}
+              </div>
+              <input
+                className="govuk-input govuk-input--width-3"
+                data-cast="number"
+                id="field-schema-min"
+                aria-describedby="field-schema-min-hint"
+                name="schema.min"
+                value={'min' in schema ? schema.min : undefined}
+                type="number"
+                onChange={(e) =>
+                  dispatch({
+                    type: Schema.EDIT_SCHEMA_MIN,
+                    payload: e.target.value
+                  })
+                }
+              />
+            </div>
 
-        <div className="govuk-form-group">
-          <label
-            className="govuk-label govuk-label--s"
-            htmlFor="field-schema-max"
-          >
-            {i18n('textFieldEditComponent.maxLengthField.title')}
-          </label>
-          <div className="govuk-hint" id="field-schema-max-hint">
-            {i18n('textFieldEditComponent.maxLengthField.helpText')}
-          </div>
-          <input
-            className="govuk-input govuk-input--width-3"
-            data-cast="number"
-            id="field-schema-max"
-            aria-describedby="field-schema-max-hint"
-            name="schema.max"
-            value={'max' in schema ? schema.max : undefined}
-            type="number"
-            onChange={(e) =>
-              dispatch({
-                type: Schema.EDIT_SCHEMA_MAX,
-                payload: e.target.value
-              })
-            }
-          />
-        </div>
+            <div className="govuk-form-group">
+              <label
+                className="govuk-label govuk-label--s"
+                htmlFor="field-schema-max"
+              >
+                {i18n('textFieldEditComponent.maxLengthField.title')}
+              </label>
+              <div className="govuk-hint" id="field-schema-max-hint">
+                {i18n('textFieldEditComponent.maxLengthField.helpText')}
+              </div>
+              <input
+                className="govuk-input govuk-input--width-3"
+                data-cast="number"
+                id="field-schema-max"
+                aria-describedby="field-schema-max-hint"
+                name="schema.max"
+                value={'max' in schema ? schema.max : undefined}
+                type="number"
+                onChange={(e) =>
+                  dispatch({
+                    type: Schema.EDIT_SCHEMA_MAX,
+                    payload: e.target.value
+                  })
+                }
+              />
+            </div>
 
-        <div className="govuk-form-group">
-          <label
-            className="govuk-label govuk-label--s"
-            htmlFor="field-schema-maxwords"
-          >
-            {i18n('textFieldEditComponent.maxWordField.title')}
-          </label>
-          <div className="govuk-hint" id="field-schema-maxwords-hint">
-            {i18n('textFieldEditComponent.maxWordField.helpText')}
-          </div>
-          <input
-            className="govuk-input govuk-input--width-3"
-            data-cast="number"
-            id="field-schema-maxwords"
-            aria-describedby="field-schema-maxwords-hint"
-            name="schema.maxwords"
-            value={'maxWords' in options ? options.maxWords : undefined}
-            type="number"
-            onChange={(e) =>
-              dispatch({
-                type: Options.EDIT_OPTIONS_MAX_WORDS,
-                payload: e.target.value
-              })
-            }
-          />
-        </div>
-
-        <div className="govuk-form-group">
-          <label
-            className="govuk-label govuk-label--s"
-            htmlFor="field-schema-length"
-          >
-            {i18n('textFieldEditComponent.lengthField.title')}
-          </label>
-          <div className="govuk-hint" id="field-schema-length-hint">
-            {i18n('textFieldEditComponent.lengthField.helpText')}
-          </div>
-          <input
-            className="govuk-input govuk-input--width-3"
-            data-cast="number"
-            id="field-schema-length"
-            aria-describedby="field-schema-length-hint"
-            name="schema.length"
-            value={'length' in schema ? schema.length : undefined}
-            type="number"
-            onChange={(e) =>
-              dispatch({
-                type: Schema.EDIT_SCHEMA_LENGTH,
-                payload: e.target.value
-              })
-            }
-          />
-        </div>
+            <div className="govuk-form-group">
+              <label
+                className="govuk-label govuk-label--s"
+                htmlFor="field-schema-length"
+              >
+                {i18n('textFieldEditComponent.lengthField.title')}
+              </label>
+              <div className="govuk-hint" id="field-schema-length-hint">
+                {i18n('textFieldEditComponent.lengthField.helpText')}
+              </div>
+              <input
+                className="govuk-input govuk-input--width-3"
+                data-cast="number"
+                id="field-schema-length"
+                aria-describedby="field-schema-length-hint"
+                name="schema.length"
+                value={'length' in schema ? schema.length : undefined}
+                type="number"
+                onChange={(e) =>
+                  dispatch({
+                    type: Schema.EDIT_SCHEMA_LENGTH,
+                    payload: e.target.value
+                  })
+                }
+              />
+            </div>
+          </>
+        )}
 
         {children}
 
-        <div className="govuk-form-group">
-          <label
-            className="govuk-label govuk-label--s"
-            htmlFor="field-schema-regex"
-          >
-            {i18n('textFieldEditComponent.regexField.title')}
-          </label>
-          <div className="govuk-hint" id="field-schema-regex-hint">
-            {i18n('textFieldEditComponent.regexField.helpText')}
+        {showSchemaFields && (
+          <div className="govuk-form-group">
+            <label
+              className="govuk-label govuk-label--s"
+              htmlFor="field-schema-regex"
+            >
+              {i18n('textFieldEditComponent.regexField.title')}
+            </label>
+            <div className="govuk-hint" id="field-schema-regex-hint">
+              {i18n('textFieldEditComponent.regexField.helpText')}
+            </div>
+            <input
+              className="govuk-input"
+              id="field-schema-regex"
+              aria-describedby="field-schema-regex-hint"
+              name="schema.regex"
+              value={'regex' in schema ? schema.regex : undefined}
+              onChange={(e) =>
+                dispatch({
+                  type: Schema.EDIT_SCHEMA_REGEX,
+                  payload: e.target.value
+                })
+              }
+            />
           </div>
-          <input
-            className="govuk-input"
-            id="field-schema-regex"
-            aria-describedby="field-schema-regex-hint"
-            name="schema.regex"
-            value={'regex' in schema ? schema.regex : undefined}
-            onChange={(e) =>
-              dispatch({
-                type: Schema.EDIT_SCHEMA_REGEX,
-                payload: e.target.value
-              })
-            }
-          />
-        </div>
+        )}
 
         <Autocomplete />
 

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -231,6 +231,10 @@
     "summary": "Summary"
   },
   "multilineTextFieldEditComponent": {
+    "maxWordField": {
+      "helpText": "Specifies the maximum number of words users can enter",
+      "title": "Max words"
+    },
     "rowsField": {
       "helpText": "Specifies the number of textarea rows (default is 5 rows).",
       "title": "Rows"
@@ -303,10 +307,6 @@
     "minLengthField": {
       "helpText": "Specifies the minimum number of characters users can enter",
       "title": "Min length"
-    },
-    "maxWordField": {
-      "helpText": "Specifies the maximum number of words users can enter",
-      "title": "Max words"
     },
     "regexField": {
       "helpText": "Specifies a regular expression to validate users' inputs. Use JavaScript syntax.",

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -159,6 +159,8 @@ export interface MultilineTextFieldComponent extends TextFieldBase {
   schema: {
     max?: number
     min?: number
+    length?: number
+    regex?: string
   }
 }
 

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -100,8 +100,18 @@ export const componentSchema = Joi.object<ComponentDef>()
     name: Joi.string(),
     title: localisedString,
     hint: localisedString.optional(),
-    options: Joi.object().default({}),
-    schema: Joi.object({ min: Joi.number(), max: Joi.number() })
+    options: Joi.object({
+      rows: Joi.number().empty(''),
+      maxWords: Joi.number().empty(''),
+      customValidationMessage: Joi.string().allow('')
+    })
+      .default({})
+      .unknown(true),
+    schema: Joi.object({
+      min: Joi.number().empty(''),
+      max: Joi.number().empty(''),
+      length: Joi.number().empty('')
+    })
       .unknown(true)
       .default({}),
     list: Joi.string().optional()


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/398579#18941354

- `maxWords` is now an option for TextAreas only, and it should now actually work
- `min`, `max`, `length` and `regex` should only be displayed for Text and TextArea components (removed from Email, Phone...)
- Unsetting (clearing a previous value) numeric values (`min`, `max`, `length`, `maxWords`, `rows`) should now work
