### PR TITLE
Fix date condition validation (pad numbers before parsing)

### DIFF
--- a/designer/client/src/conditions/AbsoluteDateValues.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.tsx
@@ -102,10 +102,7 @@ export const AbsoluteDateValues = ({ value = {}, updateValue }: Props) => {
     <div className="govuk-date-input">
       <div className="govuk-date-input__item">
         <div className="govuk-form-group">
-          <label
-            htmlFor="cond-value-day"
-            className="govuk-label govuk-label--s"
-          >
+          <label htmlFor="cond-value-day" className="govuk-label">
             Day
           </label>
           <input
@@ -125,10 +122,7 @@ export const AbsoluteDateValues = ({ value = {}, updateValue }: Props) => {
       </div>
       <div className="govuk-date-input__item">
         <div className="govuk-form-group">
-          <label
-            htmlFor="cond-value-month"
-            className="govuk-label govuk-label--s"
-          >
+          <label htmlFor="cond-value-month" className="govuk-label">
             Month
           </label>
           <input
@@ -148,10 +142,7 @@ export const AbsoluteDateValues = ({ value = {}, updateValue }: Props) => {
       </div>
       <div className="govuk-date-input__item">
         <div className="govuk-form-group">
-          <label
-            htmlFor="cond-value-year"
-            className="govuk-label govuk-label--s"
-          >
+          <label htmlFor="cond-value-year" className="govuk-label">
             Year
           </label>
           <input

--- a/designer/client/src/conditions/AbsoluteDateValues.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.tsx
@@ -12,45 +12,37 @@ export interface YearMonthDay {
   day: number
 }
 
-export interface YearMonthDayOptional {
-  year?: number
-  month?: number
-  day?: number
-}
-
-interface Props {
-  value?: YearMonthDayOptional
+export interface Props {
+  value?: Partial<YearMonthDay>
   updateValue: ({ year, month, day }: YearMonthDay) => void
 }
 
-function isValidateDate(props: {
-  year?: number | string
-  month?: number | string
-  day?: number | string
-}) {
-  const { year = 2020, month = 12, day = 1 } = props
-  const parsedDate = Date.parse(`${year}-${month}-${day}`)
+function isValidateDate(props: Partial<YearMonthDay>): props is YearMonthDay {
+  const year = `${props.year}`
+  const month = `${props.month}`.padStart(2, '0')
+  const day = `${props.day}`.padStart(2, '0')
 
-  if (isNaN(parsedDate)) {
-    return false
-  }
-
-  return true
+  return !isNaN(Date.parse(`${year}-${month}-${day}`))
 }
 
 function isValidDay(day?: number): day is number {
-  return isValidateDate({ day })
+  const date = { day, month: 12, year: 2020 }
+  return isValidateDate(date)
 }
+
 function isValidMonth(month?: number): month is number {
-  return isValidateDate({ month })
+  const date = { day: 1, month, year: 2020 }
+  return isValidateDate(date)
 }
-function isValidYear(year = 0): year is number {
-  return year >= 1000 && isValidateDate({ year })
+
+function isValidYear(year?: number): year is number {
+  const date = { day: 1, month: 12, year }
+  return isValidateDate(date) && date.year >= 1000
 }
 
 export const AbsoluteDateValues = ({ value = {}, updateValue }: Props) => {
   const [year, setYear] = useState(() =>
-    value.year && isInt(value.year) ? value.year.toString() : undefined
+    isInt(value.year) ? `${value.year}` : undefined
   )
 
   const [month, setMonth] = useState(() =>

--- a/designer/client/src/conditions/RelativeTimeValues.tsx
+++ b/designer/client/src/conditions/RelativeTimeValues.tsx
@@ -1,12 +1,16 @@
 import { DateDirections, RelativeTimeValue } from '@defra/forms-model'
+import upperFirst from 'lodash/upperFirst.js'
 import React, { Component } from 'react'
+
+import { i18n } from '~/src/i18n/i18n.jsx'
 
 export class RelativeTimeValues extends Component {
   constructor(props) {
     super(props)
+
     this.state = {
       timePeriod: props.value?.timePeriod,
-      timeUnits: props.value?.timeUnit,
+      timeUnit: props.value?.timeUnit,
       direction: props.value?.direction
     }
   }
@@ -18,70 +22,126 @@ export class RelativeTimeValues extends Component {
   }
 
   passValueToParentComponentIfComplete() {
-    const { timePeriod, timeUnits, direction } = this.state
-    if (timePeriod && timeUnits && direction) {
-      this.props.updateValue(
+    const { timeOnly, updateValue } = this.props
+    const { timePeriod, timeUnit, direction } = this.state
+
+    if (timePeriod && timeUnit && direction) {
+      updateValue(
         new RelativeTimeValue(
           timePeriod,
-          timeUnits,
+          timeUnit,
           direction,
-          this.props.timeOnly || false
+          timeOnly ?? false
         )
       )
     }
   }
 
   render() {
-    const { timePeriod, timeUnits, direction } = this.state
+    const { units } = this.props
+    const { timePeriod, timeUnit, direction } = this.state
 
     return (
       <>
-        <input
-          className="govuk-input govuk-input--width-20"
-          id="cond-value-period"
-          name="cond-value-period"
-          type="text"
-          defaultValue={timePeriod}
-          required
-          onChange={(e) => this.updateState({ timePeriod: e.target.value })}
-          data-testid="cond-value-period"
-        />
+        <div className="govuk-form-group govuk-!-margin-bottom-3">
+          <label className="govuk-label" htmlFor="cond-value-period">
+            {i18n('conditions.conditionDatePeriod')}
+          </label>
+          <input
+            className="govuk-input govuk-input--width-5"
+            id="cond-value-period"
+            name="cond-value-period"
+            type="text"
+            defaultValue={timePeriod}
+            required
+            onChange={(e) =>
+              this.updateState({
+                timePeriod: e.currentTarget.value
+              })
+            }
+            data-testid="cond-value-period"
+          />
+        </div>
 
-        <select
-          className="govuk-select"
-          id="cond-value-units"
-          name="cond-value-units"
-          value={timeUnits ?? ''}
-          onChange={(e) => this.updateState({ timeUnits: e.target.value })}
-          data-testid="cond-value-units"
-        >
-          <option value="" />
-          {Object.values(this.props.units).map((unit) => {
-            return (
-              <option key={unit.value} value={unit.value}>
-                {unit.display}
-              </option>
-            )
-          })}
-        </select>
+        <div className="govuk-form-group">
+          <fieldset className="govuk-fieldset">
+            <legend className="govuk-fieldset__legend">
+              {i18n('conditions.conditionDateUnits')}
+            </legend>
+            <div className="govuk-radios" data-module="govuk-radios">
+              {Object.values(units).map((unit) => {
+                const name = 'cond-value-units'
+                const id = `${name}-${unit.value}`
 
-        <select
-          className="govuk-select"
-          id="cond-value-direction"
-          name="cond-value-direction"
-          value={direction ?? ''}
-          onChange={(e) => this.updateState({ direction: e.target.value })}
-          data-testid="cond-value-direction"
-        >
-          <option value="" />
-          {Object.values(DateDirections).map((direction) => {
-            return (
-              <option key={direction} value={direction}>
-                {direction}
-              </option>
-            )
-          })}
-        </select>
+                return (
+                  <div className="govuk-radios__item" key={unit.value}>
+                    <input
+                      className="govuk-radios__input"
+                      id={id}
+                      name={name}
+                      type="radio"
+                      defaultValue={unit.value}
+                      defaultChecked={timeUnit === unit.value}
+                      onClick={(e) => {
+                        const { value: unit } = e.currentTarget
+
+                        this.updateState({
+                          timeUnit: unit
+                        })
+                      }}
+                    />
+                    <label
+                      className="govuk-label govuk-radios__label"
+                      htmlFor={id}
+                    >
+                      {upperFirst(unit.value)}
+                    </label>
+                  </div>
+                )
+              })}
+            </div>
+          </fieldset>
+        </div>
+
+        <div className="govuk-form-group">
+          <fieldset className="govuk-fieldset">
+            <legend className="govuk-fieldset__legend">
+              {i18n('conditions.conditionDateDirection')}
+            </legend>
+            <div className="govuk-radios" data-module="govuk-radios">
+              {Object.values(DateDirections).map((directionValue) => {
+                const name = 'cond-value-direction'
+                const id = `${name}-${directionValue}`
+
+                return (
+                  <div className="govuk-radios__item" key={directionValue}>
+                    <input
+                      className="govuk-radios__input"
+                      id={id}
+                      name={name}
+                      type="radio"
+                      defaultValue={directionValue}
+                      defaultChecked={direction === directionValue}
+                      onClick={(e) => {
+                        const { value: direction } = e.currentTarget
+
+                        this.updateState({
+                          direction: direction as DateDirections
+                        })
+                      }}
+                    />
+                    <label
+                      className="govuk-label govuk-radios__label"
+                      htmlFor={id}
+                    >
+                      {upperFirst(directionValue)}
+                    </label>
+                  </div>
+                )
+              })}
+            </div>
+          </fieldset>
+        </div>
       </>
     )
   }

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -110,6 +110,9 @@
     "conditionField": "Component title",
     "conditionOperator": "Operator",
     "conditionCoordinator": "Coordinator",
+    "conditionDatePeriod": "Period",
+    "conditionDateUnits": "Units",
+    "conditionDateDirection": "Direction",
     "conditionValue": "Value",
     "youCannotEditWarning": "You cannot edit this condition '{{conditionString}}'. Please recreate it in the editor below to continue"
   },


### PR DESCRIPTION
This PR fixes a regression where month/day/year condition values hit `Date.parse()` without padded zeroes

This was split out of the work to resolve:

1. [**Amended conditions are not being saved** #405841](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/405841)
2. [**Date conditions not working** #418871](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/418871)

Missing labels were also added in to fix the UI

## Before

<img width="437" alt="Relative dates, before" src="https://github.com/user-attachments/assets/ffe90d1e-c024-441c-9967-6be51b0e70bf">

## After

<img width="317" alt="Relative dates, after" src="https://github.com/user-attachments/assets/32c7ba13-854a-4777-b03d-0f87e0205bd0">