### PR TITLE
Fix “List component” missing list formatting options

### DIFF
--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -167,7 +167,7 @@ describe('ComponentTypeEdit', () => {
         name: false,
         hint: true,
         title: true,
-        hideTitle: false,
+        hideTitle: true,
         content: false,
         optional: false,
         selectList: true,

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -164,7 +164,7 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.List,
       {
-        name: true,
+        name: false,
         hint: true,
         title: true,
         hideTitle: false,

--- a/designer/client/src/ComponentTypeEdit.tsx
+++ b/designer/client/src/ComponentTypeEdit.tsx
@@ -11,6 +11,7 @@ import { MultilineTextFieldEdit } from '~/src/MultilineTextFieldEdit.jsx'
 import { ConditionEdit } from '~/src/components/FieldEditors/ConditionEdit.jsx'
 import { ContentEdit } from '~/src/components/FieldEditors/ContentEdit.jsx'
 import { DateFieldEdit } from '~/src/components/FieldEditors/DateFieldEdit.jsx'
+import { ListContentEdit } from '~/src/components/FieldEditors/ListContentEdit.jsx'
 import { ListFieldEdit } from '~/src/components/FieldEditors/ListFieldEdit.jsx'
 import { NumberFieldEdit } from '~/src/components/FieldEditors/NumberFieldEdit.jsx'
 import { SelectFieldEdit } from '~/src/components/FieldEditors/SelectFieldEdit.jsx'
@@ -24,6 +25,7 @@ const componentTypeEditors = {
   [ComponentType.MultilineTextField]: MultilineTextFieldEdit,
   [ComponentType.NumberField]: NumberFieldEdit,
   [ComponentType.SelectField]: SelectFieldEdit,
+  [ComponentType.List]: ListContentEdit,
   [ComponentType.DatePartsField]: DateFieldEdit
 } as Partial<
   Record<

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -71,7 +71,7 @@ describe('Field Edit', () => {
     const $selects = screen.queryAllByRole('combobox')
 
     expect($inputs).toHaveLength(2)
-    expect($checkboxes).toHaveLength(0)
+    expect($checkboxes).toHaveLength(1)
     expect($selects).toHaveLength(0)
   })
 

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -70,7 +70,7 @@ describe('Field Edit', () => {
     const $checkboxes = screen.queryAllByRole('checkbox')
     const $selects = screen.queryAllByRole('combobox')
 
-    expect($inputs).toHaveLength(3)
+    expect($inputs).toHaveLength(2)
     expect($checkboxes).toHaveLength(0)
     expect($selects).toHaveLength(0)
   })

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -31,7 +31,7 @@ export function FieldEdit() {
 
   // Limit options by component type
   const hasFieldTitle = hasTitle(selectedComponent)
-  const hasFieldName = hasInput || type === ComponentType.List
+  const hasFieldName = hasInput
   const hasFieldHint = hasInput || type === ComponentType.List
   const hasOptionRequired = hasInput
   const hasOptionHideTitle = type === ComponentType.UkAddressField

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -34,7 +34,8 @@ export function FieldEdit() {
   const hasFieldName = hasInput
   const hasFieldHint = hasInput || type === ComponentType.List
   const hasOptionRequired = hasInput
-  const hasOptionHideTitle = type === ComponentType.UkAddressField
+  const hasOptionHideTitle =
+    type === ComponentType.List || type === ComponentType.UkAddressField
 
   return (
     <>

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -120,26 +120,26 @@ export function ComponentListSelect() {
             )
           })}
         </select>
-      </div>
-      <p className="govuk-body">
-        {selectedListTitle && (
+        <p className="govuk-body govuk-!-margin-top-2">
+          {selectedListTitle && (
+            <a
+              className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
+              onClick={handleEditListClick}
+              href="#"
+            >
+              {i18n('list.edit', { title: selectedListTitle })}
+            </a>
+          )}
           <a
             className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
-            onClick={handleEditListClick}
+            data-testid="add-list"
+            onClick={handleAddListClick}
             href="#"
           >
-            {i18n('list.edit', { title: selectedListTitle })}
+            {i18n('list.addNew')}
           </a>
-        )}
-        <a
-          className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
-          data-testid="add-list"
-          onClick={handleAddListClick}
-          href="#"
-        >
-          {i18n('list.addNew')}
-        </a>
-      </p>
+        </p>
+      </div>
     </>
   )
 }

--- a/designer/client/src/components/FieldEditors/ListContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.tsx
@@ -1,6 +1,7 @@
 import { hasListField } from '@defra/forms-model'
 import React, { useContext } from 'react'
 
+import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
 import { Options } from '~/src/reducers/component/types.js'
@@ -53,6 +54,8 @@ export function ListContentEdit({ context = ComponentContext }: Props) {
             </label>
           </div>
         </div>
+
+        <CssClasses />
       </div>
     </details>
   )

--- a/designer/client/src/components/FieldEditors/ListContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.tsx
@@ -1,4 +1,5 @@
 import { hasListField } from '@defra/forms-model'
+import upperFirst from 'lodash/upperFirst.js'
 import React, { useContext } from 'react'
 
 import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
@@ -19,7 +20,6 @@ export function ListContentEdit({ context = ComponentContext }: Props) {
   }
 
   const { options } = selectedComponent
-  const checked = options.type === 'numbered'
 
   return (
     <details className="govuk-details">
@@ -30,29 +30,46 @@ export function ListContentEdit({ context = ComponentContext }: Props) {
       </summary>
 
       <div className="govuk-details__text">
-        <div className="govuk-checkboxes govuk-form-group">
-          <div className="govuk-checkboxes__item">
-            <input
-              className="govuk-checkboxes__input"
-              id="field-options-type"
-              name="options.type"
-              value="numbered"
-              type="checkbox"
-              checked={checked}
-              onChange={() =>
-                dispatch({
-                  type: Options.EDIT_OPTIONS_TYPE,
-                  payload: checked ? undefined : 'numbered'
-                })
-              }
-            />
-            <label
-              className="govuk-label govuk-checkboxes__label"
-              htmlFor="field-options-type"
-            >
-              Numbered
-            </label>
-          </div>
+        <div className="govuk-form-group">
+          <fieldset className="govuk-fieldset">
+            <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
+              {i18n('listContentEditComponent.bulletField.title')}
+            </legend>
+            <div className="govuk-radios" data-module="govuk-radios">
+              {['bulleted', 'numbered'].map((bullet) => {
+                const name = 'cond-value-units'
+                const id = `${name}-${bullet}`
+
+                return (
+                  <div className="govuk-radios__item" key={bullet}>
+                    <input
+                      className="govuk-radios__input"
+                      id={id}
+                      name={name}
+                      type="radio"
+                      defaultValue={bullet}
+                      defaultChecked={
+                        options.type === bullet ||
+                        (!options.type && bullet === 'bulleted')
+                      }
+                      onClick={() => {
+                        dispatch({
+                          type: Options.EDIT_OPTIONS_TYPE,
+                          payload: bullet
+                        })
+                      }}
+                    />
+                    <label
+                      className="govuk-label govuk-radios__label"
+                      htmlFor={id}
+                    >
+                      {upperFirst(bullet)}
+                    </label>
+                  </div>
+                )
+              })}
+            </div>
+          </fieldset>
         </div>
 
         <CssClasses />

--- a/designer/client/src/components/FieldEditors/ListContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.tsx
@@ -1,5 +1,7 @@
+import { hasListField } from '@defra/forms-model'
 import React, { useContext } from 'react'
 
+import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
 import { Options } from '~/src/reducers/component/types.js'
 
@@ -11,37 +13,47 @@ export function ListContentEdit({ context = ComponentContext }: Props) {
   const { state, dispatch } = useContext(context)
   const { selectedComponent } = state
 
-  if (!selectedComponent) {
+  if (!selectedComponent || !hasListField(selectedComponent)) {
     return null
   }
 
   const { options } = selectedComponent
-  const checked = 'type' in options && options.type === 'numbered'
+  const checked = options.type === 'numbered'
 
   return (
-    <div className="govuk-checkboxes govuk-form-group">
-      <div className="govuk-checkboxes__item">
-        <input
-          className="govuk-checkboxes__input"
-          id="field-options-type"
-          name="options.type"
-          value="numbered"
-          type="checkbox"
-          checked={checked}
-          onChange={() =>
-            dispatch({
-              type: Options.EDIT_OPTIONS_TYPE,
-              payload: checked ? undefined : 'numbered'
-            })
-          }
-        />
-        <label
-          className="govuk-label govuk-checkboxes__label"
-          htmlFor="field-options-type"
-        >
-          Numbered
-        </label>
+    <details className="govuk-details">
+      <summary className="govuk-details__summary">
+        <span className="govuk-details__summary-text">
+          {i18n('common.detailsLink.title')}
+        </span>
+      </summary>
+
+      <div className="govuk-details__text">
+        <div className="govuk-checkboxes govuk-form-group">
+          <div className="govuk-checkboxes__item">
+            <input
+              className="govuk-checkboxes__input"
+              id="field-options-type"
+              name="options.type"
+              value="numbered"
+              type="checkbox"
+              checked={checked}
+              onChange={() =>
+                dispatch({
+                  type: Options.EDIT_OPTIONS_TYPE,
+                  payload: checked ? undefined : 'numbered'
+                })
+              }
+            />
+            <label
+              className="govuk-label govuk-checkboxes__label"
+              htmlFor="field-options-type"
+            >
+              Numbered
+            </label>
+          </div>
+        </div>
       </div>
-    </div>
+    </details>
   )
 }

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -222,6 +222,11 @@
     "title": "List title",
     "titleHint": "Enter a unique name for your list"
   },
+  "listContentEditComponent": {
+    "bulletField": {
+      "title": "List format"
+    }
+  },
   "menu": {
     "addPage": "Add page",
     "conditions": "Conditions",

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -195,6 +195,9 @@ export interface InsetTextComponent extends ContentFieldBase {
 // List Fields
 export interface ListComponent extends ListFieldBase {
   type: ComponentType.List
+  options: ListFieldBase['options'] & {
+    hideTitle?: boolean
+  }
 }
 
 export interface AutocompleteFieldComponent extends ListFieldBase {


### PR DESCRIPTION
This PR adds a few extra **List** component fixes whilst testing the condition UI

1. Add option to hide list title
2. Remove unused "Name" field
3. Restore bullet formatting option that wasn't wired up

Fixes [bug #424830](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/424830)

<img width="657" alt="List in form runner" src="https://github.com/user-attachments/assets/213634e6-712a-4a55-acde-67042d670f60">

## Editor
Unlike other content components (**Details**, **HTML**, **Inset text**) we show unnecessary fields for **List**

<img width="806" alt="List component, before" src="https://github.com/user-attachments/assets/bd470a90-6d78-4b2c-bc22-a7de239085cc">

### Formatting options
We also have formatting options in **ListContentEdit.tsx** but it's not wired up (is now)

<img width="805" alt="Formatting options, after" src="https://github.com/user-attachments/assets/308c0864-b24d-4cee-bb0f-4bffc326d2bb">