### PR TITLE
Fix double-quoted absolute date condition expressions

### DIFF
--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -7,6 +7,7 @@ import {
   RelativeDateValue
 } from '~/src/conditions/condition-values.js'
 import {
+  ConditionType,
   DateDirections,
   Operator,
   OperatorName
@@ -156,11 +157,12 @@ function formatValue(
   value: ConditionValue | RelativeDateValue
 ) {
   if (
-    'value' in value &&
-    (field.type === ComponentType.YesNoField ||
-      field.type === ComponentType.NumberField)
+    (field.type === ComponentType.DatePartsField &&
+      value.type === ConditionType.RelativeDate) ||
+    field.type === ComponentType.NumberField ||
+    field.type === ComponentType.YesNoField
   ) {
-    return value.value
+    return value.toExpression()
   }
 
   return `'${value.toExpression()}'`
@@ -183,7 +185,7 @@ function absoluteDate(operator: Operator): OperatorDefinition {
         )
       }
 
-      return `${field.name} ${operator} '${formatValue(field, value)}'`
+      return `${field.name} ${operator} ${formatValue(field, value)}`
     }
   }
 }
@@ -201,7 +203,7 @@ function relativeDate(
       }
 
       const isPast = value.direction === DateDirections.PAST
-      return `${field.name} ${isPast ? pastOperator : futureOperator} ${value.toExpression()}`
+      return `${field.name} ${isPast ? pastOperator : futureOperator} ${formatValue(field, value)}`
     }
   }
 }


### PR DESCRIPTION
This PR ensures story [#418871](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/418871) is ready for testing

It fixes one extra double-quote bug to prevent **forms-runner** from throwing an error, following on from:

* https://github.com/DEFRA/forms-designer/pull/366

The bug affected lines [234-237 of **FormModel.ts**](https://github.com/DEFRA/forms-runner/blob/6eaada2d316553aa8202c7100f38cd8ff53a45b2/src/server/plugins/engine/models/FormModel.ts#L234-L237) where condition objects are turned into expression strings

## Before

```console
exampleDate > ''2024-07-30''
```

## After

```console
exampleDate > '2024-07-30'
```