### PR TITLE
Fix differences between page create/edit components

### DIFF
--- a/designer/client/src/LinkCreate.test.tsx
+++ b/designer/client/src/LinkCreate.test.tsx
@@ -55,7 +55,7 @@ describe('LinkCreate', () => {
 
     render(
       <RenderWithContext data={data}>
-        <LinkCreate />
+        <LinkCreate onSave={jest.fn} />
       </RenderWithContext>
     )
 
@@ -68,7 +68,7 @@ describe('LinkCreate', () => {
 
     render(
       <RenderWithContext data={data}>
-        <LinkCreate />
+        <LinkCreate onSave={jest.fn} />
       </RenderWithContext>
     )
 
@@ -81,7 +81,7 @@ describe('LinkCreate', () => {
   test('Renders from and to inputs with the correct options', () => {
     render(
       <RenderWithContext data={data}>
-        <LinkCreate />
+        <LinkCreate onSave={jest.fn} />
       </RenderWithContext>
     )
 
@@ -97,7 +97,7 @@ describe('LinkCreate', () => {
   test('Selecting a from value causes the SelectConditions component to be displayed', async () => {
     render(
       <RenderWithContext data={data}>
-        <LinkCreate />
+        <LinkCreate onSave={jest.fn} />
       </RenderWithContext>
     )
 
@@ -167,7 +167,7 @@ describe('LinkCreate', () => {
 
     render(
       <RenderWithContext data={updated} save={save}>
-        <LinkCreate />
+        <LinkCreate onSave={jest.fn} />
       </RenderWithContext>
     )
 
@@ -250,7 +250,7 @@ describe('LinkCreate', () => {
 
     render(
       <RenderWithContext data={data} save={save}>
-        <LinkCreate />
+        <LinkCreate onSave={jest.fn} />
       </RenderWithContext>
     )
 

--- a/designer/client/src/LinkCreate.tsx
+++ b/designer/client/src/LinkCreate.tsx
@@ -16,7 +16,7 @@ import { i18n } from '~/src/i18n/i18n.jsx'
 import { hasValidationErrors } from '~/src/validations.js'
 
 interface Props {
-  onCreate?: () => void
+  onSave: () => void
 }
 
 interface State {
@@ -35,7 +35,7 @@ export class LinkCreate extends Component<Props, State> {
   onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
-    const { onCreate } = this.props
+    const { onSave } = this.props
     const { data, save } = this.context
     const { from, to, selectedCondition } = this.state
 
@@ -47,7 +47,7 @@ export class LinkCreate extends Component<Props, State> {
     const definition = addLink(data, from, to, selectedCondition)
 
     await save(definition)
-    onCreate?.()
+    onSave()
   }
 
   conditionSelected = (selectedCondition: string) => {

--- a/designer/client/src/LinkEdit.test.tsx
+++ b/designer/client/src/LinkEdit.test.tsx
@@ -86,7 +86,7 @@ describe('LinkEdit', () => {
   test('Submitting with a condition updates the link', async () => {
     render(
       <RenderWithContext data={data}>
-        <LinkCreate />
+        <LinkCreate onSave={jest.fn} />
       </RenderWithContext>
     )
 

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -17,7 +17,7 @@ import { i18n } from '~/src/i18n/i18n.jsx'
 
 interface Props {
   edge: Edge
-  onEdit: () => void
+  onSave: () => void
 }
 
 interface State {
@@ -55,7 +55,7 @@ export class LinkEdit extends Component<Props, State> {
   onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
-    const { onEdit } = this.props
+    const { onSave } = this.props
     const { link, page, selectedCondition } = this.state
     const { data, save } = this.context
 
@@ -63,7 +63,7 @@ export class LinkEdit extends Component<Props, State> {
 
     try {
       await save(definition)
-      onEdit()
+      onSave()
     } catch (error) {
       logger.error(error, 'LinkEdit')
     }
@@ -76,7 +76,7 @@ export class LinkEdit extends Component<Props, State> {
       return
     }
 
-    const { onEdit } = this.props
+    const { onSave } = this.props
     const { link, page } = this.state
     const { data, save } = this.context
 
@@ -84,7 +84,7 @@ export class LinkEdit extends Component<Props, State> {
 
     try {
       await save(definition)
-      onEdit()
+      onSave()
     } catch (error) {
       logger.error(error, 'LinkEdit')
     }

--- a/designer/client/src/PageCreate.test.tsx
+++ b/designer/client/src/PageCreate.test.tsx
@@ -19,7 +19,7 @@ describe('page create fields text', () => {
   test('displays field titles and help texts', () => {
     render(
       <RenderWithContext data={data}>
-        <PageCreate />
+        <PageCreate onCreate={jest.fn()} />
       </RenderWithContext>
     )
 

--- a/designer/client/src/PageCreate.test.tsx
+++ b/designer/client/src/PageCreate.test.tsx
@@ -19,7 +19,7 @@ describe('page create fields text', () => {
   test('displays field titles and help texts', () => {
     render(
       <RenderWithContext data={data}>
-        <PageCreate onCreate={jest.fn()} />
+        <PageCreate onSave={jest.fn()} />
       </RenderWithContext>
     )
 

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -1,4 +1,4 @@
-import { slugify } from '@defra/forms-model'
+import { slugify, type Page, type Section } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
@@ -22,11 +22,27 @@ import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
 
-export class PageCreate extends Component {
+interface Props {
+  onCreate: () => void
+}
+
+interface State {
+  path: string
+  controller?: string
+  title: string
+  section?: Section
+  linkFrom?: string
+  selectedCondition?: string
+  isEditingSection: boolean
+  isNewSection: boolean
+  errors: Partial<ErrorList<'path' | 'title'>>
+}
+
+export class PageCreate extends Component<Props, State> {
   declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
-  constructor(props, context) {
+  constructor(props: Props, context: typeof DataContext) {
     super(props, context)
 
     this.state = {
@@ -52,7 +68,7 @@ export class PageCreate extends Component {
     const validationErrors = this.validate(titleTrim, pathTrim)
     if (hasValidationErrors(validationErrors)) return
 
-    const value = {
+    const value: Page = {
       path: pathTrim,
       title: titleTrim,
       components: [],
@@ -78,7 +94,7 @@ export class PageCreate extends Component {
     }
   }
 
-  validate = (title, path): ErrorList => {
+  validate = (title: string, path: string) => {
     const { data } = this.context
 
     const titleErrors = validateTitle(
@@ -148,7 +164,7 @@ export class PageCreate extends Component {
     })
   }
 
-  conditionSelected = (selectedCondition) => {
+  conditionSelected = (selectedCondition?: string) => {
     this.setState({
       selectedCondition
     })

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -29,12 +29,9 @@ export class PageCreate extends Component {
   constructor(props, context) {
     super(props, context)
 
-    const { page } = this.props
-
     this.state = {
       path: '/',
-      controller: page?.controller ?? '',
-      title: page?.title,
+      title: '',
       isEditingSection: false,
       isNewSection: false,
       errors: {}

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -37,6 +37,7 @@ export class PageCreate extends Component {
       controller: page?.controller ?? '',
       title: page?.title,
       isEditingSection: false,
+      isNewSection: false,
       errors: {}
     }
   }
@@ -170,11 +171,12 @@ export class PageCreate extends Component {
     })
   }
 
-  editSection = (e: MouseEvent<HTMLAnchorElement>) => {
+  editSection = (e: MouseEvent<HTMLAnchorElement>, isNewSection = false) => {
     e.preventDefault()
 
     this.setState({
-      isEditingSection: true
+      isEditingSection: true,
+      isNewSection
     })
   }
 
@@ -184,6 +186,7 @@ export class PageCreate extends Component {
 
     this.setState({
       isEditingSection: false,
+      isNewSection: false,
       section: findSection(data, sectionName ?? section?.name)
     })
   }
@@ -198,6 +201,7 @@ export class PageCreate extends Component {
       section,
       path,
       isEditingSection,
+      isNewSection,
       errors
     } = this.state
 
@@ -340,7 +344,7 @@ export class PageCreate extends Component {
                 className="govuk-link govuk-!-display-block"
                 onClick={this.editSection}
               >
-                Edit section
+                {i18n('section.edit')}
               </a>
             )}
             <a
@@ -348,13 +352,13 @@ export class PageCreate extends Component {
               className="govuk-link govuk-!-display-block"
               onClick={this.editSection}
             >
-              Create section
+              {i18n('section.create')}
             </a>
           </p>
 
           <div className="govuk-button-group">
             <button type="submit" className="govuk-button">
-              Save
+              {i18n('save')}
             </button>
           </div>
         </form>
@@ -362,11 +366,16 @@ export class PageCreate extends Component {
           <RenderInPortal>
             <Flyout
               title={
-                section?.name ? `Editing ${section.name}` : 'Add a new section'
+                !isNewSection && !!section
+                  ? i18n('section.editingTitle', { title: section.title })
+                  : i18n('section.newTitle')
               }
               onHide={this.closeFlyout}
             >
-              <SectionEdit section={section} onEdit={this.closeFlyout} />
+              <SectionEdit
+                section={!isNewSection ? section : undefined}
+                onEdit={this.closeFlyout}
+              />
             </Flyout>
           </RenderInPortal>
         )}

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -73,7 +73,7 @@ export class PageCreate extends Component {
     }
     try {
       await save(copy)
-      this.props.onCreate({ value })
+      this.props.onCreate()
     } catch (error) {
       logger.error(error, 'PageCreate')
     }

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -68,20 +68,16 @@ export class PageCreate extends Component<Props, State> {
     const validationErrors = this.validate(titleTrim, pathTrim)
     if (hasValidationErrors(validationErrors)) return
 
-    const value: Page = {
+    const newPage: Page = {
       path: pathTrim,
       title: titleTrim,
+      controller,
       components: [],
+      section: section?.name,
       next: []
     }
-    if (section) {
-      value.section = section.name
-    }
-    if (controller) {
-      value.controller = controller
-    }
 
-    let copy = addPage({ ...data }, value)
+    let copy = addPage({ ...data }, newPage)
 
     if (linkFrom) {
       copy = addLink(copy, linkFrom, pathTrim, selectedCondition)

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -19,7 +19,6 @@ import { addPage } from '~/src/data/page/addPage.js'
 import { findSection } from '~/src/data/section/findSection.js'
 import { toUrl } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
-import randomId from '~/src/randomId.js'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
 
@@ -111,18 +110,6 @@ export class PageCreate extends Component {
     return errors
   }
 
-  generatePath(title, data) {
-    let path = toUrl(title)
-    if (
-      title.length > 0 &&
-      data.pages.find((page) => page.path.startsWith(path))
-    ) {
-      path = `${path}-${randomId()}`
-    }
-
-    return path
-  }
-
   onChangeSection = (e: ChangeEvent<HTMLSelectElement>) => {
     const { value: sectionName } = e.target
     const { data } = this.context
@@ -147,21 +134,17 @@ export class PageCreate extends Component {
   }
 
   onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
-    const { data } = this.context
-    const input = e.target
-    const title = input.value
-    this.setState({
-      title,
-      path: this.generatePath(title, data)
-    })
+    const { value: title } = e.target
+
+    this.onChangePath(e)
+    this.setState({ title })
   }
 
   onChangePath = (e: ChangeEvent<HTMLInputElement>) => {
-    const input = e.target
-    const path = input.value.startsWith('/') ? input.value : `/${input.value}`
-    const sanitisedPath = path.replace(/\s/g, '-')
+    const { value: path } = e.target
+
     this.setState({
-      path: sanitisedPath
+      path: toUrl(path)
     })
   }
 

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -1,3 +1,4 @@
+import { slugify } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
@@ -17,7 +18,6 @@ import { DataContext } from '~/src/context/DataContext.js'
 import { addLink } from '~/src/data/page/addLink.js'
 import { addPage } from '~/src/data/page/addPage.js'
 import { findSection } from '~/src/data/section/findSection.js'
-import { toUrl } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
@@ -144,7 +144,7 @@ export class PageCreate extends Component {
     const { value: path } = e.target
 
     this.setState({
-      path: toUrl(path)
+      path: `/${slugify(path)}`
     })
   }
 

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -97,8 +97,12 @@ export class PageCreate extends Component {
       ...titleErrors
     }
 
-    const alreadyExists = data.pages.find((page) => page.path === path)
-    if (alreadyExists) {
+    // Check for duplicate path
+    function isDuplicate(input: string) {
+      return data.pages.some((p) => p.path === input)
+    }
+
+    if (isDuplicate(path)) {
       errors.path = {
         href: '#page-path',
         children: `Path '${path}' already exists`

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -42,25 +42,24 @@ export class PageCreate extends Component {
     e.preventDefault()
 
     const { data, save } = this.context
+    const { path, controller, title, section, linkFrom, selectedCondition } =
+      this.state
 
-    const title = this.state.title?.trim()
-    const linkFrom = this.state.linkFrom?.trim()
-    const section = this.state.section?.name?.trim()
-    const controller = this.state.controller?.trim()
-    const selectedCondition = this.state.selectedCondition?.trim()
-    const path = this.state.path
+    // Remove trailing spaces and hyphens
+    const pathTrim = `/${slugify(path)}`
+    const titleTrim = title.trim()
 
-    const validationErrors = this.validate(title, path)
+    const validationErrors = this.validate(titleTrim, pathTrim)
     if (hasValidationErrors(validationErrors)) return
 
     const value = {
-      path,
-      title,
+      path: pathTrim,
+      title: titleTrim,
       components: [],
       next: []
     }
     if (section) {
-      value.section = section
+      value.section = section.name
     }
     if (controller) {
       value.controller = controller
@@ -69,7 +68,7 @@ export class PageCreate extends Component {
     let copy = addPage({ ...data }, value)
 
     if (linkFrom) {
-      copy = addLink(copy, linkFrom, path, selectedCondition)
+      copy = addLink(copy, linkFrom, pathTrim, selectedCondition)
     }
     try {
       await save(copy)
@@ -145,7 +144,7 @@ export class PageCreate extends Component {
     const { value: path } = e.target
 
     this.setState({
-      path: `/${slugify(path)}`
+      path: `/${slugify(path, { trim: false })}`
     })
   }
 

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -16,6 +16,7 @@ import { SelectConditions } from '~/src/conditions/SelectConditions.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { addLink } from '~/src/data/page/addLink.js'
 import { addPage } from '~/src/data/page/addPage.js'
+import { findSection } from '~/src/data/section/findSection.js'
 import { toUrl } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import randomId from '~/src/randomId.js'
@@ -35,7 +36,6 @@ export class PageCreate extends Component {
       path: '/',
       controller: page?.controller ?? '',
       title: page?.title,
-      section: page?.section ?? {},
       isEditingSection: false,
       errors: {}
     }
@@ -122,15 +122,12 @@ export class PageCreate extends Component {
     return path
   }
 
-  findSectionWithName(name) {
-    const { data } = this.context
-    const { sections } = data
-    return sections.find((section) => section.name === name)
-  }
-
   onChangeSection = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value: sectionName } = e.target
+    const { data } = this.context
+
     this.setState({
-      section: this.findSectionWithName(e.target.value)
+      section: findSection(data, sectionName)
     })
   }
 
@@ -173,19 +170,21 @@ export class PageCreate extends Component {
     })
   }
 
-  editSection = (e: MouseEvent<HTMLAnchorElement>, section) => {
+  editSection = (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
+
     this.setState({
-      section,
       isEditingSection: true
     })
   }
 
-  closeFlyout = (sectionName) => {
-    const propSection = this.state.section ?? {}
+  closeFlyout = (sectionName?: string) => {
+    const { section } = this.state
+    const { data } = this.context
+
     this.setState({
       isEditingSection: false,
-      section: sectionName ? this.findSectionWithName(sectionName) : propSection
+      section: findSection(data, sectionName ?? section?.name)
     })
   }
 
@@ -321,7 +320,7 @@ export class PageCreate extends Component {
                 id="page-section"
                 aria-describedby="page-section-hint"
                 name="section"
-                value={section?.name}
+                value={section?.name ?? ''}
                 onChange={this.onChangeSection}
               >
                 <option value="" />
@@ -335,7 +334,7 @@ export class PageCreate extends Component {
           )}
 
           <p className="govuk-body">
-            {section?.name && (
+            {section && (
               <a
                 href="#"
                 className="govuk-link govuk-!-display-block"

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -23,7 +23,7 @@ import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
 
 interface Props {
-  onCreate: () => void
+  onSave: () => void
 }
 
 interface State {
@@ -57,6 +57,7 @@ export class PageCreate extends Component<Props, State> {
   onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
+    const { onSave } = this.props
     const { data, save } = this.context
     const { path, controller, title, section, linkFrom, selectedCondition } =
       this.state
@@ -82,9 +83,10 @@ export class PageCreate extends Component<Props, State> {
     if (linkFrom) {
       copy = addLink(copy, linkFrom, pathTrim, selectedCondition)
     }
+
     try {
       await save(copy)
-      this.props.onCreate()
+      onSave()
     } catch (error) {
       logger.error(error, 'PageCreate')
     }
@@ -132,16 +134,18 @@ export class PageCreate extends Component<Props, State> {
   }
 
   onChangeLinkFrom = (e: ChangeEvent<HTMLSelectElement>) => {
-    const input = e.target
+    const { value: linkFrom } = e.target
+
     this.setState({
-      linkFrom: input.value
+      linkFrom
     })
   }
 
   onChangeController = (e: ChangeEvent<HTMLSelectElement>) => {
-    const input = e.target
+    const { value: controller } = e.target
+
     this.setState({
-      controller: input.value
+      controller
     })
   }
 
@@ -246,7 +250,7 @@ export class PageCreate extends Component<Props, State> {
               id="link-from"
               aria-describedby="link-from-hint"
               name="from"
-              value={linkFrom}
+              value={linkFrom ?? ''}
               onChange={this.onChangeLinkFrom}
             >
               <option value="" />
@@ -258,7 +262,7 @@ export class PageCreate extends Component<Props, State> {
             </select>
           </div>
 
-          {linkFrom && linkFrom.trim() !== '' && (
+          {linkFrom && (
             <SelectConditions
               path={linkFrom}
               conditionsChange={this.conditionSelected}
@@ -273,7 +277,7 @@ export class PageCreate extends Component<Props, State> {
               className: 'govuk-label--s',
               children: [i18n('addPage.pageTitleField.title')]
             }}
-            value={title || ''}
+            value={title}
             onChange={this.onChangeTitle}
             errorMessage={errors.title}
           />
@@ -303,6 +307,7 @@ export class PageCreate extends Component<Props, State> {
               </p>
             </>
           )}
+
           {sections.length > 0 && (
             <div className="govuk-form-group">
               <label
@@ -369,7 +374,7 @@ export class PageCreate extends Component<Props, State> {
             >
               <SectionEdit
                 section={!isNewSection ? section : undefined}
-                onEdit={this.closeFlyout}
+                onSave={this.closeFlyout}
               />
             </Flyout>
           </RenderInPortal>

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -20,7 +20,6 @@ import { updateLinksTo } from '~/src/data/page/updateLinksTo.js'
 import { findSection } from '~/src/data/section/findSection.js'
 import { controllerNameFromPath, toUrl } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
-import randomId from '~/src/randomId.js'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
 
@@ -35,7 +34,7 @@ export class PageEdit extends Component {
     const { data } = this.context
 
     this.state = {
-      path: page?.path ?? this.generatePath(page.title),
+      path: page?.path,
       controller: page?.controller ?? '',
       title: page?.title ?? '',
       section: findSection(data, page?.section),
@@ -156,28 +155,16 @@ export class PageEdit extends Component {
   onChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
     const { value: title } = e.target
 
-    this.setState({
-      title,
-      path: this.generatePath(title)
-    })
+    this.onChangePath(e)
+    this.setState({ title })
   }
 
   onChangePath = (e: ChangeEvent<HTMLInputElement>) => {
-    const input = e.target.value
-    const path = input.startsWith('/') ? input : `/${input}`
-    this.setState({
-      path: path.replace(/\s/g, '-')
-    })
-  }
+    const { value: path } = e.target
 
-  generatePath(title) {
-    let path = toUrl(title)
-    const { data } = this.context
-    const { page } = this.props
-    if (data.pages.find((page) => page.path === path) && page.title !== title) {
-      path = `${path}-${randomId()}`
-    }
-    return path
+    this.setState({
+      path: toUrl(path)
+    })
   }
 
   editSection = (e: MouseEvent<HTMLAnchorElement>, isNewSection = false) => {

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -49,19 +49,22 @@ export class PageEdit extends Component {
     const { title, path, section, controller } = this.state
     const { page } = this.props
 
-    const validationErrors = this.validate(title, path)
+    // Remove trailing spaces and hyphens
+    const pathTrim = `/${slugify(path)}`
+    const titleTrim = title.trim()
+
+    const validationErrors = this.validate(titleTrim, pathTrim)
     if (hasValidationErrors(validationErrors)) return
 
     let copy = { ...data }
     const [copyPage, copyIndex] = findPage(data, page.path)
-    const pathChanged = path !== page.path
 
-    if (pathChanged) {
-      copy = updateLinksTo(data, page.path, path)
-      copyPage.path = path
+    if (pathTrim !== page.path) {
+      copy = updateLinksTo(data, page.path, pathTrim)
+      copyPage.path = pathTrim
     }
 
-    copyPage.title = title
+    copyPage.title = titleTrim
     section ? (copyPage.section = section.name) : delete copyPage.section
     controller ? (copyPage.controller = controller) : delete copyPage.controller
 
@@ -162,7 +165,7 @@ export class PageEdit extends Component {
     const { value: path } = e.target
 
     this.setState({
-      path: `/${slugify(path)}`
+      path: `/${slugify(path, { trim: false })}`
     })
   }
 

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -94,10 +94,12 @@ export class PageEdit extends Component {
       ...titleErrors
     }
 
-    const pathHasErrors =
-      path !== page.path ? data.pages.some((page) => page.path === path) : false
+    // Check for duplicate path
+    function isDuplicate(input: string) {
+      return data.pages.some((p) => p.path !== page.path && p.path === input)
+    }
 
-    if (pathHasErrors) {
+    if (isDuplicate(path)) {
       errors.path = {
         href: '#page-path',
         children: `Path '${path}' already exists`

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -330,15 +330,13 @@ export class PageEdit extends Component {
                 {i18n('section.edit')}
               </a>
             )}
-            {!section && (
-              <a
-                href="#"
-                className="govuk-link govuk-!-display-block"
-                onClick={(e) => this.editSection(e, true)}
-              >
-                {i18n('section.create')}
-              </a>
-            )}
+            <a
+              href="#"
+              className="govuk-link govuk-!-display-block"
+              onClick={(e) => this.editSection(e, true)}
+            >
+              {i18n('section.create')}
+            </a>
           </p>
 
           <div className="govuk-button-group">

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -80,8 +80,8 @@ export class PageEdit extends Component<Props, State> {
     }
 
     copyPage.title = titleTrim
-    section ? (copyPage.section = section.name) : delete copyPage.section
-    controller ? (copyPage.controller = controller) : delete copyPage.controller
+    copyPage.controller = controller
+    copyPage.section = section?.name
 
     copy.pages[copyIndex] = copyPage
 

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -1,4 +1,4 @@
-import { clone } from '@defra/forms-model'
+import { clone, slugify } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
@@ -18,7 +18,7 @@ import { DataContext } from '~/src/context/DataContext.js'
 import { findPage } from '~/src/data/page/findPage.js'
 import { updateLinksTo } from '~/src/data/page/updateLinksTo.js'
 import { findSection } from '~/src/data/section/findSection.js'
-import { controllerNameFromPath, toUrl } from '~/src/helpers.js'
+import { controllerNameFromPath } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
@@ -163,7 +163,7 @@ export class PageEdit extends Component {
     const { value: path } = e.target
 
     this.setState({
-      path: toUrl(path)
+      path: `/${slugify(path)}`
     })
   }
 

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -3,7 +3,6 @@ import { clone, slugify } from '@defra/forms-model'
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
   Component,
-  createRef,
   type ChangeEvent,
   type ContextType,
   type FormEvent,
@@ -42,8 +41,6 @@ export class PageEdit extends Component {
       isNewSection: false,
       errors: {}
     }
-
-    this.formEditSection = createRef()
   }
 
   onSubmit = async (e: FormEvent<HTMLFormElement>) => {

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -1,4 +1,4 @@
-import { clone, slugify } from '@defra/forms-model'
+import { clone, slugify, type Page, type Section } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import React, {
@@ -22,11 +22,26 @@ import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { validateTitle, hasValidationErrors } from '~/src/validations.js'
 
-export class PageEdit extends Component {
+interface Props {
+  page: Page
+  onEdit: () => void
+}
+
+interface State {
+  path: string
+  controller?: string
+  title: string
+  section?: Section
+  isEditingSection: boolean
+  isNewSection: boolean
+  errors: Partial<ErrorList<'path' | 'title'>>
+}
+
+export class PageEdit extends Component<Props, State> {
   declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
-  constructor(props, context) {
+  constructor(props: Props, context: typeof DataContext) {
     super(props, context)
 
     const { page } = this.props
@@ -78,7 +93,7 @@ export class PageEdit extends Component {
     }
   }
 
-  validate = (title, path): ErrorList => {
+  validate = (title: string, path: string) => {
     const { page } = this.props
     const { data } = this.context
 

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -24,7 +24,7 @@ import { validateTitle, hasValidationErrors } from '~/src/validations.js'
 
 interface Props {
   page: Page
-  onEdit: () => void
+  onSave: () => void
 }
 
 interface State {
@@ -48,10 +48,10 @@ export class PageEdit extends Component<Props, State> {
     const { data } = this.context
 
     this.state = {
-      path: page?.path,
-      controller: page?.controller ?? '',
-      title: page?.title ?? '',
-      section: findSection(data, page?.section),
+      path: page.path,
+      controller: page.controller,
+      title: page.title,
+      section: findSection(data, page.section),
       isEditingSection: false,
       isNewSection: false,
       errors: {}
@@ -60,9 +60,10 @@ export class PageEdit extends Component<Props, State> {
 
   onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
+
     const { save, data } = this.context
     const { title, path, section, controller } = this.state
-    const { page } = this.props
+    const { page, onSave } = this.props
 
     // Remove trailing spaces and hyphens
     const pathTrim = `/${slugify(path)}`
@@ -87,7 +88,7 @@ export class PageEdit extends Component<Props, State> {
 
     try {
       await save(copy)
-      this.props.onEdit()
+      onSave()
     } catch (error) {
       logger.error(error, 'PageEdit')
     }
@@ -134,9 +135,9 @@ export class PageEdit extends Component<Props, State> {
     }
 
     const { save, data } = this.context
-    const { page } = this.props
-    const copy = clone(data)
+    const { page, onSave } = this.props
 
+    const copy = clone(data)
     const copyPageIdx = copy.pages.findIndex((p) => p.path === page.path)
 
     // Remove all links to the page
@@ -155,7 +156,7 @@ export class PageEdit extends Component<Props, State> {
 
     try {
       await save(copy)
-      this.props.onEdit()
+      onSave()
     } catch (error) {
       logger.error(error, 'PageEdit')
     }
@@ -216,7 +217,6 @@ export class PageEdit extends Component<Props, State> {
 
   render() {
     const { data } = this.context
-    const { sections } = data
     const {
       title,
       path,
@@ -227,11 +227,14 @@ export class PageEdit extends Component<Props, State> {
       errors
     } = this.state
 
+    const { sections } = data
+
     return (
       <div data-testid="page-edit">
         {hasValidationErrors(errors) && (
           <ErrorSummary errorList={Object.values(errors)} />
         )}
+
         <form onSubmit={this.onSubmit} autoComplete="off">
           <div className="govuk-form-group">
             <label className="govuk-label govuk-label--s" htmlFor="controller">
@@ -260,6 +263,7 @@ export class PageEdit extends Component<Props, State> {
               </option>
             </select>
           </div>
+
           <Input
             id="page-title"
             name="title"
@@ -271,6 +275,7 @@ export class PageEdit extends Component<Props, State> {
             onChange={this.onChangeTitle}
             errorMessage={errors.title}
           />
+
           <Input
             id="page-path"
             name="path"
@@ -285,6 +290,7 @@ export class PageEdit extends Component<Props, State> {
             onChange={this.onChangePath}
             errorMessage={errors.path}
           />
+
           {!sections.length && (
             <>
               <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
@@ -295,6 +301,7 @@ export class PageEdit extends Component<Props, State> {
               </p>
             </>
           )}
+
           {sections.length > 0 && (
             <div className="govuk-form-group">
               <label
@@ -370,7 +377,7 @@ export class PageEdit extends Component<Props, State> {
             >
               <SectionEdit
                 section={!isNewSection ? section : undefined}
-                onEdit={this.closeFlyout}
+                onSave={this.closeFlyout}
               />
             </Flyout>
           </RenderInPortal>

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -148,7 +148,7 @@ export function Menu({ slug }: Props) {
       {page.isVisible && (
         <RenderInPortal>
           <Flyout title="Add Page" onHide={page.hide}>
-            <PageCreate onCreate={page.hide} />
+            <PageCreate onSave={page.hide} />
           </Flyout>
         </RenderInPortal>
       )}
@@ -156,7 +156,7 @@ export function Menu({ slug }: Props) {
       {link.isVisible && (
         <RenderInPortal>
           <Flyout title={i18n('menu.links')} onHide={link.hide}>
-            <LinkCreate onCreate={() => link.hide()} />
+            <LinkCreate onSave={link.hide} />
           </Flyout>
         </RenderInPortal>
       )}

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -148,7 +148,7 @@ export function Menu({ slug }: Props) {
       {page.isVisible && (
         <RenderInPortal>
           <Flyout title="Add Page" onHide={page.hide}>
-            <PageCreate onCreate={() => page.hide()} />
+            <PageCreate onCreate={page.hide} />
           </Flyout>
         </RenderInPortal>
       )}

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -66,11 +66,7 @@ export const Page = (props: {
   const [isEditingPage, setIsEditingPage] = useState(false)
   const [isCreatingComponent, setIsCreatingComponent] = useState(false)
 
-  const onEditEnd = () => {
-    setIsEditingPage(false)
-  }
-
-  const section = data.sections.find((section) => section.name === page.section)
+  const section = data.sections.find(({ name }) => name === page.section)
 
   // Remove slashes from IDs
   const pageId = page.path.replace(/\//g, '')
@@ -115,7 +111,7 @@ export const Page = (props: {
       {isEditingPage && (
         <RenderInPortal>
           <Flyout title="Edit Page" onHide={() => setIsEditingPage(false)}>
-            <PageEdit page={page} onEdit={onEditEnd} />
+            <PageEdit page={page} onSave={() => setIsEditingPage(false)} />
           </Flyout>
         </RenderInPortal>
       )}

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -125,10 +125,7 @@ export const Page = (props: {
           <Flyout onHide={() => setIsCreatingComponent(false)}>
             <ComponentContextProvider>
               <ComponentCreate
-                renderInForm={true}
-                toggleAddComponent={() => {
-                  setIsCreatingComponent(false)
-                }}
+                toggleAddComponent={() => setIsCreatingComponent(false)}
                 page={page}
               />
             </ComponentContextProvider>

--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -110,7 +110,7 @@ export class Lines extends Component<Props, State> {
             >
               <LinkEdit
                 edge={this.state.edge}
-                onEdit={() => this.setState({ edge: undefined })}
+                onSave={() => this.setState({ edge: undefined })}
               />
             </Flyout>
           </RenderInPortal>

--- a/designer/client/src/data/section/findSection.ts
+++ b/designer/client/src/data/section/findSection.ts
@@ -1,0 +1,5 @@
+import { type FormDefinition } from '@defra/forms-model'
+
+export function findSection({ sections }: FormDefinition, name?: string) {
+  return sections.find((section) => section.name === name)
+}

--- a/designer/client/src/helpers.js
+++ b/designer/client/src/helpers.js
@@ -1,14 +1,4 @@
 /**
- * @param {string} [title]
- */
-export function toUrl(title) {
-  return `/${(title?.replace(/[^a-zA-Z0-9- ]/g, '') ?? '')
-    .trim()
-    .replace(/ +/g, '-')
-    .toLowerCase()}`
-}
-
-/**
  * @param {string} str
  */
 export function camelCase(str) {

--- a/designer/client/src/helpers.js
+++ b/designer/client/src/helpers.js
@@ -1,23 +1,4 @@
 /**
- * @param {string} str
- */
-export function camelCase(str) {
-  return str
-    .trim()
-    .toLowerCase()
-    .replace(
-      /[\s-_]+(.)/g,
-
-      /**
-       * @param {string} m
-       * @param {string} chr
-       */
-      (m, chr) => chr.toUpperCase()
-    )
-    .replace(/[^a-zA-Z0-9]/g, '')
-}
-
-/**
  * @param {string | number} [str]
  * @returns {str is '' | null | undefined}
  */

--- a/designer/client/src/helpers.js
+++ b/designer/client/src/helpers.js
@@ -26,7 +26,7 @@ export function arrayMove(arr, from, to) {
 }
 
 /**
- * @param {string} nameOrPath
+ * @param {string} [nameOrPath]
  */
 export function controllerNameFromPath(nameOrPath) {
   const controllers = [

--- a/designer/client/src/helpers.test.tsx
+++ b/designer/client/src/helpers.test.tsx
@@ -1,32 +1,6 @@
-import { camelCase, controllerNameFromPath, isEmpty } from '~/src/helpers.js'
+import { controllerNameFromPath, isEmpty } from '~/src/helpers.js'
 
 describe('helpers', () => {
-  describe('camelCase', () => {
-    test('should camel case string', () => {
-      expect(camelCase('My page')).toBe('myPage')
-    })
-
-    test('should camel case string with leading space', () => {
-      expect(camelCase(' My page')).toBe('myPage')
-    })
-
-    test('should camel case hyphenated string', () => {
-      expect(camelCase('My-page')).toBe('myPage')
-    })
-
-    test('should camel case underscored string', () => {
-      expect(camelCase('My_page')).toBe('myPage')
-    })
-
-    test('should camel case string with special chars', () => {
-      expect(camelCase('My page!$£')).toBe('myPage')
-    })
-
-    test('should camel case string with apostrophes chars', () => {
-      expect(camelCase("Bob's your uncle")).toBe('bobsYourUncle')
-    })
-  })
-
   describe('isEmpty', () => {
     test('should return the correct value', () => {
       expect(isEmpty(1)).toBeFalsy()

--- a/designer/client/src/section/SectionEdit.test.tsx
+++ b/designer/client/src/section/SectionEdit.test.tsx
@@ -11,7 +11,7 @@ describe('Section edit fields', () => {
   test('should display titles and help texts', () => {
     render(
       <RenderWithContext>
-        <SectionEdit />
+        <SectionEdit onSave={jest.fn()} />
       </RenderWithContext>
     )
 

--- a/designer/client/src/section/SectionEdit.tsx
+++ b/designer/client/src/section/SectionEdit.tsx
@@ -23,7 +23,7 @@ import {
 
 interface Props {
   section?: Section
-  onEdit?: (sectionName?: string) => void
+  onSave: (sectionName?: string) => void
 }
 
 interface State {
@@ -56,7 +56,7 @@ export class SectionEdit extends Component<Props, State> {
     e.preventDefault()
 
     const { data, save } = this.context
-    const { onEdit, section } = this.props
+    const { onSave, section } = this.props
     const { name, title, hideTitle, isNewSection } = this.state
 
     const validationErrors = this.validate(name, title)
@@ -92,7 +92,7 @@ export class SectionEdit extends Component<Props, State> {
 
     try {
       await save(updated)
-      onEdit?.(name)
+      onSave(name)
     } catch (error) {
       logger.error(error, 'SectionEdit')
     }
@@ -132,7 +132,7 @@ export class SectionEdit extends Component<Props, State> {
     }
 
     const { data, save } = this.context
-    const { onEdit, section } = this.props
+    const { onSave, section } = this.props
 
     if (!section) {
       return
@@ -152,7 +152,7 @@ export class SectionEdit extends Component<Props, State> {
 
     try {
       await save(copy)
-      onEdit?.()
+      onSave()
     } catch (error) {
       logger.error(error, 'SectionEdit')
     }

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -79,7 +79,7 @@ export class SectionsEdit extends Component<Props, State> {
               show={isEditingSection}
               onHide={() => this.closeFlyout()}
             >
-              <SectionEdit section={section} onEdit={this.closeFlyout} />
+              <SectionEdit section={section} onSave={this.closeFlyout} />
             </Flyout>
           </RenderInPortal>
         )}

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -4,6 +4,7 @@ import React, { Component, type ContextType, type MouseEvent } from 'react'
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
+import { findSection } from '~/src/data/section/findSection.js'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 
 type Props = Record<string, never>
@@ -30,17 +31,12 @@ export class SectionsEdit extends Component<Props, State> {
 
   closeFlyout = (sectionName?: string) => {
     const { section } = this.state
+    const { data } = this.context
 
     this.setState({
       isEditingSection: false,
-      section: sectionName ? this.findSectionWithName(sectionName) : section
+      section: findSection(data, sectionName ?? section?.name)
     })
-  }
-
-  findSectionWithName(name?: string) {
-    const { data } = this.context
-    const { sections } = data
-    return sections.find((section) => section.name === name)
   }
 
   render() {

--- a/model/src/utils/helpers.test.js
+++ b/model/src/utils/helpers.test.js
@@ -1,11 +1,15 @@
 import { slugify } from '~/src/utils/helpers.js'
 
 describe('Helpers', () => {
-  describe('Slugify', () => {
+  describe('slugify', () => {
     it.each([
       {
         title: 'This is a form title',
         slug: 'this-is-a-form-title'
+      },
+      {
+        title: 'this-is-already-slugified-with-trailing-hyphen-',
+        slug: 'this-is-already-slugified-with-trailing-hyphen'
       },
       {
         title: 'This is a form’s—really—punctuated: title',
@@ -33,6 +37,14 @@ describe('Helpers', () => {
       }
     ])("formats '$title' to '$slug'", ({ title, slug }) => {
       expect(slugify(title)).toBe(slug)
+    })
+
+    it('suports slug options', () => {
+      const title = 'This is a form title with trailing spaces  '
+      const slug = 'this-is-a-form-title-with-trailing-spaces-'
+
+      // Skip trim, e.g. path formatting "as you type"
+      expect(slugify(title, { trim: false })).toBe(slug)
     })
   })
 })

--- a/model/src/utils/helpers.ts
+++ b/model/src/utils/helpers.ts
@@ -35,10 +35,16 @@ export function filter<T extends Record<string, unknown>>(
 }
 
 /**
- * Replace spaces, en-dashes and em-dashes with hyphens
+ * Replace whitespace, en-dashes and em-dashes with spaces
  * before running through the slug package
  */
-export function slugify(input = '') {
-  const string = input.trim().replace(/[\s–—]/g, '-')
-  return slug(string, { lower: true })
+export function slugify(input = '', options?: slug.Options) {
+  const string = input.trimStart().replace(/[\s–—]/g, ' ')
+
+  return slug(string, {
+    fallback: false,
+    lower: true,
+    trim: true,
+    ...options
+  })
 }


### PR DESCRIPTION
This PR is in preparation for [bug #399485](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/399485) with types added to page components

Various differences have been fixed, including page paths generated differently when editing the page title

Changes include:

1. Always use `slugify()` to set page paths (including via title)
2. Consistent "Create section" and "Edit section" between create/edit pages
4. Removes unused helpers `toUrl()` and `camelCase()`

I've also removed `randomId()` from duplicate page paths, preferring the validation to kick in instead:

<img width="467" alt="Duplicate page path validation" src="https://github.com/user-attachments/assets/c3264466-638c-4117-bb96-55c1ddb2c275">
