### PR TITLE
Add missing types for filters, events and GOV.UK Frontend

### DIFF
--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -1,4 +1,9 @@
-import React, { useContext, useLayoutEffect } from 'react'
+import React, {
+  useContext,
+  useLayoutEffect,
+  type FormEvent,
+  type MouseEvent
+} from 'react'
 
 import { ComponentTypeEdit } from '~/src/ComponentTypeEdit.jsx'
 import { ErrorSummary } from '~/src/ErrorSummary.jsx'
@@ -15,7 +20,7 @@ export function ComponentEdit(props) {
   const { page, toggleShowEditor } = props
   const hasErrors = hasValidationErrors(errors)
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e?: FormEvent<HTMLFormElement>) => {
     e?.preventDefault()
 
     if (!hasValidated) {
@@ -37,7 +42,7 @@ export function ComponentEdit(props) {
     toggleShowEditor()
   }
 
-  const handleDelete = async (e) => {
+  const handleDelete = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
 
     if (!window.confirm('Confirm delete') || !selectedComponent) {

--- a/designer/client/src/DeclarationEdit.tsx
+++ b/designer/client/src/DeclarationEdit.tsx
@@ -1,5 +1,5 @@
 import { clone } from '@defra/forms-model'
-import React, { Component, type ContextType } from 'react'
+import React, { Component, type ContextType, type FormEvent } from 'react'
 
 import { Editor } from '~/src/Editor.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -15,7 +15,7 @@ export class DeclarationEdit extends Component {
     this.onSubmit = this.onSubmit.bind(this)
   }
 
-  onSubmit = async (e) => {
+  onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const form = e.target
     const formData = new window.FormData(form)
@@ -38,7 +38,7 @@ export class DeclarationEdit extends Component {
     const { declaration, skipSummary } = data
 
     return (
-      <form onSubmit={(e) => this.onSubmit(e)} autoComplete="off">
+      <form onSubmit={this.onSubmit} autoComplete="off">
         <div className="govuk-checkboxes govuk-form-group">
           <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
             <p className="govuk-fieldset__heading">Skip summary page?</p>

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -3,6 +3,7 @@ import {
   getComponentDefaults,
   hasContentField
 } from '@defra/forms-model'
+// @ts-expect-error -- No types available
 import { Input, Textarea } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
 import React, { type ChangeEvent, useContext } from 'react'

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -5,7 +5,7 @@ import {
 } from '@defra/forms-model'
 import { Input, Textarea } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
-import React, { useContext } from 'react'
+import React, { type ChangeEvent, useContext } from 'react'
 
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
@@ -37,7 +37,7 @@ export function FieldEdit() {
           children: [i18n('common.titleField.helpText')]
         }}
         value={title ?? defaults?.title}
-        onChange={(e) => {
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
           dispatch({
             type: Fields.EDIT_TITLE,
             payload: e.target.value
@@ -58,7 +58,7 @@ export function FieldEdit() {
         }}
         required={false}
         value={'hint' in selectedComponent ? selectedComponent.hint : undefined}
-        onChange={(e) => {
+        onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
           dispatch({
             type: Fields.EDIT_HELP,
             payload: e.target.value

--- a/designer/client/src/LinkCreate.tsx
+++ b/designer/client/src/LinkCreate.tsx
@@ -1,5 +1,10 @@
 import classNames from 'classnames'
-import React, { Component, type ContextType } from 'react'
+import React, {
+  Component,
+  type ChangeEvent,
+  type ContextType,
+  type FormEvent
+} from 'react'
 
 import { ErrorSummary, type ErrorList } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -17,7 +22,7 @@ export class LinkCreate extends Component {
 
   state = { errors: {} }
 
-  onSubmit = async (e) => {
+  onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const { data, save } = this.context
     const { from, to, selectedCondition } = this.state
@@ -38,7 +43,7 @@ export class LinkCreate extends Component {
     })
   }
 
-  storeValue = (e, key) => {
+  storeValue = (e: ChangeEvent<HTMLSelectElement>, key) => {
     const input = e.target
     const stateUpdate = {}
     stateUpdate[key] = input.value

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -1,5 +1,11 @@
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
-import React, { Component, type ContextType } from 'react'
+import React, {
+  Component,
+  type ChangeEvent,
+  type ContextType,
+  type FormEvent,
+  type MouseEvent
+} from 'react'
 
 import { type ErrorList, ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -34,7 +40,7 @@ export class PageCreate extends Component {
     }
   }
 
-  onSubmit = async (e) => {
+  onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     const { data, save } = this.context
@@ -119,27 +125,27 @@ export class PageCreate extends Component {
     return sections.find((section) => section.name === name)
   }
 
-  onChangeSection = (e) => {
+  onChangeSection = (e: ChangeEvent<HTMLSelectElement>) => {
     this.setState({
       section: this.findSectionWithName(e.target.value)
     })
   }
 
-  onChangeLinkFrom = (e) => {
+  onChangeLinkFrom = (e: ChangeEvent<HTMLSelectElement>) => {
     const input = e.target
     this.setState({
       linkFrom: input.value
     })
   }
 
-  onChangePageType = (e) => {
+  onChangePageType = (e: ChangeEvent<HTMLSelectElement>) => {
     const input = e.target
     this.setState({
       pageType: input.value
     })
   }
 
-  onChangeTitle = (e) => {
+  onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
     const { data } = this.context
     const input = e.target
     const title = input.value
@@ -149,7 +155,7 @@ export class PageCreate extends Component {
     })
   }
 
-  onChangePath = (e) => {
+  onChangePath = (e: ChangeEvent<HTMLInputElement>) => {
     const input = e.target
     const path = input.value.startsWith('/') ? input.value : `/${input.value}`
     const sanitisedPath = path.replace(/\s/g, '-')
@@ -164,7 +170,7 @@ export class PageCreate extends Component {
     })
   }
 
-  editSection = (e, section) => {
+  editSection = (e: MouseEvent<HTMLAnchorElement>, section) => {
     e.preventDefault()
     this.setState({
       section,
@@ -198,7 +204,7 @@ export class PageCreate extends Component {
         {hasValidationErrors(errors) && (
           <ErrorSummary errorList={Object.values(errors)} />
         )}
-        <form onSubmit={(e) => this.onSubmit(e)} autoComplete="off">
+        <form onSubmit={this.onSubmit} autoComplete="off">
           <div className="govuk-form-group">
             <label className="govuk-label govuk-label--s" htmlFor="page-type">
               {i18n('addPage.pageTypeOption.title')}

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -1,3 +1,4 @@
+// @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
   Component,

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -1,4 +1,5 @@
 import { clone } from '@defra/forms-model'
+// @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
   Component,

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -1,6 +1,13 @@
 import { clone } from '@defra/forms-model'
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
-import React, { Component, createRef, type ContextType } from 'react'
+import React, {
+  Component,
+  createRef,
+  type ChangeEvent,
+  type ContextType,
+  type FormEvent,
+  type MouseEvent
+} from 'react'
 
 import { type ErrorList, ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
@@ -36,7 +43,7 @@ export class PageEdit extends Component {
     this.formEditSection = createRef()
   }
 
-  onSubmit = async (e) => {
+  onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const { save, data } = this.context
     const { title, path, section, controller } = this.state
@@ -97,7 +104,7 @@ export class PageEdit extends Component {
     return errors
   }
 
-  onClickDelete = async (e) => {
+  onClickDelete = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault()
 
     if (!window.confirm('Confirm delete')) {
@@ -132,15 +139,16 @@ export class PageEdit extends Component {
     }
   }
 
-  onChangeTitle = (e) => {
-    const title = e.target.value
+  onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value: title } = e.target
+
     this.setState({
       title,
       path: this.generatePath(title)
     })
   }
 
-  onChangePath = (e) => {
+  onChangePath = (e: ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value
     const path = input.startsWith('/') ? input : `/${input}`
     this.setState({
@@ -158,8 +166,9 @@ export class PageEdit extends Component {
     return path
   }
 
-  editSection = (e, newSection = false) => {
+  editSection = (e: MouseEvent<HTMLAnchorElement>, newSection = false) => {
     e.preventDefault()
+
     this.setState({
       isEditingSection: true,
       isNewSection: newSection
@@ -174,7 +183,7 @@ export class PageEdit extends Component {
     })
   }
 
-  onChangeSection = (e) => {
+  onChangeSection = (e: ChangeEvent<HTMLSelectElement>) => {
     this.setState({
       section: e.target.value
     })

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -4,7 +4,8 @@ import React, {
   useContext,
   useState,
   useLayoutEffect,
-  type FormEvent
+  type FormEvent,
+  type MouseEvent
 } from 'react'
 
 import { ComponentTypeEdit } from '~/src/ComponentTypeEdit.jsx'
@@ -57,15 +58,13 @@ function useComponentCreate(props) {
 
   useLayoutEffect(() => {
     if (hasValidated && !hasErrors) {
-      handleSubmit()
-        .then()
-        .catch((error: unknown) => {
-          logger.error(error, 'ComponentCreate')
-        })
+      handleSubmit().catch((error: unknown) => {
+        logger.error(error, 'ComponentCreate')
+      })
     }
   }, [hasValidated, hasErrors])
 
-  const handleSubmit = async (e?: FormEvent<HTMLFormElement>) => {
+  async function handleSubmit(e?: FormEvent<HTMLFormElement>) {
     e?.preventDefault()
 
     if (!hasValidated) {
@@ -102,7 +101,7 @@ function useComponentCreate(props) {
     })
   }
 
-  const reset = (e) => {
+  function reset(e: MouseEvent<HTMLAnchorElement>) {
     e.preventDefault()
     dispatch({ type: Meta.SET_COMPONENT })
   }

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -67,19 +67,19 @@ export function ComponentListSelect() {
     }
   }, [listsEditorState.isEditingList, selectedList?.name, isAddingNew])
 
-  const editList = (e: ChangeEvent<HTMLSelectElement>) => {
+  function editList(e: ChangeEvent<HTMLSelectElement>) {
     dispatch({
       type: Meta.SET_SELECTED_LIST,
       payload: e.target.value
     })
   }
 
-  const handleEditListClick = (e: MouseEvent) => {
+  function handleEditListClick(e: MouseEvent) {
     e.preventDefault()
     listsEditorDispatch([ListsEditorStateActions.IS_EDITING_LIST, true])
   }
 
-  const handleAddListClick = (e: MouseEvent) => {
+  function handleAddListClick(e: MouseEvent) {
     e.preventDefault()
     setIsAddingNew(true)
     listDispatch({ type: ListActions.ADD_NEW_LIST })

--- a/designer/client/src/components/FieldEditors/DetailsEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DetailsEdit.tsx
@@ -1,6 +1,6 @@
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
-import React, { useContext } from 'react'
+import React, { useContext, type ChangeEvent } from 'react'
 
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
@@ -34,7 +34,7 @@ export function DetailsEdit({ context = ComponentContext }: Props) {
           children: [i18n('common.titleField.helpText')]
         }}
         value={selectedComponent.title}
-        onChange={(e) =>
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
           dispatch({
             type: Fields.EDIT_TITLE,
             payload: e.target.value

--- a/designer/client/src/components/FieldEditors/DetailsEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DetailsEdit.tsx
@@ -1,3 +1,4 @@
+// @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
 import React, { useContext, type ChangeEvent } from 'react'

--- a/designer/client/src/components/Flyout/Flyout.tsx
+++ b/designer/client/src/components/Flyout/Flyout.tsx
@@ -15,10 +15,7 @@ import { i18n } from '~/src/i18n/i18n.jsx'
 interface Props {
   style?: string
   width?: string
-  onHide?: (
-    e?: KeyboardEvent<HTMLButtonElement> | MouseEvent<HTMLButtonElement>
-  ) => void
-  closeOnEnter?: (e: KeyboardEvent<HTMLButtonElement>) => void
+  onHide?: () => void
   show?: boolean
   offset?: number
   title?: string
@@ -56,7 +53,9 @@ export function useFlyoutEffect(props: Props) {
     }
   }, [offset])
 
-  const onHide: Props['onHide'] = (e) => {
+  const onHide = (
+    e?: KeyboardEvent<HTMLButtonElement> | MouseEvent<HTMLButtonElement>
+  ) => {
     e?.preventDefault()
 
     if (props.onHide) {
@@ -68,7 +67,7 @@ export function useFlyoutEffect(props: Props) {
     }
   }
 
-  const closeOnEnter: Props['closeOnEnter'] = (e) => {
+  function closeOnEnter(e: KeyboardEvent<HTMLButtonElement>) {
     if (e.key === 'Enter') {
       onHide(e)
     }

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -114,7 +114,7 @@ export const Page = (props: {
       </div>
       {isEditingPage && (
         <RenderInPortal>
-          <Flyout title="Edit Page" onHide={setIsEditingPage}>
+          <Flyout title="Edit Page" onHide={() => setIsEditingPage(false)}>
             <PageEdit page={page} onEdit={onEditEnd} />
           </Flyout>
         </RenderInPortal>
@@ -122,7 +122,7 @@ export const Page = (props: {
 
       {isCreatingComponent && (
         <RenderInPortal>
-          <Flyout onHide={setIsCreatingComponent}>
+          <Flyout onHide={() => setIsCreatingComponent(false)}>
             <ComponentContextProvider>
               <ComponentCreate
                 renderInForm={true}

--- a/designer/client/src/components/Tabs/Tabs.tsx
+++ b/designer/client/src/components/Tabs/Tabs.tsx
@@ -33,6 +33,7 @@ export const Tabs: FunctionComponent<Props> = (props) => {
 
   useEffect(() => {
     if (tabsRef.current) {
+      // eslint-disable-next-line no-new
       new TabsJS(tabsRef.current)
       onInit?.()
     }

--- a/designer/client/src/conditions/AbsoluteDateValues.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.tsx
@@ -87,21 +87,21 @@ export const AbsoluteDateValues = ({ value = {}, updateValue }: Props) => {
     }
   }, [year, month, day])
 
-  const dayChanged = (e: ChangeEvent<HTMLInputElement>) => {
+  function dayChanged(e: ChangeEvent<HTMLInputElement>) {
     const day = e.target.value
     if (Number(day) <= 31) {
       setDay(day)
     }
   }
 
-  const monthChanged = (e: ChangeEvent<HTMLInputElement>) => {
+  function monthChanged(e: ChangeEvent<HTMLInputElement>) {
     const month = e.target.value
     if (Number(month) <= 12) {
       setMonth(month)
     }
   }
 
-  const yearChanged = (e: ChangeEvent<HTMLInputElement>) => {
+  function yearChanged(e: ChangeEvent<HTMLInputElement>) {
     const year = e.target.value
     setYear(year)
   }

--- a/designer/client/src/conditions/AbsoluteTimeValues.tsx
+++ b/designer/client/src/conditions/AbsoluteTimeValues.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, type ChangeEvent } from 'react'
 
 import { isInt } from '~/src/conditions/inline-condition-helpers.js'
 
@@ -40,8 +40,11 @@ export const AbsoluteTimeValues = ({ value = {}, updateValue }: Props) => {
     }
   }, [hour, minute])
 
-  const hoursChanged = (e) => setHour(e.target.value)
-  const minutesChanged = (e) => setMinute(e.target.value)
+  const hoursChanged = (e: ChangeEvent<HTMLInputElement>) =>
+    setHour(e.target.value)
+
+  const minutesChanged = (e: ChangeEvent<HTMLInputElement>) =>
+    setMinute(e.target.value)
 
   return (
     <div className="govuk-date-input">

--- a/designer/client/src/conditions/ConditionsEdit.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.tsx
@@ -1,5 +1,5 @@
 import { ConditionsModel } from '@defra/forms-model'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, type MouseEvent } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
@@ -12,21 +12,22 @@ function useConditionsEditor() {
   const [editingCondition, setEditingCondition] = useState(null)
   const [showAddCondition, setShowAddCondition] = useState(false)
 
-  function onClickCondition(e, condition) {
+  function onClickCondition(e: MouseEvent<HTMLAnchorElement>, condition) {
     e.preventDefault()
     setEditingCondition(condition)
   }
-  function onClickAddCondition(e) {
+
+  function onClickAddCondition(e: MouseEvent<HTMLButtonElement>) {
     e.preventDefault()
     setShowAddCondition(true)
   }
-  function editFinished(e) {
-    e?.preventDefault()
+
+  function editFinished() {
     setEditingCondition(null)
     setShowAddCondition(false)
   }
-  function cancelInlineCondition(e) {
-    e?.preventDefault?.()
+
+  function cancelInlineCondition() {
     setEditingCondition(null)
     setShowAddCondition(false)
   }

--- a/designer/client/src/conditions/InlineConditionsDefinition.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinition.tsx
@@ -7,7 +7,7 @@ import {
   clone,
   Coordinator
 } from '@defra/forms-model'
-import React, { Component } from 'react'
+import React, { Component, type ChangeEvent } from 'react'
 
 import { InlineConditionsDefinitionValue } from '~/src/conditions/InlineConditionsDefinitionValue.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
@@ -39,7 +39,7 @@ export class InlineConditionsDefinition extends Component {
     }
   }
 
-  onChangeCoordinator = (e) => {
+  onChangeCoordinator = (e: ChangeEvent<HTMLSelectElement>) => {
     const input = e.target
     let newCondition = {}
 
@@ -75,7 +75,7 @@ export class InlineConditionsDefinition extends Component {
     }
   }
 
-  onChangeField = (e) => {
+  onChangeField = (e: ChangeEvent<HTMLSelectElement>) => {
     const input = e.target
     const fieldName = input.value
 
@@ -127,7 +127,7 @@ export class InlineConditionsDefinition extends Component {
     })
   }
 
-  onChangeOperator = (e) => {
+  onChangeOperator = (e: ChangeEvent<HTMLSelectElement>) => {
     const input = e.target
     const { condition } = this.state
 

--- a/designer/client/src/conditions/InlineConditionsEdit.tsx
+++ b/designer/client/src/conditions/InlineConditionsEdit.tsx
@@ -4,7 +4,12 @@ import {
   clone
 } from '@defra/forms-model'
 import classNames from 'classnames'
-import React, { Component, Fragment } from 'react'
+import React, {
+  Component,
+  Fragment,
+  type ChangeEvent,
+  type MouseEvent
+} from 'react'
 
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { InlineConditionsDefinition } from '~/src/conditions/InlineConditionsDefinition.jsx'
@@ -19,7 +24,7 @@ export class InlineConditionsEdit extends Component {
     }
   }
 
-  onChangeCheckbox = (e) => {
+  onChangeCheckbox = (e: ChangeEvent<HTMLInputElement>) => {
     let copy = clone(this.state.selectedConditions ?? [])
     const index = Number(e.target.value)
     if (e.target.checked) {
@@ -32,8 +37,8 @@ export class InlineConditionsEdit extends Component {
     })
   }
 
-  onClickGroup = (e) => {
-    e?.preventDefault()
+  onClickGroup = (e: MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault()
     if (this.state.selectedConditions.length < 2) {
       this.setState({
         editingError: 'Please select at least 2 items for grouping'
@@ -104,8 +109,9 @@ export class InlineConditionsEdit extends Component {
     }
   }
 
-  onClickCancelEditView = (e) => {
-    e?.preventDefault()
+  onClickCancelEditView = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+
     this.setState({
       selectedConditions: [],
       editingIndex: undefined

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -3,6 +3,7 @@ import {
   type ConditionWrapper,
   type FormDefinition
 } from '@defra/forms-model'
+// @ts-expect-error -- No types available
 import { Select } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
   Component,

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -4,7 +4,12 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { Select } from '@xgovformbuilder/govuk-react-jsx'
-import React, { Component, type ChangeEvent, type ContextType } from 'react'
+import React, {
+  Component,
+  type ChangeEvent,
+  type ContextType,
+  type MouseEvent
+} from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
@@ -164,7 +169,7 @@ export class SelectConditions extends Component<Props, State> {
     return fieldName
   }
 
-  onClickDefineCondition = (e) => {
+  onClickDefineCondition = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
     this.setState({
       inline: true

--- a/designer/client/src/conditions/SelectValues.tsx
+++ b/designer/client/src/conditions/SelectValues.tsx
@@ -1,12 +1,12 @@
 import { ConditionValue } from '@defra/forms-model'
-import React from 'react'
+import React, { type ChangeEvent } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 
 export const SelectValues = (props) => {
   const { fieldDef, updateValue, value } = props
 
-  const onChangeSelect = (e) => {
+  const onChangeSelect = (e: ChangeEvent<HTMLSelectElement>) => {
     const input = e.target
     const newValue = input.value
 

--- a/designer/client/src/conditions/TextValues.tsx
+++ b/designer/client/src/conditions/TextValues.tsx
@@ -1,12 +1,12 @@
 import { ConditionValue } from '@defra/forms-model'
-import React from 'react'
+import React, { type ChangeEvent } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 
 export const TextValues = (props) => {
   const { updateValue, value } = props
 
-  const onChangeTextInput = (e) => {
+  const onChangeTextInput = (e: ChangeEvent<HTMLInputElement>) => {
     const input = e.target
     const newValue = input.value
     updateValue(new ConditionValue(newValue))

--- a/designer/client/src/hooks/list/useListItem/types.ts
+++ b/designer/client/src/hooks/list/useListItem/types.ts
@@ -1,10 +1,11 @@
 import { type FormDefinition } from '@defra/forms-model'
+import { type ChangeEvent } from 'react'
 
 export interface ListItemHook {
-  handleTitleChange: (e) => void
-  handleConditionChange: (e) => void
-  handleValueChange: (e) => void
-  handleHintChange: (e) => void
+  handleTitleChange: (e: ChangeEvent<HTMLInputElement>) => void
+  handleConditionChange: (e: ChangeEvent<HTMLSelectElement>) => void
+  handleValueChange: (e: ChangeEvent<HTMLInputElement>) => void
+  handleHintChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
   prepareForDelete: <T>(data: T, index?: number) => T
   prepareForSubmit: (data: FormDefinition) => FormDefinition
   validate: (i18n: any) => boolean

--- a/designer/client/src/hooks/list/useListItem/useListItem.tsx
+++ b/designer/client/src/hooks/list/useListItem/useListItem.tsx
@@ -14,28 +14,28 @@ export function useListItem(state, dispatch): ListItemHook {
   const { selectedItem = {} } = state
   const { value = '', condition } = selectedItem
 
-  function handleTitleChange(e) {
+  const handleTitleChange: ListItemHook['handleTitleChange'] = (e) => {
     dispatch({
       type: ListActions.EDIT_LIST_ITEM_TEXT,
       payload: e.target.value
     })
   }
 
-  function handleConditionChange(e) {
+  const handleConditionChange: ListItemHook['handleConditionChange'] = (e) => {
     dispatch({
       type: ListActions.EDIT_LIST_ITEM_CONDITION,
       payload: e.target.value
     })
   }
 
-  function handleValueChange(e) {
+  const handleValueChange: ListItemHook['handleValueChange'] = (e) => {
     dispatch({
       type: ListActions.EDIT_LIST_ITEM_VALUE,
       payload: e.target.value
     })
   }
 
-  function handleHintChange(e) {
+  const handleHintChange: ListItemHook['handleHintChange'] = (e) => {
     dispatch({
       type: ListActions.EDIT_LIST_ITEM_DESCRIPTION,
       payload: e.target.value

--- a/designer/client/src/javascripts/application.js
+++ b/designer/client/src/javascripts/application.js
@@ -14,4 +14,5 @@ createAll(ErrorSummary)
 createAll(Radios)
 createAll(NotificationBanner)
 
+// eslint-disable-next-line no-new
 new ServiceHeader(document.querySelector("[data-module='one-login-header']"))

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -1,6 +1,11 @@
 import { clone } from '@defra/forms-model'
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
-import React, { useContext, type FormEvent, type MouseEvent } from 'react'
+import React, {
+  useContext,
+  type ChangeEvent,
+  type FormEvent,
+  type MouseEvent
+} from 'react'
 
 import { ErrorSummary, type ErrorList } from '~/src/ErrorSummary.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
@@ -152,7 +157,7 @@ export function ListEdit() {
               children: [i18n('list.title')]
             }}
             value={selectedList.title}
-            onChange={(e) =>
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
               dispatch({
                 type: ListActions.EDIT_TITLE,
                 payload: e.target.value

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -1,4 +1,5 @@
 import { clone } from '@defra/forms-model'
+// @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
   useContext,

--- a/designer/client/src/list/ListItemEdit.tsx
+++ b/designer/client/src/list/ListItemEdit.tsx
@@ -1,3 +1,4 @@
+// @ts-expect-error -- No types available
 import { Input, Textarea } from '@xgovformbuilder/govuk-react-jsx'
 import React, { useContext, type FormEvent, type MouseEvent } from 'react'
 

--- a/designer/client/src/section/SectionEdit.tsx
+++ b/designer/client/src/section/SectionEdit.tsx
@@ -2,6 +2,7 @@ import { type Section } from '@defra/forms-model'
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
   Component,
+  type ChangeEvent,
   type ContextType,
   type FormEvent,
   type MouseEvent
@@ -176,7 +177,9 @@ export class SectionEdit extends Component<Props, State> {
               children: [i18n('sectionEdit.titleField.title')]
             }}
             value={title}
-            onChange={(e) => this.setState({ title: e.target.value })}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              this.setState({ title: e.target.value })
+            }
             errorMessage={errors.name}
           />
           <Input
@@ -191,7 +194,9 @@ export class SectionEdit extends Component<Props, State> {
               children: [i18n('sectionEdit.nameField.helpText')]
             }}
             value={name}
-            onChange={(e) => this.setState({ name: e.target.value })}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              this.setState({ name: e.target.value })
+            }
             errorMessage={errors.name}
           />
           <div className="govuk-checkboxes govuk-form-group">

--- a/designer/client/src/section/SectionEdit.tsx
+++ b/designer/client/src/section/SectionEdit.tsx
@@ -1,4 +1,5 @@
 import { type Section } from '@defra/forms-model'
+// @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
   Component,

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -1,5 +1,5 @@
 import { type Section } from '@defra/forms-model'
-import React, { Component, type ContextType } from 'react'
+import React, { Component, type ContextType, type MouseEvent } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
@@ -19,8 +19,9 @@ export class SectionsEdit extends Component<Props, State> {
 
   state: State = {}
 
-  onClickSection = (e, section?: Section) => {
+  onClickSection = (e: MouseEvent, section?: Section) => {
     e.preventDefault()
+
     this.setState({
       section,
       isEditingSection: true

--- a/designer/server/src/common/nunjucks/filters/format-currency.js
+++ b/designer/server/src/common/nunjucks/filters/format-currency.js
@@ -1,4 +1,9 @@
-function formatCurrency(value, locale = 'en-GB', currency = 'GBP') {
+/**
+ * @param {Parameters<Intl.NumberFormat['format']>[0]} value
+ * @param {Intl.LocalesArgument} locale
+ * @param {string} currency
+ */
+export function formatCurrency(value, locale = 'en-GB', currency = 'GBP') {
   const formatter = new Intl.NumberFormat(locale, {
     style: 'currency',
     currency
@@ -6,5 +11,3 @@ function formatCurrency(value, locale = 'en-GB', currency = 'GBP') {
 
   return formatter.format(value)
 }
-
-export { formatCurrency }

--- a/designer/server/src/common/nunjucks/filters/format-date.js
+++ b/designer/server/src/common/nunjucks/filters/format-date.js
@@ -1,13 +1,11 @@
 import { format, isDate, parseISO } from 'date-fns'
 
 /**
- * @param {string} value
- * @param {string} [formattedDateStr]
+ * @param {string | Date} value
+ * @param {string} formattedDateStr
  */
-function formatDate(value, formattedDateStr = 'd MMM yyyy') {
+export function formatDate(value, formattedDateStr = 'd MMM yyyy') {
   const date = isDate(value) ? value : parseISO(value)
 
   return format(date, formattedDateStr)
 }
-
-export { formatDate }

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@types/dagre": "^0.7.52",
         "@types/enzyme": "^3.10.18",
         "@types/enzyme-adapter-react-16": "^1.0.9",
+        "@types/govuk-frontend": "^5.4.0",
         "@types/hapi__catbox-memory": "^4.1.8",
         "@types/hapi__cookie": "^12.0.5",
         "@types/hapi__crumb": "^7.3.7",
@@ -4837,6 +4838,13 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/govuk-frontend": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@types/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-asQCANHwpkvM72nO7m3zqk3jeawYta87+mNEg8Xu9jbmSg7ImpRYtlqnv+pDECye/dDe5DUFU0D60GP2NQaX2w==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/dagre": "^0.7.52",
     "@types/enzyme": "^3.10.18",
     "@types/enzyme-adapter-react-16": "^1.0.9",
+    "@types/govuk-frontend": "^5.4.0",
     "@types/hapi__catbox-memory": "^4.1.8",
     "@types/hapi__cookie": "^12.0.5",
     "@types/hapi__crumb": "^7.3.7",


### PR DESCRIPTION
I've had this branch for a while, might as well get it out the way

Types added for:

1. Nunjucks filters
1. Event handlers to determine `e.target.value` etc
1. GOV.UK Frontend components

### Before

```console
✖ 767 problems (51 errors, 716 warnings)
```

### After

```console
✖ 631 problems (49 errors, 582 warnings)
```