### PR TITLE
Enable conditions UI for all supported components

### DIFF
--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -1,6 +1,8 @@
 import {
   ComponentType,
+  ConditionType,
   getComponentDefaults,
+  OperatorName,
   type ComponentDef,
   type FormDefinition
 } from '@defra/forms-model'
@@ -38,7 +40,30 @@ describe('ComponentTypeEdit', () => {
         }
       ],
       sections: [],
-      conditions: []
+      conditions: [
+        {
+          name: 'someCondition',
+          displayName: 'My condition',
+          value: {
+            name: 'My condition',
+            conditions: [
+              {
+                field: {
+                  name: 'field1',
+                  display: 'Something',
+                  type: ComponentType.YesNoField
+                },
+                operator: OperatorName.Is,
+                value: {
+                  type: ConditionType.Value,
+                  value: 'true',
+                  display: 'Yes'
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
   })
 
@@ -53,7 +78,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: true
+        selectList: true,
+        selectCondition: true
       }
     ],
     [
@@ -64,7 +90,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: true
+        selectList: true,
+        selectCondition: true
       }
     ],
     [
@@ -75,7 +102,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ],
     [
@@ -85,8 +113,10 @@ describe('ComponentTypeEdit', () => {
         hint: false,
         title: true,
         hideTitle: false,
+        content: true,
         optional: false,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ],
     [
@@ -97,7 +127,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ],
     [
@@ -107,8 +138,10 @@ describe('ComponentTypeEdit', () => {
         hint: false,
         title: false,
         hideTitle: false,
+        content: true,
         optional: false,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ],
     [
@@ -118,8 +151,10 @@ describe('ComponentTypeEdit', () => {
         hint: false,
         title: false,
         hideTitle: false,
+        content: true,
         optional: false,
-        selectList: false
+        selectList: false,
+        selectCondition: false
       }
     ],
     [
@@ -130,7 +165,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: false,
-        selectList: true
+        selectList: true,
+        selectCondition: false
       }
     ],
     [
@@ -141,7 +177,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: false
       }
     ],
     [
@@ -152,7 +189,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ],
     [
@@ -163,7 +201,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ],
     [
@@ -174,7 +213,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: true
+        selectList: true,
+        selectCondition: true
       }
     ],
     [
@@ -185,7 +225,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: true
+        selectList: true,
+        selectCondition: true
       }
     ],
     [
@@ -196,7 +237,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ],
     [
@@ -207,7 +249,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ],
     [
@@ -218,7 +261,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: true,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: false
       }
     ],
     [
@@ -229,7 +273,8 @@ describe('ComponentTypeEdit', () => {
         title: true,
         hideTitle: false,
         optional: true,
-        selectList: false
+        selectList: false,
+        selectCondition: true
       }
     ]
   ])('Component type edit: %s', (type, options) => {
@@ -418,6 +463,31 @@ describe('ComponentTypeEdit', () => {
       it("should not render 'Select list' options", () => {
         const $select = screen.queryByRole('combobox', {
           name: 'Select list'
+        })
+
+        expect($select).not.toBeInTheDocument()
+      })
+    }
+
+    if (options.selectCondition) {
+      it("should render 'Condition (optional)' options", () => {
+        const $select = screen.queryByRole<HTMLSelectElement>('combobox', {
+          name: 'Condition (optional)',
+          description:
+            'Select a condition that determines whether to show the contents of this component. You can create and edit conditions from the Conditions screen.'
+        })
+
+        expect($select).toBeInTheDocument()
+        expect($select?.value).toBe(
+          selectedComponent && 'list' in selectedComponent
+            ? selectedComponent.list
+            : ''
+        )
+      })
+    } else {
+      it("should not render 'Condition (optional)' options", () => {
+        const $select = screen.queryByRole('combobox', {
+          name: 'Condition (optional)'
         })
 
         expect($select).not.toBeInTheDocument()

--- a/designer/client/src/ComponentTypeEdit.tsx
+++ b/designer/client/src/ComponentTypeEdit.tsx
@@ -8,6 +8,7 @@ import React, {
 
 import { FieldEdit } from '~/src/FieldEdit.jsx'
 import { MultilineTextFieldEdit } from '~/src/MultilineTextFieldEdit.jsx'
+import { ConditionEdit } from '~/src/components/FieldEditors/ConditionEdit.jsx'
 import { DateFieldEdit } from '~/src/components/FieldEditors/DateFieldEdit.jsx'
 import { DetailsEdit } from '~/src/components/FieldEditors/DetailsEdit.jsx'
 import { ListFieldEdit } from '~/src/components/FieldEditors/ListFieldEdit.jsx'
@@ -61,6 +62,7 @@ export const ComponentTypeEdit: FunctionComponent<Props> = (props) => {
   return (
     <>
       <FieldEdit />
+      <ConditionEdit />
       <CustomEdit>{children}</CustomEdit>
     </>
   )

--- a/designer/client/src/ComponentTypeEdit.tsx
+++ b/designer/client/src/ComponentTypeEdit.tsx
@@ -1,5 +1,10 @@
-import { ComponentType, hasEditor } from '@defra/forms-model'
-import React, { useContext, type FunctionComponent } from 'react'
+import { ComponentType } from '@defra/forms-model'
+import React, {
+  useContext,
+  type FunctionComponent,
+  type JSXElementConstructor,
+  type ReactNode
+} from 'react'
 
 import { FieldEdit } from '~/src/FieldEdit.jsx'
 import { MultilineTextFieldEdit } from '~/src/MultilineTextFieldEdit.jsx'
@@ -27,7 +32,15 @@ const componentTypeEditors = {
   [ComponentType.Html]: ParaEdit,
   [ComponentType.InsetText]: ParaEdit,
   [ComponentType.DatePartsField]: DateFieldEdit
-}
+} as Partial<
+  Record<
+    ComponentType,
+    JSXElementConstructor<{
+      children?: ReactNode
+      context?: typeof ComponentContext
+    }>
+  >
+>
 
 export interface Props {
   context?: typeof ComponentContext
@@ -42,14 +55,13 @@ export const ComponentTypeEdit: FunctionComponent<Props> = (props) => {
     return null
   }
 
-  const FieldEditCustom = hasEditor(selectedComponent)
-    ? componentTypeEditors[selectedComponent.type]
-    : () => null
+  const CustomEdit =
+    componentTypeEditors[selectedComponent.type] ?? (() => null)
 
   return (
     <>
       <FieldEdit />
-      <FieldEditCustom>{children}</FieldEditCustom>
+      <CustomEdit>{children}</CustomEdit>
     </>
   )
 }

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -21,9 +21,13 @@ export function FieldEdit() {
     return null
   }
 
-  const { name, title, options } = selectedComponent
+  const { hint, name, title, type, options } = selectedComponent
   const defaults = getComponentDefaults(selectedComponent)
   const isRequired = !('required' in options) || options.required !== false
+
+  // Limit options by component type
+  const hasOptionRequired = type !== ComponentType.List
+  const hasOptionHideTitle = type === ComponentType.UkAddressField
 
   return (
     <div data-test-id="standard-inputs">
@@ -37,7 +41,7 @@ export function FieldEdit() {
         hint={{
           children: [i18n('common.titleField.helpText')]
         }}
-        value={title ?? defaults?.title}
+        value={title}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
           dispatch({
             type: Fields.EDIT_TITLE,
@@ -58,7 +62,7 @@ export function FieldEdit() {
           children: [i18n('common.helpTextField.helpText')]
         }}
         required={false}
-        value={'hint' in selectedComponent ? selectedComponent.hint : undefined}
+        value={hint}
         onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
           dispatch({
             type: Fields.EDIT_HELP,
@@ -66,7 +70,7 @@ export function FieldEdit() {
           })
         }}
       />
-      {[ComponentType.UkAddressField].includes(selectedComponent.type) && (
+      {hasOptionHideTitle && (
         <div className="govuk-checkboxes govuk-form-group">
           <div className="govuk-checkboxes__item">
             <input
@@ -135,7 +139,7 @@ export function FieldEdit() {
           }}
         />
       </div>
-      {selectedComponent.type !== ComponentType.List && (
+      {hasOptionRequired && (
         <div className="govuk-checkboxes govuk-form-group">
           <div className="govuk-checkboxes__item">
             <input

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.enzyme.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.enzyme.test.tsx
@@ -62,7 +62,6 @@ describe('ComponentCreateList', () => {
       .map((c) => c.find('a').text())
 
     expect(listItems).toEqual([
-      'Autocomplete',
       'Date',
       'Email address',
       'Month & year',
@@ -94,10 +93,9 @@ describe('ComponentCreateList', () => {
     expect(onSelectComponent.mock.calls[0]).toEqual(
       expect.arrayContaining([
         {
-          name: 'AutocompleteField',
-          title: 'Autocomplete field',
-          list: '',
-          type: ComponentType.AutocompleteField,
+          name: 'DatePartsField',
+          title: 'Date field',
+          type: ComponentType.DatePartsField,
           options: {},
           schema: {},
           hint: ''
@@ -116,7 +114,13 @@ describe('ComponentCreateList', () => {
       .find('li')
       .map((c) => c.find('a').text())
 
-    expect(listItems).toEqual(['Checkboxes', 'Radios', 'Select', 'YesNo'])
+    expect(listItems).toEqual([
+      'Autocomplete',
+      'Checkboxes',
+      'Radios',
+      'Select',
+      'YesNo'
+    ])
   })
 
   test('it selects Selection fields on click', () => {
@@ -139,10 +143,10 @@ describe('ComponentCreateList', () => {
     expect(onSelectComponent.mock.calls[0]).toEqual(
       expect.arrayContaining([
         {
-          name: 'CheckboxesField',
-          title: 'Checkboxes field',
+          name: 'AutocompleteField',
+          title: 'Autocomplete field',
           list: '',
-          type: ComponentType.CheckboxesField,
+          type: ComponentType.AutocompleteField,
           options: {},
           schema: {},
           hint: ''

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -1,18 +1,16 @@
 import {
-  ComponentType,
   ComponentTypes,
-  hasContentField,
+  hasContent,
   hasSelectionFields,
   type ComponentDef,
   type ContentComponentsDef,
-  type ListComponent,
   type SelectionComponentsDef
 } from '@defra/forms-model'
 import React, { type MouseEvent, useCallback } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 
-const contentFields: (ContentComponentsDef | ListComponent)[] = []
+const contentFields: ContentComponentsDef[] = []
 const selectionFields: SelectionComponentsDef[] = []
 const inputFields: ComponentDef[] = []
 
@@ -21,8 +19,7 @@ const ComponentTypesSorted = ComponentTypes.sort(
 )
 
 for (const component of ComponentTypesSorted) {
-  // Ensure the list component is grouped with other content fields
-  if (hasContentField(component) || component.type === ComponentType.List) {
+  if (hasContent(component)) {
     contentFields.push(component)
   } else if (hasSelectionFields(component)) {
     selectionFields.push(component)

--- a/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
+++ b/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
@@ -127,23 +127,6 @@ exports[`ComponentCreateList should match snapshot 1`] = `
                 class="govuk-link"
                 href="#0"
               >
-                Autocomplete
-              </a>
-            </p>
-            <div
-              class="govuk-hint govuk-!-margin-top-2"
-            >
-              Sets a list of values to suggest to users as they complete this field
-            </div>
-          </li>
-          <li>
-            <p
-              class="govuk-body govuk-!-margin-bottom-2"
-            >
-              <a
-                class="govuk-link"
-                href="#0"
-              >
                 Date
               </a>
             </p>
@@ -293,6 +276,23 @@ exports[`ComponentCreateList should match snapshot 1`] = `
         <ol
           class="govuk-list"
         >
+          <li>
+            <p
+              class="govuk-body govuk-!-margin-bottom-2"
+            >
+              <a
+                class="govuk-link"
+                href="#0"
+              >
+                Autocomplete
+              </a>
+            </p>
+            <div
+              class="govuk-hint govuk-!-margin-top-2"
+            >
+              Sets a list of values to suggest to users as they complete this field
+            </div>
+          </li>
           <li>
             <p
               class="govuk-body govuk-!-margin-bottom-2"

--- a/designer/client/src/components/FieldEditors/ConditionEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ConditionEdit.tsx
@@ -1,0 +1,60 @@
+import { hasConditionSupport } from '@defra/forms-model'
+import React, { useContext } from 'react'
+
+import { DataContext } from '~/src/context/DataContext.js'
+import { i18n } from '~/src/i18n/i18n.jsx'
+import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
+import { Options } from '~/src/reducers/component/types.js'
+
+interface Props {
+  context?: typeof ComponentContext
+}
+
+export function ConditionEdit({ context = ComponentContext }: Props) {
+  const { data } = useContext(DataContext)
+  const { state, dispatch } = useContext(context)
+
+  const { conditions } = data
+  const { selectedComponent } = state
+
+  if (
+    !conditions.length ||
+    !selectedComponent ||
+    !hasConditionSupport(selectedComponent)
+  ) {
+    return null
+  }
+
+  const { options } = selectedComponent
+
+  return (
+    <div className="govuk-form-group">
+      <label className="govuk-label govuk-label--s" htmlFor="condition">
+        Condition (optional)
+      </label>
+      <div className="govuk-hint" id="condition-hint">
+        {i18n('fieldEdit.conditions.hint')}
+      </div>
+      <select
+        className="govuk-select"
+        id="condition"
+        aria-describedby="condition-hint"
+        name="options.condition"
+        value={options.condition}
+        onChange={(e) =>
+          dispatch({
+            type: Options.EDIT_OPTIONS_CONDITION,
+            payload: e.target.value
+          })
+        }
+      >
+        <option value="" />
+        {conditions.map((condition) => (
+          <option key={condition.name} value={condition.name}>
+            {condition.displayName}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/designer/client/src/components/FieldEditors/ParaEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ParaEdit.tsx
@@ -1,12 +1,12 @@
+import { hasContentField } from '@defra/forms-model'
 import classNames from 'classnames'
 import React, { useContext } from 'react'
 
 import { Editor } from '~/src/Editor.jsx'
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
-import { DataContext } from '~/src/context/DataContext.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
-import { Fields, Options } from '~/src/reducers/component/types.js'
+import { Fields } from '~/src/reducers/component/types.js'
 
 interface Props {
   context?: typeof ComponentContext
@@ -15,86 +15,46 @@ interface Props {
 export function ParaEdit({ context = ComponentContext }: Props) {
   // If you are editing a component, the default context will be ComponentContext because props.context is undefined,
   // but if you editing a component which is a children of a list based component, then the props.context is the ListContext.
-  const { data } = useContext(DataContext)
   const { state, dispatch } = useContext(context)
 
-  const { conditions } = data
   const { selectedComponent, errors = {} } = state
 
-  if (!selectedComponent) {
+  if (!selectedComponent || !hasContentField(selectedComponent)) {
     return null
   }
 
-  const { options } = selectedComponent
-
   return (
-    <>
-      <div
-        className={classNames({
-          'govuk-form-group': true,
-          'govuk-form-group--error': errors.content
-        })}
-      >
-        <label className="govuk-label govuk-label--s" htmlFor="field-content">
-          Content
-        </label>
-        <div className="govuk-hint" id="field-content-error">
-          {i18n('fieldEdit.para.hint')}
-        </div>
-        {errors.content && (
-          <ErrorMessage id="field-content-error">
-            {errors.content.children}
-          </ErrorMessage>
-        )}
-        <Editor
-          id="field-content"
-          aria-describedby={
-            'field-content-hint' + (errors.name ? 'field-content-error' : '')
-          }
-          name="content"
-          value={
-            'content' in selectedComponent
-              ? selectedComponent.content
-              : undefined
-          }
-          onValueChange={(content) => {
-            dispatch({
-              type: Fields.EDIT_CONTENT,
-              payload: content
-            })
-          }}
-        />
+    <div
+      className={classNames({
+        'govuk-form-group': true,
+        'govuk-form-group--error': errors.content
+      })}
+    >
+      <label className="govuk-label govuk-label--s" htmlFor="field-content">
+        Content
+      </label>
+      <div className="govuk-hint" id="field-content-error">
+        {i18n('fieldEdit.para.hint')}
       </div>
-      {!conditions.length || (
-        <div className="govuk-form-group">
-          <label className="govuk-label govuk-label--s" htmlFor="condition">
-            Condition (optional)
-          </label>
-          <div className="govuk-hint" id="condition-hint">
-            {i18n('fieldEdit.conditions.hint')}{' '}
-          </div>
-          <select
-            className="govuk-select"
-            id="condition"
-            aria-describedby="condition-hint"
-            name="options.condition"
-            value={'condition' in options ? options.condition : undefined}
-            onChange={(e) =>
-              dispatch({
-                type: Options.EDIT_OPTIONS_CONDITION,
-                payload: e.target.value
-              })
-            }
-          >
-            <option value="" />
-            {conditions.map((condition) => (
-              <option key={condition.name} value={condition.name}>
-                {condition.displayName}
-              </option>
-            ))}
-          </select>
-        </div>
+      {errors.content && (
+        <ErrorMessage id="field-content-error">
+          {errors.content.children}
+        </ErrorMessage>
       )}
-    </>
+      <Editor
+        id="field-content"
+        aria-describedby={
+          'field-content-hint' + (errors.name ? 'field-content-error' : '')
+        }
+        name="content"
+        value={selectedComponent.content}
+        onValueChange={(content) => {
+          dispatch({
+            type: Fields.EDIT_CONTENT,
+            payload: content
+          })
+        }}
+      />
+    </div>
   )
 }

--- a/designer/client/src/data/component/inputs.ts
+++ b/designer/client/src/data/component/inputs.ts
@@ -1,4 +1,8 @@
-import { hasConditionSupport, type FormDefinition } from '@defra/forms-model'
+import {
+  hasConditionSupport,
+  hasContent,
+  type FormDefinition
+} from '@defra/forms-model'
 
 import { allPathsLeadingTo } from '~/src/data/page/allPathsLeadingTo.js'
 import { type Input, type Path } from '~/src/data/types.js'
@@ -7,9 +11,9 @@ export function allInputs(data: FormDefinition): Input[] {
   const { pages = [] } = data
 
   return pages.flatMap((page) => {
-    const inputs = (page.components ?? []).filter((component) =>
-      hasConditionSupport(component)
-    )
+    const inputs = (page.components ?? [])
+      .filter(hasConditionSupport)
+      .filter((component) => !hasContent(component))
 
     return inputs.map((input) => {
       return {

--- a/model/src/components/helpers.test.ts
+++ b/model/src/components/helpers.test.ts
@@ -1,9 +1,9 @@
 import { ComponentType, type ComponentDef } from '@defra/forms-model'
 
-import { hasContentField } from '~/src/components/helpers.js'
+import { hasContent, hasContentField } from '~/src/components/helpers.js'
 
 describe('Type guards', () => {
-  describe('hasContentField', () => {
+  describe('hasContent', () => {
     it.each([
       {
         name: 'field',
@@ -27,20 +27,12 @@ describe('Type guards', () => {
         list: 'items',
         options: {},
         schema: {}
-      } satisfies ComponentDef,
-      {
-        name: 'field',
-        title: 'Items',
-        type: ComponentType.List,
-        list: 'items',
-        options: {},
-        schema: {}
       } satisfies ComponentDef
-    ])('should allow non-content types', (component) => {
+    ])('should prevent non-content types', (component) => {
       const { type } = component
 
-      expect({ hasContentField: false, type }).toEqual({
-        hasContentField: hasContentField(component),
+      expect({ hasContent: false, type }).toEqual({
+        hasContent: hasContent(component),
         type
       })
     })
@@ -69,11 +61,73 @@ describe('Type guards', () => {
         content: 'It can take up to 8 weeks to register a lasting power of…',
         options: {},
         schema: {}
+      } satisfies ComponentDef,
+      {
+        name: 'field',
+        title: 'Items',
+        type: ComponentType.List,
+        list: 'items',
+        options: {},
+        schema: {}
       } satisfies ComponentDef
-    ])('should prevent content types', (component) => {
+    ])('should allow content types', (component) => {
+      const { type } = component
+
+      expect({ hasContent: true, type }).toEqual({
+        hasContent: hasContent(component),
+        type
+      })
+    })
+  })
+
+  describe('hasContentField', () => {
+    it.each([
+      {
+        name: 'content',
+        title: 'Help with nationality',
+        type: ComponentType.Details,
+        content: 'We need to know your nationality so we can work out…',
+        options: {},
+        schema: {}
+      } satisfies ComponentDef,
+      {
+        name: 'content',
+        title: 'HTML',
+        type: ComponentType.Html,
+        content: '<p class="govuk-body">Some content</p>',
+        options: {},
+        schema: {}
+      } satisfies ComponentDef,
+      {
+        name: 'content',
+        title: '',
+        type: ComponentType.InsetText,
+        content: 'It can take up to 8 weeks to register a lasting power of…',
+        options: {},
+        schema: {}
+      } satisfies ComponentDef
+    ])('should allow content types with textarea field', (component) => {
       const { type } = component
 
       expect({ hasContentField: true, type }).toEqual({
+        hasContentField: hasContentField(component),
+        type
+      })
+    })
+
+    it.each([
+      {
+        name: 'field',
+        title: 'Items',
+        type: ComponentType.List,
+        list: 'items',
+        options: {},
+        schema: {}
+      } satisfies ComponentDef
+    ])('should prevent content types with list', (component) => {
+      const { type } = component
+
+      expect({ hasContentField: false, type }).toEqual({
         hasContentField: hasContentField(component),
         type
       })

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -47,7 +47,9 @@ export function isConditionalType(
     ComponentType.NumberField,
     ComponentType.SelectField,
     ComponentType.TextField,
-    ComponentType.YesNoField
+    ComponentType.YesNoField,
+    ComponentType.Html,
+    ComponentType.Details
   ]
 
   return !!type && allowedTypes.includes(type)

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -36,11 +36,13 @@ export function isConditionalType(
   type?: ComponentType
 ): type is ConditionalComponentType {
   const allowedTypes = [
+    ComponentType.AutocompleteField,
     ComponentType.RadiosField,
     ComponentType.CheckboxesField,
     ComponentType.DatePartsField,
     ComponentType.EmailAddressField,
     ComponentType.MultilineTextField,
+    ComponentType.TelephoneNumberField,
     ComponentType.NumberField,
     ComponentType.SelectField,
     ComponentType.TextField,

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -5,11 +5,12 @@ import {
   type ConditionalComponentsDef,
   type ConditionalComponentType,
   type ContentComponentsDef,
+  type EditorComponentsDef,
   type HtmlComponent,
   type InsetTextComponent,
+  type ListComponent,
   type ListComponentsDef,
-  type SelectionComponentsDef,
-  type EditorComponentsDef
+  type SelectionComponentsDef
 } from '~/src/components/types.js'
 
 /**
@@ -53,18 +54,35 @@ export function isConditionalType(
 }
 
 /**
- * Filter known components with content fields
+ * Filter known components with content (textarea or list)
+ */
+export function hasContent(
+  component?: Partial<ComponentDef>
+): component is ContentComponentsDef {
+  return isContentType(component?.type)
+}
+
+/**
+ * Filter known components with content textarea
  */
 export function hasContentField(
   component?: Partial<ComponentDef>
-): component is ContentComponentsDef {
+): component is Exclude<ContentComponentsDef, ListComponent> {
+  const deniedTypes = [ComponentType.List]
+  return hasContent(component) && !deniedTypes.includes(component.type)
+}
+
+export function isContentType(
+  type?: ComponentType
+): type is ContentComponentsDef['type'] {
   const allowedTypes = [
     ComponentType.Details,
     ComponentType.Html,
-    ComponentType.InsetText
+    ComponentType.InsetText,
+    ComponentType.List
   ]
 
-  return !!component?.type && allowedTypes.includes(component.type)
+  return !!type && allowedTypes.includes(type)
 }
 
 /**

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -5,7 +5,6 @@ import {
   type ConditionalComponentsDef,
   type ConditionalComponentType,
   type ContentComponentsDef,
-  type EditorComponentsDef,
   type HtmlComponent,
   type InsetTextComponent,
   type ListComponent,
@@ -85,32 +84,6 @@ export function isContentType(
   ]
 
   return !!type && allowedTypes.includes(type)
-}
-
-/**
- * Filter known components with text editor or list select
- */
-export function hasEditor(
-  component?: Partial<ComponentDef>
-): component is EditorComponentsDef {
-  const allowedTypes = [
-    ComponentType.TextField,
-    ComponentType.EmailAddressField,
-    ComponentType.TelephoneNumberField,
-    ComponentType.MultilineTextField,
-    ComponentType.NumberField,
-    ComponentType.AutocompleteField,
-    ComponentType.SelectField,
-    ComponentType.RadiosField,
-    ComponentType.CheckboxesField,
-    ComponentType.List,
-    ComponentType.Details,
-    ComponentType.Html,
-    ComponentType.InsetText,
-    ComponentType.DatePartsField
-  ]
-
-  return !!component?.type && allowedTypes.includes(component.type)
 }
 
 /**

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -141,6 +141,7 @@ export function hasSelectionFields(
   component?: Partial<ComponentDef>
 ): component is SelectionComponentsDef {
   const allowedTypes = [
+    ComponentType.AutocompleteField,
     ComponentType.CheckboxesField,
     ComponentType.RadiosField,
     ComponentType.SelectField,

--- a/model/src/components/index.ts
+++ b/model/src/components/index.ts
@@ -2,6 +2,7 @@ export { ComponentTypes } from '~/src/components/component-types.js'
 export {
   getComponentDefaults,
   hasConditionSupport,
+  hasContent,
   hasContentField,
   hasEditor,
   hasListField,

--- a/model/src/components/index.ts
+++ b/model/src/components/index.ts
@@ -4,7 +4,6 @@ export {
   hasConditionSupport,
   hasContent,
   hasContentField,
-  hasEditor,
   hasListField,
   hasSelectionFields,
   hasTitle,

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -1,15 +1,6 @@
 import { type ComponentType } from '~/src/components/enums.js'
 
-export type ConditionalComponentType =
-  | ComponentType.RadiosField
-  | ComponentType.CheckboxesField
-  | ComponentType.DatePartsField
-  | ComponentType.EmailAddressField
-  | ComponentType.MultilineTextField
-  | ComponentType.NumberField
-  | ComponentType.SelectField
-  | ComponentType.TextField
-  | ComponentType.YesNoField
+export type ConditionalComponentType = ConditionalComponentsDef['type']
 
 /**
  * Types for Components JSON structure which are expected by engine and turned into actual form input/content/lists
@@ -135,6 +126,7 @@ export interface NumberFieldComponent extends NumberFieldBase {
 export interface TelephoneNumberFieldComponent extends TextFieldBase {
   type: ComponentType.TelephoneNumberField
   options: TextFieldBase['options'] & {
+    condition?: string
     customValidationMessage?: string
   }
 }
@@ -204,6 +196,9 @@ export interface ListComponent extends ListFieldBase {
 
 export interface AutocompleteFieldComponent extends ListFieldBase {
   type: ComponentType.AutocompleteField
+  options: ListFieldBase['options'] & {
+    condition?: string
+  }
 }
 
 export interface CheckboxesFieldComponent extends ListFieldBase {
@@ -229,23 +224,10 @@ export interface SelectFieldComponent extends ListFieldBase {
 }
 
 export type ComponentDef =
-  | InsetTextComponent
-  | AutocompleteFieldComponent
-  | CheckboxesFieldComponent
-  | DatePartsFieldFieldComponent
-  | MonthYearFieldComponent
-  | DetailsComponent
-  | EmailAddressFieldComponent
-  | HtmlComponent
+  | InputFieldsComponentsDef
+  | SelectionComponentsDef
+  | ContentComponentsDef
   | ListComponent
-  | MultilineTextFieldComponent
-  | NumberFieldComponent
-  | RadiosFieldComponent
-  | SelectFieldComponent
-  | TelephoneNumberFieldComponent
-  | TextFieldComponent
-  | UkAddressFieldComponent
-  | YesNoFieldComponent
 
 // Components that render inputs
 export type InputFieldsComponentsDef =
@@ -254,7 +236,6 @@ export type InputFieldsComponentsDef =
   | NumberFieldComponent
   | MultilineTextFieldComponent
   | TelephoneNumberFieldComponent
-  | YesNoFieldComponent
   | MonthYearFieldComponent
   | DatePartsFieldFieldComponent
   | UkAddressFieldComponent
@@ -284,11 +265,8 @@ export type EditorComponentsDef =
 
 // Components that render lists
 export type ListComponentsDef =
+  | Exclude<SelectionComponentsDef, YesNoFieldComponent>
   | ListComponent
-  | AutocompleteFieldComponent
-  | CheckboxesFieldComponent
-  | RadiosFieldComponent
-  | SelectFieldComponent
 
 // Components that have selection fields
 export type SelectionComponentsDef =
@@ -298,11 +276,7 @@ export type SelectionComponentsDef =
   | YesNoFieldComponent
 
 // Components that have custom condition operators
-export type ConditionalComponentsDef =
-  | CheckboxesFieldComponent
-  | DatePartsFieldFieldComponent
-  | EmailAddressFieldComponent
-  | MultilineTextFieldComponent
-  | NumberFieldComponent
-  | TextFieldComponent
-  | YesNoFieldComponent
+export type ConditionalComponentsDef = Exclude<
+  InputFieldsComponentsDef | SelectionComponentsDef,
+  MonthYearFieldComponent | UkAddressFieldComponent
+>

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -1,6 +1,9 @@
 import { type ComponentType } from '~/src/components/enums.js'
 
-export type ConditionalComponentType = ConditionalComponentsDef['type']
+export type ConditionalComponentType = Exclude<
+  ConditionalComponentsDef['type'],
+  ContentComponentsDef
+>
 
 /**
  * Types for Components JSON structure which are expected by engine and turned into actual form input/content/lists
@@ -276,8 +279,11 @@ export type SelectionComponentsDef =
   | SelectFieldComponent
   | YesNoFieldComponent
 
-// Components that have custom condition operators
+// Components that have condition support
 export type ConditionalComponentsDef = Exclude<
-  InputFieldsComponentsDef | SelectionComponentsDef,
-  MonthYearFieldComponent | UkAddressFieldComponent
+  ComponentDef,
+  | InsetTextComponent
+  | ListComponent
+  | MonthYearFieldComponent
+  | UkAddressFieldComponent
 >

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -270,6 +270,7 @@ export type ListComponentsDef =
 
 // Components that have selection fields
 export type SelectionComponentsDef =
+  | AutocompleteFieldComponent
   | CheckboxesFieldComponent
   | RadiosFieldComponent
   | SelectFieldComponent

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -249,23 +249,6 @@ export type ContentComponentsDef =
   | InsetTextComponent
   | ListComponent
 
-// Components with editors
-export type EditorComponentsDef =
-  | TextFieldComponent
-  | EmailAddressFieldComponent
-  | TelephoneNumberFieldComponent
-  | MultilineTextFieldComponent
-  | NumberFieldComponent
-  | AutocompleteFieldComponent
-  | SelectFieldComponent
-  | RadiosFieldComponent
-  | CheckboxesFieldComponent
-  | ListComponent
-  | DetailsComponent
-  | HtmlComponent
-  | InsetTextComponent
-  | DatePartsFieldFieldComponent
-
 // Components that render lists
 export type ListComponentsDef =
   | Exclude<SelectionComponentsDef, YesNoFieldComponent>

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -227,7 +227,6 @@ export type ComponentDef =
   | InputFieldsComponentsDef
   | SelectionComponentsDef
   | ContentComponentsDef
-  | ListComponent
 
 // Components that render inputs
 export type InputFieldsComponentsDef =
@@ -245,6 +244,7 @@ export type ContentComponentsDef =
   | DetailsComponent
   | HtmlComponent
   | InsetTextComponent
+  | ListComponent
 
 // Components with editors
 export type EditorComponentsDef =

--- a/model/src/conditions/condition-field.ts
+++ b/model/src/conditions/condition-field.ts
@@ -1,5 +1,5 @@
 import { type ComponentType } from '~/src/components/enums.js'
-import { isConditionalType } from '~/src/components/helpers.js'
+import { isConditionalType, isContentType } from '~/src/components/helpers.js'
 import { type ConditionalComponentType } from '~/src/components/types.js'
 import { type ConditionFieldData } from '~/src/conditions/types.js'
 
@@ -13,7 +13,7 @@ export class ConditionField {
       throw new Error("ConditionField param 'name' must be a string")
     }
 
-    if (!isConditionalType(type)) {
+    if (!isConditionalType(type) || isContentType(type)) {
       throw new Error("ConditionField param 'type' must support conditions")
     }
 

--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -1,6 +1,9 @@
 import { ComponentType } from '~/src/components/enums.js'
 import { isConditionalType } from '~/src/components/helpers.js'
-import { type ComponentDef } from '~/src/components/types.js'
+import {
+  type ComponentDef,
+  type ConditionalComponentType
+} from '~/src/components/types.js'
 import {
   ConditionValue,
   RelativeDateValue
@@ -53,6 +56,7 @@ const relativeDateOperators = {
 }
 
 export const customOperators = {
+  [ComponentType.AutocompleteField]: defaultOperators,
   [ComponentType.RadiosField]: defaultOperators,
   [ComponentType.CheckboxesField]: {
     [OperatorName.Contains]: reverseInline(Operator.Contains),
@@ -71,6 +75,7 @@ export const customOperators = {
   [ComponentType.TextField]: withDefaults(textFieldOperators),
   [ComponentType.MultilineTextField]: withDefaults(textFieldOperators),
   [ComponentType.EmailAddressField]: withDefaults(textFieldOperators),
+  [ComponentType.TelephoneNumberField]: defaultOperators,
   [ComponentType.SelectField]: defaultOperators,
   [ComponentType.YesNoField]: defaultOperators
 }

--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -75,7 +75,7 @@ export const customOperators = {
   [ComponentType.YesNoField]: defaultOperators
 }
 
-export function getOperatorNames(fieldType?: ComponentType) {
+export function getOperatorNames(fieldType?: ConditionalComponentType) {
   const conditionals = getConditionals(fieldType)
   if (!conditionals) {
     return []
@@ -85,7 +85,7 @@ export function getOperatorNames(fieldType?: ComponentType) {
 }
 
 export function getExpression(
-  fieldType: ComponentType,
+  fieldType: ConditionalComponentType,
   fieldName: string,
   operator: OperatorName,
   value: Condition['value']
@@ -102,14 +102,14 @@ export function getExpression(
 }
 
 export function getOperatorConfig(
-  fieldType: ComponentType,
+  fieldType: ConditionalComponentType,
   operator: OperatorName
 ) {
   return getConditionals(fieldType)?.[operator]
 }
 
 function getConditionals(
-  fieldType?: ComponentType
+  fieldType?: ConditionalComponentType
 ): Partial<Conditionals> | undefined {
   if (!fieldType || !isConditionalType(fieldType)) {
     return

--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -106,13 +106,6 @@ export function getExpression(
   )
 }
 
-export function getOperatorConfig(
-  fieldType: ConditionalComponentType,
-  operator: OperatorName
-) {
-  return getConditionals(fieldType)?.[operator]
-}
-
 function getConditionals(
   fieldType?: ConditionalComponentType
 ): Partial<Conditionals> | undefined {

--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -1,5 +1,5 @@
 import { ComponentType } from '~/src/components/enums.js'
-import { isConditionalType } from '~/src/components/helpers.js'
+import { isConditionalType, isContentType } from '~/src/components/helpers.js'
 import {
   type ComponentDef,
   type ConditionalComponentType
@@ -116,7 +116,7 @@ export function getOperatorConfig(
 function getConditionals(
   fieldType?: ConditionalComponentType
 ): Partial<Conditionals> | undefined {
-  if (!fieldType || !isConditionalType(fieldType)) {
+  if (!fieldType || !isConditionalType(fieldType) || isContentType(fieldType)) {
     return
   }
 


### PR DESCRIPTION
This PR resolves a couple of issues split out from https://github.com/DEFRA/forms-designer/pull/377

1. Conditions could not be selected when editing form components
2. Conditions could not be configured for autocomplete + telephone components

Fixes [bug #424825](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/424825)

<img width="669" alt="Component conditions" src="https://github.com/user-attachments/assets/568a6120-e679-4e70-aa33-ebcfbdfc7f46">


All components now support conditions except for:

* Inset text component
* List component
* Month year component
* UK address component

I've also updated the types for `InputFieldsComponentsDef` and `SelectionComponentsDef` so we can type all known components with the `hint` property in forms runner by excluding content components:

```js
hint?: Exclude<ComponentDef, ContentComponentsDef>['hint']
```

Thanks to https://github.com/DEFRA/forms-designer/pull/378 we can also remove helpers like `hasEditor()`