### PR TITLE
Fix skipped inline condition definition tests

### DIFF
--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -12,7 +12,7 @@ import React from 'react'
 
 import { InlineConditionsDefinitionValue } from '~/src/conditions/InlineConditionsDefinitionValue.jsx'
 
-describe.skip('InlineConditionsDefinitionValue', () => {
+describe('InlineConditionsDefinitionValue', () => {
   afterEach(cleanup)
 
   it('should display a text input for fields without custom mappings or options', async () => {

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -13,17 +13,21 @@ import { userEvent } from '@testing-library/user-event'
 import upperFirst from 'lodash/upperFirst.js'
 import React from 'react'
 
-import { InlineConditionsDefinitionValue } from '~/src/conditions/InlineConditionsDefinitionValue.jsx'
+import {
+  InlineConditionsDefinitionValue,
+  type FieldDef
+} from '~/src/conditions/InlineConditionsDefinitionValue.jsx'
 
 describe('InlineConditionsDefinitionValue', () => {
   afterEach(cleanup)
 
   it('should display a text input for fields without custom mappings or options', async () => {
-    const fieldDef = {
+    const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
       type: ComponentType.TextField
     }
+
     render(
       <InlineConditionsDefinitionValue
         updateValue={jest.fn()}
@@ -39,12 +43,14 @@ describe('InlineConditionsDefinitionValue', () => {
   })
 
   it('inputting a text value should call update value', async () => {
-    const fieldDef = {
+    const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
       type: ComponentType.TextField
     }
+
     const updateValueCallback = jest.fn()
+
     render(
       <InlineConditionsDefinitionValue
         updateValue={updateValueCallback}
@@ -67,12 +73,14 @@ describe('InlineConditionsDefinitionValue', () => {
   })
 
   it('inputting a blank text value should call update value with undefined', async () => {
-    const fieldDef = {
+    const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
       type: ComponentType.TextField
     }
+
     const updateValueCallback = jest.fn()
+
     render(
       <InlineConditionsDefinitionValue
         updateValue={updateValueCallback}
@@ -93,12 +101,14 @@ describe('InlineConditionsDefinitionValue', () => {
       { value: 'value1', text: 'Value 1' },
       { value: 'value2', text: 'Value 2' }
     ]
-    const fieldDef = {
+
+    const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
       values,
       type: ComponentType.SelectField
     }
+
     render(
       <InlineConditionsDefinitionValue
         updateValue={jest.fn()}
@@ -125,13 +135,16 @@ describe('InlineConditionsDefinitionValue', () => {
       { value: 'value1', text: 'Value 1' },
       { value: 'value2', text: 'Value 2' }
     ]
-    const fieldDef = {
+
+    const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
       values,
       type: ComponentType.SelectField
     }
+
     const updateValueCallback = jest.fn()
+
     render(
       <InlineConditionsDefinitionValue
         updateValue={updateValueCallback}
@@ -156,13 +169,16 @@ describe('InlineConditionsDefinitionValue', () => {
       { value: true, text: 'Value 1' },
       { value: false, text: 'Value 2' }
     ]
-    const fieldDef = {
+
+    const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
       values,
       type: ComponentType.SelectField
     }
+
     const updateValueCallback = jest.fn()
+
     render(
       <InlineConditionsDefinitionValue
         updateValue={updateValueCallback}
@@ -187,13 +203,16 @@ describe('InlineConditionsDefinitionValue', () => {
       { value: 42, text: 'Value 1' },
       { value: 43, text: 'Value 2' }
     ]
-    const fieldDef = {
+
+    const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
       values,
       type: ComponentType.SelectField
     }
+
     const updateValueCallback = jest.fn()
+
     render(
       <InlineConditionsDefinitionValue
         updateValue={updateValueCallback}
@@ -218,13 +237,16 @@ describe('InlineConditionsDefinitionValue', () => {
       { value: 42, text: 'Value 1' },
       { value: 43, text: 'Value 2' }
     ]
-    const fieldDef = {
+
+    const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
       values,
       type: ComponentType.SelectField
     }
+
     const updateValueCallback = jest.fn()
+
     render(
       <InlineConditionsDefinitionValue
         updateValue={updateValueCallback}

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -3,7 +3,8 @@ import {
   ConditionType,
   ConditionValue,
   OperatorName,
-  relativeDateOperatorNames
+  relativeDateOperatorNames,
+  type Item
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { act, cleanup, render, waitFor } from '@testing-library/react'
@@ -84,9 +85,9 @@ describe('InlineConditionsDefinitionValue', () => {
   })
 
   it('should display a select input for fields without custom mappings and with options', async () => {
-    const values = [
-      { value: 'value1', label: 'Value 1' },
-      { value: 'value2', label: 'Value 2' }
+    const values: Item[] = [
+      { value: 'value1', text: 'Value 1' },
+      { value: 'value2', text: 'Value 2' }
     ]
     const fieldDef = {
       label: 'Something',
@@ -114,9 +115,9 @@ describe('InlineConditionsDefinitionValue', () => {
   })
 
   it('selecting a value from the select list should call update value', async () => {
-    const values = [
-      { value: 'value1', label: 'Value 1' },
-      { value: 'value2', label: 'Value 2' }
+    const values: Item[] = [
+      { value: 'value1', text: 'Value 1' },
+      { value: 'value2', text: 'Value 2' }
     ]
     const fieldDef = {
       label: 'Something',
@@ -145,9 +146,9 @@ describe('InlineConditionsDefinitionValue', () => {
   })
 
   it('should correctly compare boolean string to boolean value', async () => {
-    const values = [
-      { value: true, label: 'Value 1' },
-      { value: false, label: 'Value 2' }
+    const values: Item[] = [
+      { value: true, text: 'Value 1' },
+      { value: false, text: 'Value 2' }
     ]
     const fieldDef = {
       label: 'Something',
@@ -176,9 +177,9 @@ describe('InlineConditionsDefinitionValue', () => {
   })
 
   it('should correctly compare number string to number value', async () => {
-    const values = [
-      { value: 42, label: 'Value 1' },
-      { value: 43, label: 'Value 2' }
+    const values: Item[] = [
+      { value: 42, text: 'Value 1' },
+      { value: 43, text: 'Value 2' }
     ]
     const fieldDef = {
       label: 'Something',
@@ -207,9 +208,9 @@ describe('InlineConditionsDefinitionValue', () => {
   })
 
   it('selecting a blank value from the select list should call update value with undefined', async () => {
-    const values = [
-      { value: 42, label: 'Value 1' },
-      { value: 43, label: 'Value 2' }
+    const values: Item[] = [
+      { value: 42, text: 'Value 1' },
+      { value: 43, text: 'Value 2' }
     ]
     const fieldDef = {
       label: 'Something',

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -4,6 +4,7 @@ import {
   ConditionValue,
   DateUnits,
   OperatorName,
+  absoluteDateOperatorNames,
   relativeDateOperatorNames,
   type Item
 } from '@defra/forms-model'
@@ -312,6 +313,49 @@ describe('InlineConditionsDefinitionValue', () => {
 
         expect($unit).toBeInTheDocument()
       }
+    }
+  )
+
+  it.each(absoluteDateOperatorNames)(
+    `should display absolute date component fields for '%s' operator`,
+    async (operator) => {
+      const fieldDef: FieldDef = {
+        label: 'Something',
+        name: 'field1',
+        type: ComponentType.DatePartsField
+      }
+
+      const updateValueCallback = jest.fn()
+
+      render(
+        <InlineConditionsDefinitionValue
+          updateValue={updateValueCallback}
+          fieldDef={fieldDef}
+          operator={operator}
+        />
+      )
+
+      const $day = await waitFor(() =>
+        screen.findByRole('spinbutton', {
+          name: 'Day'
+        })
+      )
+
+      const $month = await waitFor(() =>
+        screen.findByRole('spinbutton', {
+          name: 'Month'
+        })
+      )
+
+      const $year = await waitFor(() =>
+        screen.findByRole('spinbutton', {
+          name: 'Year'
+        })
+      )
+
+      expect($day).toBeInTheDocument()
+      expect($month).toBeInTheDocument()
+      expect($year).toBeInTheDocument()
     }
   )
 })

--- a/designer/client/src/conditions/SelectValues.tsx
+++ b/designer/client/src/conditions/SelectValues.tsx
@@ -15,7 +15,7 @@ export const SelectValues = (props) => {
       const option = fieldDef.values?.find(
         (value) => String(value.value) === newValue
       )
-      value = new ConditionValue(String(option.value), option.label)
+      value = new ConditionValue(String(option.value), option.text)
     }
     updateValue(value)
   }

--- a/designer/client/src/conditions/SelectValues.tsx
+++ b/designer/client/src/conditions/SelectValues.tsx
@@ -7,17 +7,16 @@ export const SelectValues = (props) => {
   const { fieldDef, updateValue, value } = props
 
   const onChangeSelect = (e: ChangeEvent<HTMLSelectElement>) => {
-    const input = e.target
-    const newValue = input.value
+    const { value: newValue } = e.target
 
-    let value
-    if (newValue && newValue?.trim() !== '') {
-      const option = fieldDef.values?.find(
-        (value) => String(value.value) === newValue
-      )
-      value = new ConditionValue(String(option.value), option.text)
+    // Find the selected option
+    const option = fieldDef.values?.find((item) => `${item.value}` === newValue)
+    if (!option || !newValue) {
+      updateValue(undefined)
+      return
     }
-    updateValue(value)
+
+    updateValue(new ConditionValue(`${option.value}`, option.text))
   }
 
   return (

--- a/designer/client/src/conditions/TextValues.tsx
+++ b/designer/client/src/conditions/TextValues.tsx
@@ -7,8 +7,12 @@ export const TextValues = (props) => {
   const { updateValue, value } = props
 
   const onChangeTextInput = (e: ChangeEvent<HTMLInputElement>) => {
-    const input = e.target
-    const newValue = input.value
+    const { value: newValue } = e.target
+    if (!newValue) {
+      updateValue(undefined)
+      return
+    }
+
     updateValue(new ConditionValue(newValue))
   }
 


### PR DESCRIPTION
This PR fixes and re-enables the inline condition definition tests (skipped since 2021)

* Fix typo on condition list item `label` → `text`
* Fix inline conditions not being unset when blank
* Prefer input via label selectors in tests
* Add missing tests for absolute date conditions