### PR TITLE
Fix stylesheet 404 error

### DIFF
--- a/designer/server/src/common/templates/layouts/page.njk
+++ b/designer/server/src/common/templates/layouts/page.njk
@@ -5,7 +5,7 @@
 {% from "heading/macro.njk" import appHeading %}
 
 {% block head %}
-  <link href="{{ getAssetPath("stylesheets/application.css") }}" rel="stylesheet">
+  <link href="{{ getAssetPath("stylesheets/application.scss") }}" rel="stylesheet">
 {% endblock %}
 
 {% block header %}

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -6,7 +6,7 @@
 
 {% block head %}
   {{ super() }}
-  <link href="{{ getAssetPath("stylesheets/editor.css") }}" rel="stylesheet">
+  <link href="{{ getAssetPath("stylesheets/editor.scss") }}" rel="stylesheet">
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
This PR fixes calls to `getAssetPath()` to use the original asset resource filename

Unfortunately this was a side effect of `NODE_ENV=production` that was missed from the assets manifest JSON

**Context:** Since the [`webpack@5.93.0`](https://github.com/webpack/webpack/releases/tag/v5.93.0) update we've removed `css-loader` and `mini-css-extract-plugin` now that webpack `asset/resource` files added source map support out of the box