### PR TITLE
Fix condition presentation in “Add or edit condition”

### DIFF
--- a/designer/client/src/conditions/ConditionsEdit.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.tsx
@@ -1,3 +1,4 @@
+import { ConditionsModel } from '@defra/forms-model'
 import React, { useContext, useState } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
@@ -40,7 +41,9 @@ function useConditionsEditor() {
   }
 }
 
-interface Props {}
+interface Props {
+  path?: string
+}
 
 export function ConditionsEdit({ path }: Props) {
   const {
@@ -54,6 +57,7 @@ export function ConditionsEdit({ path }: Props) {
   const { data } = useContext(DataContext)
   const { conditions } = data
   const inputs = allInputs(data)
+
   return (
     <>
       <div className="govuk-hint">{i18n('conditions.hint')}</div>
@@ -76,24 +80,26 @@ export function ConditionsEdit({ path }: Props) {
           )}
 
           <ul
-            className="govuk-list govuk-list--bullet"
+            className="govuk-list govuk-list--bullet govuk-list--spaced"
             data-testid="conditions-list"
           >
-            {conditions.map((condition) => (
-              <li key={condition.name} data-testid="conditions-list-item">
-                <a
-                  className="govuk-link"
-                  href="#"
-                  onClick={(e) => onClickCondition(e, condition)}
-                >
-                  {condition.displayName}
-                </a>{' '}
-                <small>{condition.name}</small>
-                {'   ('}
-                <small>{condition.expression}</small>
-                {')'}
-              </li>
-            ))}
+            {conditions.map((condition) => {
+              const model = ConditionsModel.from(condition.value)
+
+              return (
+                <li key={condition.name}>
+                  <a
+                    className="govuk-link"
+                    href="#"
+                    onClick={(e) => onClickCondition(e, condition)}
+                  >
+                    {condition.displayName}
+                  </a>
+                  <br />
+                  {model.toPresentationString()}
+                </li>
+              )
+            })}
           </ul>
           <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
           {inputs.length > 0 && (


### PR DESCRIPTION
This PR fixes the conditions panel to render the condition "presentation string" instead of `()`

Nicely spotted by the type fixes in https://github.com/DEFRA/forms-designer/pull/351 where the previous UI was left out of date

## Before
The legacy `condition.expression` is undefined so is rendered as `()`

<img width="600" alt="Condition panel, presentation strings are empty" src="https://github.com/user-attachments/assets/d41a01af-26a5-40be-ac1d-4d7add3caffe">

## After
The correct `model.toPresentationString()` now rendered correctly

<img width="600" alt="Condition panel, presentation strings now rendered" src="https://github.com/user-attachments/assets/f52bda90-4953-40e6-a07d-cec814a561ad">