### PR TITLE
Run GitHub Actions lint tasks after build

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -144,6 +144,16 @@ jobs:
             model/node_modules
             node_modules
 
+      - name: Restore build
+        uses: actions/cache/restore@v4
+        with:
+          enableCrossOsArchive: true
+          key: npm-build-${{ runner.os }}-${{ github.sha }}
+          path: |
+            designer/client/dist
+            designer/server/dist
+            model/dist
+
       - name: Run lint task
         run: ${{ matrix.task.run }}
 

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -103,7 +103,7 @@ jobs:
   lint:
     name: ${{ matrix.task.description }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
-    needs: [install]
+    needs: [install, build]
 
     env:
       # Authorise GitHub API requests for EditorConfig checker binary

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,7 @@ export const projectDefaults = {
  */
 export default {
   ...defaults,
+  displayName: '@defra/forms-designer (project)',
   projects: [
     '<rootDir>/designer/client',
     '<rootDir>/designer/server',


### PR DESCRIPTION
Looks like some ESLint issues could be caused by `@defra/forms-model` not being built yet

This PR adjusts our ESLint checks to wait for the build to complete first