### PR TITLE
Remove legacy condition string warning message

### DIFF
--- a/designer/client/src/conditions/InlineConditions.tsx
+++ b/designer/client/src/conditions/InlineConditions.tsx
@@ -31,7 +31,6 @@ interface State {
   editView?: boolean
   conditions: ConditionsModel
   fields: any
-  conditionString: any
   validationErrors: ErrorListItem[]
 }
 
@@ -65,8 +64,7 @@ export class InlineConditions extends Component<Props, State> {
     this.state = {
       validationErrors: [],
       conditions,
-      fields: this.fieldsForPath(path),
-      conditionString: condition?.value
+      fields: this.fieldsForPath(path)
     }
   }
 
@@ -231,8 +229,7 @@ export class InlineConditions extends Component<Props, State> {
   }
 
   render() {
-    const { conditions, editView, conditionString, validationErrors } =
-      this.state
+    const { conditions, editView, validationErrors } = this.state
     const hasConditions = conditions.hasConditions
 
     const nameError = validationErrors
@@ -245,20 +242,6 @@ export class InlineConditions extends Component<Props, State> {
       <div id="inline-conditions" data-testid={'inline-conditions'}>
         <div id="inline-condition-header">
           <div className="govuk-hint">{i18n('conditions.addOrEditHint')}</div>
-          {typeof conditionString === 'string' && (
-            <div
-              id="condition-string-edit-warning"
-              className="govuk-warning-text"
-            >
-              <span className="govuk-warning-text__icon" aria-hidden="true">
-                !
-              </span>
-              <strong className="govuk-warning-text__text">
-                <span className="govuk-visually-hidden">{i18n('warning')}</span>
-                {i18n('conditions.youCannotEditWarning', { conditionString })}
-              </strong>
-            </div>
-          )}
           <>
             {hasErrors && <ErrorSummary errorList={validationErrors} />}
             <div

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -113,8 +113,7 @@
     "conditionDatePeriod": "Period",
     "conditionDateUnits": "Units",
     "conditionDateDirection": "Direction",
-    "conditionValue": "Value",
-    "youCannotEditWarning": "You cannot edit this condition '{{conditionString}}'. Please recreate it in the editor below to continue"
+    "conditionValue": "Value"
   },
   "create": "create {{noun}}",
   "dateFieldEditComponent": {


### PR DESCRIPTION
This PR removes a warning message missed from https://github.com/DEFRA/forms-designer/pull/351/commits/26fffd7f8cc7dfbc0666aef667a36b9e905c418d in [#351](https://github.com/DEFRA/forms-designer/pull/351)

It was displayed when string conditions (removed) were edited in **forms-designer**

>You cannot edit this condition 'XYZ'. Please recreate it in the editor below to continue