### PR TITLE
Fix condition label overflow

### DIFF
--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -85,7 +85,7 @@ export class Lines extends Component<Props, State> {
                     width={textWidth}
                     height={textHeight}
                     style={{
-                      overflow: 'auto',
+                      overflow: 'visible',
                       pointerEvents: 'none',
                       textAlign: 'center'
                     }}


### PR DESCRIPTION
Minor fix to allow condition labels to expand beyond the line they're on

Previous change only worked in Safari, now Chrome and Firefox are working

Closes [bug #409869](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/409869)