### PR TITLE
Fix missing `SelectField` component condition support

### DIFF
--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -43,6 +43,7 @@ export function isConditionalType(
     ComponentType.EmailAddressField,
     ComponentType.MultilineTextField,
     ComponentType.NumberField,
+    ComponentType.SelectField,
     ComponentType.TextField,
     ComponentType.TimeField,
     ComponentType.YesNoField

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -7,6 +7,7 @@ export type ConditionalComponentType =
   | ComponentType.EmailAddressField
   | ComponentType.MultilineTextField
   | ComponentType.NumberField
+  | ComponentType.SelectField
   | ComponentType.TextField
   | ComponentType.TimeField
   | ComponentType.YesNoField
@@ -231,7 +232,10 @@ export interface RadiosFieldComponent extends ListFieldBase {
 
 export interface SelectFieldComponent extends ListFieldBase {
   type: ComponentType.SelectField
-  options: ListFieldBase['options'] & { autocomplete?: string }
+  options: ListFieldBase['options'] & {
+    autocomplete?: string
+    condition?: string
+  }
 }
 
 export type ComponentDef =

--- a/model/src/conditions/condition-model.test.ts
+++ b/model/src/conditions/condition-model.test.ts
@@ -13,6 +13,7 @@ import {
   OperatorName,
   RelativeTimeValue
 } from '~/src/conditions/index.js'
+import { type ConditionsArray } from '~/src/conditions/types.js'
 
 describe('condition model', () => {
   let underTest: ConditionsModel

--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -89,6 +89,7 @@ export const customOperators = {
   [ComponentType.TextField]: withDefaults(textFieldOperators),
   [ComponentType.MultilineTextField]: withDefaults(textFieldOperators),
   [ComponentType.EmailAddressField]: withDefaults(textFieldOperators),
+  [ComponentType.SelectField]: defaultOperators,
   [ComponentType.YesNoField]: defaultOperators
 }
 


### PR DESCRIPTION
We have tests for select fields with conditions but they're not enabled in the UI

**Note:** We'd need to enable `number` lists to fully add "more than" and "less than" support etc