### PR TITLE
#398639 Use the form's last updated in the library page

### DIFF
--- a/designer/server/src/views/forms/library.njk
+++ b/designer/server/src/views/forms/library.njk
@@ -33,11 +33,9 @@
         </a>
       {% endset %}
 
-      {% set state = form.draft if form.draft else form.live %}
-
       {% set formUpdated %}
-        <span class="app-display-until-desktop">Updated </span>{{ state.updatedAt | formatDate }}<br>
-        by {{ state.updatedBy.displayName }}
+        <span class="app-display-until-desktop">Updated </span>{{ form.updatedAt | formatDate }}<br>
+        by {{ form.updatedBy.displayName }}
       {% endset %}
 
       {% set formNameUpdated %}


### PR DESCRIPTION
Since https://github.com/DEFRA/forms-designer/pull/340 we now have top-level form updated by/at values. This PR uses them on the library page, rather than the value from the draft/live.

This is being brought in under ticket #398639, [based on our Slack conversation](https://defra-digital-team.slack.com/archives/C071FRPN9TK/p1721138889548189).