### PR TITLE
Fix missing service navigation menu

### DIFF
--- a/designer/client/test/fixtures/assets-manifest.json
+++ b/designer/client/test/fixtures/assets-manifest.json
@@ -1,0 +1,4 @@
+{
+  "example.mjs": "javascripts/example.xxxxxxx.min.js",
+  "example.scss": "stylesheets/example.xxxxxxx.min.css"
+}

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -20,9 +20,9 @@ export async function getUserSession(request, session) {
 
   // Fall back to OpenID Connect (OIDC) claim
   if (!sessionId && hasAuthenticated(auth?.credentials)) {
-    const { token } = getUserClaims(auth.credentials)
+    const claims = getUserClaims(auth.credentials)
 
-    sessionId = token.sub
+    sessionId = claims.token.sub
   }
 
   // Retrieve user session from Redis

--- a/designer/server/src/common/helpers/auth/get-user-session.js
+++ b/designer/server/src/common/helpers/auth/get-user-session.js
@@ -4,31 +4,30 @@ import { isPast, parseISO, subMinutes } from 'date-fns'
 import { groupsToScopes } from '~/src/common/constants/scopes.js'
 
 /**
- * @param {Request | Request<{ AuthArtifactsExtra: AuthArtifacts }>} request
+ * @param {Partial<Request> | Request<{ AuthArtifactsExtra: AuthArtifacts }>} request
  * @param {{ sessionId: string, user: UserCredentials }} [session] - Session cookie state
  */
 export async function getUserSession(request, session) {
   const { auth, server } = request
-  const { credentials } = auth
 
   // Check for existing user
-  if (hasUser(credentials)) {
-    return credentials
+  if (hasUser(auth?.credentials)) {
+    return auth.credentials
   }
 
   // Prefer Session ID from cookie state
   let sessionId = session?.sessionId
 
   // Fall back to OpenID Connect (OIDC) claim
-  if (!sessionId && hasAuthenticated(credentials)) {
-    const { token } = getUserClaims(credentials)
+  if (!sessionId && hasAuthenticated(auth?.credentials)) {
+    const { token } = getUserClaims(auth.credentials)
 
     sessionId = token.sub
   }
 
   // Retrieve user session from Redis
   if (sessionId) {
-    return server.methods.session.get(sessionId)
+    return server?.methods.session.get(sessionId)
   }
 }
 

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -13,7 +13,7 @@ const { phase, serviceName } = config
 let webpackManifest
 
 /**
- * @param {Request | null} request
+ * @param {Partial<Request> | null} request
  */
 export async function context(request) {
   const manifestPath = join(config.clientDir, 'assets-manifest.json')
@@ -38,7 +38,7 @@ export async function context(request) {
     navigation: buildNavigation(request),
     getAssetPath: (asset = '') => `/${webpackManifest?.[asset] ?? asset}`,
     assetPath: '/assets',
-    isAuthenticated: request?.auth.isAuthenticated ?? false,
+    isAuthenticated: request?.auth?.isAuthenticated ?? false,
     authedUser: credentials?.user
   }
 }

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -39,6 +39,7 @@ export async function context(request) {
     getAssetPath: (asset = '') => `/${webpackManifest?.[asset] ?? asset}`,
     assetPath: '/assets',
     isAuthenticated: request?.auth?.isAuthenticated ?? false,
+    isAuthorized: request?.auth?.isAuthorized ?? false,
     authedUser: credentials?.user
   }
 }

--- a/designer/server/src/common/nunjucks/context/index.test.js
+++ b/designer/server/src/common/nunjucks/context/index.test.js
@@ -1,0 +1,109 @@
+import { context } from '~/src/common/nunjucks/context/index.js'
+import config from '~/src/config.js'
+import {
+  requestAuth,
+  requestAuthScopesEmpty,
+  requestSignedOut
+} from '~/test/fixtures/request.js'
+
+describe('Nunjucks context', () => {
+  describe('Asset path', () => {
+    it("should include 'assetPath' for GOV.UK Frontend icons", async () => {
+      const { assetPath } = await context(null)
+      expect(assetPath).toBe('/assets')
+    })
+  })
+
+  describe('Asset helper', () => {
+    it("should locate 'assets-manifest.json' assets", async () => {
+      const { getAssetPath } = await context(null)
+
+      expect(getAssetPath('example.scss')).toBe(
+        '/stylesheets/example.xxxxxxx.min.css'
+      )
+
+      expect(getAssetPath('example.mjs')).toBe(
+        '/javascripts/example.xxxxxxx.min.js'
+      )
+    })
+
+    it('should return path to unknown assets', async () => {
+      const { getAssetPath } = await context(null)
+
+      expect(getAssetPath('example.jpg')).toBe('/example.jpg')
+      expect(getAssetPath('example.gif')).toBe('/example.gif')
+    })
+  })
+
+  describe('Authentication', () => {
+    it.each([
+      {
+        example: 'signed in (authorized)',
+        request: requestAuth,
+        expected: {
+          isAuthenticated: true,
+          isAuthorized: true
+        }
+      },
+      {
+        example: 'signed in (authenticated)',
+        request: requestAuthScopesEmpty,
+        expected: {
+          isAuthenticated: true,
+          isAuthorized: false
+        }
+      },
+      {
+        example: 'signed out',
+        request: requestSignedOut,
+        expected: {
+          isAuthenticated: false,
+          isAuthorized: false
+        }
+      }
+    ])(
+      'should include user context when $example',
+      async ({ request, expected }) => {
+        const { authedUser, isAuthenticated, isAuthorized } =
+          await context(request)
+
+        expect(authedUser).toEqual(request.auth?.credentials.user)
+        expect(isAuthenticated).toBe(expected.isAuthenticated)
+        expect(isAuthorized).toBe(expected.isAuthorized)
+      }
+    )
+  })
+
+  describe('Config', () => {
+    it('should include phase and service name', async () => {
+      const ctx = await context(null)
+
+      expect(ctx.config).toEqual({
+        phase: config.phase,
+        serviceName: config.serviceName
+      })
+    })
+  })
+
+  describe('Navigation', () => {
+    it('should include navigation array', async () => {
+      const { navigation } = await context(null)
+
+      expect(navigation).toHaveLength(1)
+      expect(navigation[0]).toMatchObject({
+        text: 'Forms library'
+      })
+    })
+
+    it('should include breadcrumbs array', async () => {
+      const { breadcrumbs } = await context(null)
+
+      expect(breadcrumbs).toHaveLength(0)
+      expect(breadcrumbs).toEqual([])
+    })
+  })
+})
+
+/**
+ * @import { Request } from '@hapi/hapi'
+ */

--- a/designer/server/src/common/templates/partials/navigation.test.js
+++ b/designer/server/src/common/templates/partials/navigation.test.js
@@ -1,0 +1,142 @@
+import upperFirst from 'lodash/upperFirst.js'
+
+import { renderView } from '~/test/helpers/component-helpers.js'
+
+describe('Navigation partial', () => {
+  describe('Service header', () => {
+    const selectorHeader = '.one-login-header'
+
+    it('should render by default', () => {
+      const { document } = renderView('partials/navigation.njk')
+      const $header = document.querySelector(selectorHeader)
+
+      expect($header).toBeInTheDocument()
+    })
+
+    it('should render account name when authenticated', () => {
+      const { document } = renderView('partials/navigation.njk', {
+        context: {
+          authedUser: { displayName: 'John Smith' },
+          isAuthenticated: true,
+          isAuthorized: false
+        }
+      })
+
+      const $header = document.querySelector(selectorHeader)
+      const $navLinks = $header?.querySelectorAll(
+        `${selectorHeader}__nav__link`
+      )
+
+      expect($navLinks).toHaveLength(2)
+      expect($navLinks?.[0]).toContainHTML('John Smith')
+      expect($navLinks?.[1]).toContainHTML('Sign out')
+    })
+
+    it('should not render account name by default', () => {
+      const { document } = renderView('partials/navigation.njk')
+
+      const $header = document.querySelector(selectorHeader)
+      const $navLinks = $header?.querySelectorAll(
+        `${selectorHeader}__nav__link`
+      )
+
+      expect($navLinks).toHaveLength(1)
+      expect($navLinks?.[0]).toContainHTML('Sign in')
+    })
+  })
+
+  describe('Service navigation', () => {
+    const selectorNavigation = `.service-header`
+
+    it('should render menu when signed in (authorized)', () => {
+      const { document } = renderView('partials/navigation.njk', {
+        context: {
+          navigation: [],
+          isAuthenticated: true,
+          isAuthorized: true
+        }
+      })
+
+      const $navigation = document.querySelector(selectorNavigation)
+      expect($navigation).toBeInTheDocument()
+    })
+
+    it.each([
+      {
+        example: 'signed in (unauthorized)',
+        context: {
+          navigation: [],
+          isAuthenticated: true,
+          isAuthorized: false
+        }
+      },
+      {
+        example: 'signed out',
+        context: {
+          navigation: [],
+          isAuthenticated: false,
+          isAuthorized: false
+        }
+      }
+    ])('should not render menu when $example', ({ context }) => {
+      const { document } = renderView('partials/navigation.njk', { context })
+
+      const $navigation = document.querySelector(selectorNavigation)
+      expect($navigation).not.toBeInTheDocument()
+    })
+
+    it('should not render menu by default', () => {
+      const { document } = renderView('partials/navigation.njk')
+      const $navigation = document.querySelector(selectorNavigation)
+
+      expect($navigation).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Phase banner', () => {
+    const selectorPhaseBanner = '.govuk-phase-banner'
+    const selectorTag = '.govuk-tag'
+
+    it.each([
+      {
+        context: {
+          config: { phase: 'alpha' }
+        }
+      },
+      {
+        context: {
+          config: { phase: 'beta' }
+        }
+      }
+    ])(
+      "should render for '$context.config.phase' phase (via config)",
+      ({ context }) => {
+        const { document } = renderView('partials/navigation.njk', { context })
+
+        const $phaseBanner = document.querySelector(selectorPhaseBanner)
+        const $phaseTag = $phaseBanner?.querySelector(selectorTag)
+
+        expect($phaseBanner).toBeInTheDocument()
+        expect($phaseTag).toContainHTML(upperFirst(context.config.phase))
+      }
+    )
+
+    it("should not render for 'live' phase (via config)", () => {
+      const { document } = renderView('partials/navigation.njk', {
+        context: {
+          config: { phase: 'live' }
+        }
+      })
+
+      const $phaseBanner = document.querySelector(selectorPhaseBanner)
+      expect($phaseBanner).not.toBeInTheDocument()
+    })
+
+    it('should not render by default', () => {
+      const { document } = renderView('partials/navigation.njk')
+
+      const $phaseBanner = document.querySelector(selectorPhaseBanner)
+      expect($phaseBanner).not.toBeInTheDocument()
+    })
+  })
+})

--- a/designer/server/src/config.ts
+++ b/designer/server/src/config.ts
@@ -42,7 +42,13 @@ const schema = joi.object<Config>({
   appDir: joi.string().default(dirname(configPath)),
   clientDir: joi
     .string()
-    .default(resolve(dirname(configPath), '../../client/dist')),
+    .default(resolve(dirname(configPath), '../../client/dist'))
+    .when('env', {
+      is: 'test',
+      then: joi
+        .string()
+        .default(resolve(dirname(configPath), '../../client/test/fixtures'))
+    }),
   managerUrl: joi.string().required(),
   previewUrl: joi.string().required(),
   serviceName: joi.string().required(),

--- a/designer/server/test/fixtures/auth.js
+++ b/designer/server/test/fixtures/auth.js
@@ -115,7 +115,7 @@ export const authGroupsInvalid = {
 }
 
 /**
- * Request auth without without scopes for Hapi `server.inject()`
+ * Request auth without scopes for Hapi `server.inject()`
  * @satisfies {ServerInjectOptions['auth']}
  */
 export const authScopesEmpty = {

--- a/designer/server/test/fixtures/request.js
+++ b/designer/server/test/fixtures/request.js
@@ -1,0 +1,62 @@
+import {
+  auth,
+  authGroupsInvalid,
+  authScopesEmpty
+} from '~/test/fixtures/auth.js'
+
+// Request auth types require an error property
+const error = new Error('Example authentication error')
+
+/**
+ * Request when signed in
+ * @satisfies {Partial<Request>}
+ */
+export const requestAuth = {
+  auth: {
+    ...auth,
+    error,
+    mode: 'try',
+    isAuthenticated: true,
+    isAuthorized: true
+  }
+}
+
+/**
+ * Request when signed in with invalid groups
+ * @satisfies {Partial<Request>}
+ */
+export const requestAuthGroupsInvalid = {
+  auth: {
+    ...authGroupsInvalid,
+    error,
+    mode: 'try',
+    isAuthenticated: true,
+    isAuthorized: false
+  }
+}
+
+/**
+ * Request when signed in without scopes
+ * @satisfies {Partial<Request>}
+ */
+export const requestAuthScopesEmpty = {
+  auth: {
+    ...authScopesEmpty,
+    error,
+    mode: 'try',
+    isAuthenticated: true,
+    isAuthorized: false
+  }
+}
+
+/**
+ * Request when signed out
+ * @satisfies {Partial<Request>}
+ */
+export const requestSignedOut = {
+  auth: undefined
+}
+
+/**
+ * @import { Request } from '@hapi/hapi'
+ */


### PR DESCRIPTION
This PR adds `isAuthorized` to the Nunjucks context to show the navigation menu again

See related changes in PR [#385](https://github.com/DEFRA/forms-designer/pull/385/files#diff-150daf490ebb63b71484a1baef5a2dbe3b1b4f5bf5d5a2bc70e56594ec0dfd46R7)

Lots of test coverage added too

<img width="597" alt="Navigation menu" src="https://github.com/user-attachments/assets/1442a449-f381-4299-af1b-26d817ac9653">