### PR TITLE
Remove unnecessary wrappers, classes, IDs

### DIFF
--- a/designer/client/src/LinkCreate.tsx
+++ b/designer/client/src/LinkCreate.tsx
@@ -117,18 +117,13 @@ export class LinkCreate extends Component<Props, State> {
                 'govuk-input--error': errors.from
               })}
               id="link-source"
-              data-testid="link-source"
               aria-describedby={errors.to && 'link-source-error'}
               name="path"
               onChange={(e) => this.storeValue(e, 'from')}
             >
               <option value="" />
               {pages.map((page) => (
-                <option
-                  key={page.path}
-                  value={page.path}
-                  data-testid="link-source-option"
-                >
+                <option key={page.path} value={page.path}>
                   {page.title}
                 </option>
               ))}
@@ -155,18 +150,13 @@ export class LinkCreate extends Component<Props, State> {
                 'govuk-input--error': errors.to
               })}
               id="link-target"
-              data-testid="link-target"
               aria-describedby={errors.to && 'link-target-error'}
               name="page"
               onChange={(e) => this.storeValue(e, 'to')}
             >
               <option value="" />
               {pages.map((page) => (
-                <option
-                  key={page.path}
-                  value={page.path}
-                  data-testid="link-target-option"
-                >
+                <option key={page.path} value={page.path}>
                   {page.title}
                 </option>
               ))}

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -230,7 +230,7 @@ export class PageEdit extends Component<Props, State> {
     const hasErrors = hasValidationErrors(errors)
 
     return (
-      <div data-testid="page-edit">
+      <>
         {hasErrors && (
           <ErrorSummary errorList={Object.values(errors).filter(Boolean)} />
         )}
@@ -382,7 +382,7 @@ export class PageEdit extends Component<Props, State> {
             </Flyout>
           </RenderInPortal>
         )}
-      </div>
+      </>
     )
   }
 }

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.scss
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.scss
@@ -1,6 +1,0 @@
-@import "govuk-frontend/dist/govuk/base";
-
-.component-create .govuk-back-link {
-  margin-top: 0;
-  @include govuk-responsive-margin(6, "bottom");
-}

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -137,7 +137,7 @@ export function ComponentCreate(props) {
   const type = component?.type
 
   return (
-    <div className="component-create" data-testid={'component-create'}>
+    <>
       {!type && <h4 className="govuk-heading-m">{i18n('component.create')}</h4>}
       {type && (
         <>
@@ -162,6 +162,6 @@ export function ComponentCreate(props) {
           </button>
         </form>
       )}
-    </div>
+    </>
   )
 }

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -42,13 +42,10 @@ export const ComponentCreateList = ({ onSelectComponent }: Props) => {
   )
 
   return (
-    <div
-      className="govuk-form-group component-create__list"
-      data-testid="component-create-list"
-    >
+    <div className="govuk-form-group">
       <h1 className="govuk-hint">{i18n('component.create_info')}</h1>
       <ol className="govuk-list">
-        <li className="component-create__list__item">
+        <li>
           <h2 className="govuk-heading-s">{i18n('Content')}</h2>
           <div className="govuk-hint">
             {i18n('component.contentfields_info')}
@@ -73,7 +70,7 @@ export const ComponentCreateList = ({ onSelectComponent }: Props) => {
           </ol>
           <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
         </li>
-        <li className="component-create__list__item">
+        <li>
           <h2 className="govuk-heading-s">{i18n('Input fields')}</h2>
           <div className="govuk-hint">{i18n('component.inputfields_info')}</div>
           <ol className="govuk-list">
@@ -96,7 +93,7 @@ export const ComponentCreateList = ({ onSelectComponent }: Props) => {
           </ol>
           <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
         </li>
-        <li className="component-create__list__item">
+        <li>
           <h2 className="govuk-heading-s">{i18n('Selection fields')}</h2>
           <div className="govuk-hint">
             {i18n('component.selectfields_info')}

--- a/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
+++ b/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
@@ -3,8 +3,7 @@
 exports[`ComponentCreateList should match snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="govuk-form-group component-create__list"
-    data-testid="component-create-list"
+    class="govuk-form-group"
   >
     <h1
       class="govuk-hint"
@@ -14,9 +13,7 @@ exports[`ComponentCreateList should match snapshot 1`] = `
     <ol
       class="govuk-list"
     >
-      <li
-        class="component-create__list__item"
-      >
+      <li>
         <h2
           class="govuk-heading-s"
         >
@@ -103,9 +100,7 @@ exports[`ComponentCreateList should match snapshot 1`] = `
           class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
         />
       </li>
-      <li
-        class="component-create__list__item"
-      >
+      <li>
         <h2
           class="govuk-heading-s"
         >
@@ -260,9 +255,7 @@ exports[`ComponentCreateList should match snapshot 1`] = `
           class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
         />
       </li>
-      <li
-        class="component-create__list__item"
-      >
+      <li>
         <h2
           class="govuk-heading-s"
         >

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -87,58 +87,56 @@ export function ComponentListSelect() {
   }
 
   return (
-    <>
-      <div
-        className={classNames({
-          'govuk-form-group': true,
-          'govuk-form-group--error': errors.list
-        })}
+    <div
+      className={classNames({
+        'govuk-form-group': true,
+        'govuk-form-group--error': errors.list
+      })}
+    >
+      <label
+        className="govuk-label govuk-label--s"
+        htmlFor="field-options-list"
       >
-        <label
-          className="govuk-label govuk-label--s"
-          htmlFor="field-options-list"
-        >
-          {i18n('list.select.title')}
-        </label>
-        <div className="govuk-hint" id="field-options-list-hint">
-          {i18n('list.select.helpText')}
-        </div>
-        <select
-          className="govuk-select govuk-input--width-10"
-          id="field-options-list"
-          aria-describedby="field-options-list-hint"
-          name="options.list"
-          value={list}
-          onChange={editList}
-        >
-          <option value="">{i18n('list.select.option')}</option>
-          {data.lists.map((list, index) => {
-            return (
-              <option key={`${list.name}-${index}`} value={list.name}>
-                {list.title}
-              </option>
-            )
-          })}
-        </select>
-        <p className="govuk-body govuk-!-margin-top-2">
-          {selectedListTitle && (
-            <a
-              className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
-              onClick={handleEditListClick}
-              href="#"
-            >
-              {i18n('list.edit', { title: selectedListTitle })}
-            </a>
-          )}
+        {i18n('list.select.title')}
+      </label>
+      <div className="govuk-hint" id="field-options-list-hint">
+        {i18n('list.select.helpText')}
+      </div>
+      <select
+        className="govuk-select govuk-input--width-10"
+        id="field-options-list"
+        aria-describedby="field-options-list-hint"
+        name="options.list"
+        value={list}
+        onChange={editList}
+      >
+        <option value="">{i18n('list.select.option')}</option>
+        {data.lists.map((list, index) => {
+          return (
+            <option key={`${list.name}-${index}`} value={list.name}>
+              {list.title}
+            </option>
+          )
+        })}
+      </select>
+      <p className="govuk-body govuk-!-margin-top-2">
+        {selectedListTitle && (
           <a
             className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
-            onClick={handleAddListClick}
+            onClick={handleEditListClick}
             href="#"
           >
-            {i18n('list.addNew')}
+            {i18n('list.edit', { title: selectedListTitle })}
           </a>
-        </p>
-      </div>
-    </>
+        )}
+        <a
+          className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
+          onClick={handleAddListClick}
+          href="#"
+        >
+          {i18n('list.addNew')}
+        </a>
+      </p>
+    </div>
   )
 }

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -132,7 +132,6 @@ export function ComponentListSelect() {
           )}
           <a
             className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
-            data-testid="add-list"
             onClick={handleAddListClick}
             href="#"
           >

--- a/designer/client/src/components/Flyout/Flyout.scss
+++ b/designer/client/src/components/Flyout/Flyout.scss
@@ -65,6 +65,11 @@
     overflow: hidden;
   }
 
+  & .govuk-back-link {
+    margin-top: 0;
+    @include govuk-responsive-margin(6, "bottom");
+  }
+
   & h2 a {
     color: #333;
     margin-left: 15px;

--- a/designer/client/src/components/Flyout/Flyout.tsx
+++ b/designer/client/src/components/Flyout/Flyout.tsx
@@ -104,9 +104,7 @@ export function Flyout(props: Props) {
           <div className="panel panel--flyout">
             <div className="panel-header govuk-!-padding-top-4 govuk-!-padding-left-4">
               {props.title && (
-                <h4 className="govuk-heading-m" data-testid="flyout-heading">
-                  {props.title}
-                </h4>
+                <h4 className="govuk-heading-m">{props.title}</h4>
               )}
             </div>
             <div className="panel-body">

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -73,7 +73,7 @@ export const Page = (props: {
   const headingId = `${pageId}-heading`
 
   return (
-    <div id={pageId} className="page" style={layout}>
+    <div className="page" style={layout}>
       <div className="page__heading">
         <h3 className="govuk-heading-m" id={headingId}>
           {section && <span className="govuk-caption-m">{section.title}</span>}

--- a/designer/client/src/components/Visualisation/Visualisation.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.tsx
@@ -49,24 +49,22 @@ export function Visualisation(props: Props) {
   }
 
   return (
-    <>
-      <div className="visualisation">
-        <div className="visualisation__pages-wrapper">
-          <div ref={ref} style={wrapperStyle}>
-            {pages.map((page, index) => (
-              <Page
-                key={index}
-                page={page}
-                previewUrl={previewUrl}
-                layout={layout?.nodes[index]}
-                slug={slug}
-              />
-            ))}
+    <div className="visualisation">
+      <div className="visualisation__pages-wrapper">
+        <div ref={ref} style={wrapperStyle}>
+          {pages.map((page, index) => (
+            <Page
+              key={index}
+              page={page}
+              previewUrl={previewUrl}
+              layout={layout?.nodes[index]}
+              slug={slug}
+            />
+          ))}
 
-            {layout && <Lines layout={layout} />}
-          </div>
+          {layout && <Lines layout={layout} />}
         </div>
       </div>
-    </>
+    </div>
   )
 }

--- a/designer/client/src/conditions/ConditionsEdit.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.tsx
@@ -85,10 +85,7 @@ export function ConditionsEdit({ path }: Props) {
             </RenderInPortal>
           )}
 
-          <ul
-            className="govuk-list govuk-list--bullet govuk-list--spaced"
-            data-testid="conditions-list"
-          >
+          <ul className="govuk-list govuk-list--bullet govuk-list--spaced">
             {conditions.map((condition) => {
               const model = ConditionsModel.from(condition.value)
 
@@ -110,10 +107,8 @@ export function ConditionsEdit({ path }: Props) {
           <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
           {inputs.length > 0 && (
             <button
-              id="add-condition-link"
               className="govuk-button"
               type="button"
-              data-testid={'add-condition-link'}
               onClick={onClickAddCondition}
             >
               {i18n('conditions.add')}

--- a/designer/client/src/conditions/InlineConditions.tsx
+++ b/designer/client/src/conditions/InlineConditions.tsx
@@ -272,71 +272,68 @@ export class InlineConditions extends Component<Props, State> {
 
     return (
       <>
-        <div>
-          <div className="govuk-hint">{i18n('conditions.addOrEditHint')}</div>
-          <>
-            {hasErrors && <ErrorSummary errorList={validationErrors} />}
-            <div
-              className={classNames('govuk-form-group', {
-                'govuk-form-group--error': nameError
-              })}
-            >
-              <label className="govuk-label govuk-label--s" htmlFor="cond-name">
-                {i18n('conditions.displayName')}
-              </label>
-              <div className="govuk-hint" id="cond-name-hint">
-                {i18n('conditions.displayNameHint')}
-              </div>
-              {nameError && (
-                <ErrorMessage id="cond-name-error">
-                  {nameError.children}
-                </ErrorMessage>
-              )}
-              <input
-                className={classNames('govuk-input govuk-input--width-20', {
-                  'govuk-input--error': nameError
-                })}
-                id="cond-name"
-                aria-describedby={
-                  'cond-name-hint' + (nameError ? 'cond-name-error' : '')
-                }
-                name="cond-name"
-                type="text"
-                defaultValue={conditions.name}
-                required
-                onChange={this.onChangeDisplayName}
-              />
-            </div>
-            <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
-              {i18n('conditions.condition')}
-            </h4>
-            <p className="govuk-hint govuk-!-margin-top-0">
-              {i18n('conditions.conditionHint')}
-            </p>
-          </>
-          {conditions.hasConditions && (
-            <ul className="govuk-list govuk-list--bullet">
-              <li key="condition-string">
-                <strong>{conditions.toPresentationString()}</strong>
-                {!editView && (
-                  <>
-                    <br />
-                    <a
-                      href="#"
-                      className="govuk-link"
-                      onClick={(e) => {
-                        e.preventDefault()
-                        this.toggleEdit()
-                      }}
-                    >
-                      {i18n('conditions.edit')}
-                    </a>
-                  </>
-                )}
-              </li>
-            </ul>
+        {hasErrors && <ErrorSummary errorList={validationErrors} />}
+
+        <div className="govuk-hint">{i18n('conditions.addOrEditHint')}</div>
+        <div
+          className={classNames('govuk-form-group', {
+            'govuk-form-group--error': nameError
+          })}
+        >
+          <label className="govuk-label govuk-label--s" htmlFor="cond-name">
+            {i18n('conditions.displayName')}
+          </label>
+          <div className="govuk-hint" id="cond-name-hint">
+            {i18n('conditions.displayNameHint')}
+          </div>
+          {nameError && (
+            <ErrorMessage id="cond-name-error">
+              {nameError.children}
+            </ErrorMessage>
           )}
+          <input
+            className={classNames('govuk-input govuk-input--width-20', {
+              'govuk-input--error': nameError
+            })}
+            id="cond-name"
+            aria-describedby={
+              'cond-name-hint' + (nameError ? 'cond-name-error' : '')
+            }
+            name="cond-name"
+            type="text"
+            defaultValue={conditions.name}
+            required
+            onChange={this.onChangeDisplayName}
+          />
         </div>
+        <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
+          {i18n('conditions.condition')}
+        </h4>
+        <p className="govuk-hint govuk-!-margin-top-0">
+          {i18n('conditions.conditionHint')}
+        </p>
+        {conditions.hasConditions && (
+          <ul className="govuk-list govuk-list--bullet">
+            <li key="condition-string">
+              <strong>{conditions.toPresentationString()}</strong>
+              {!editView && (
+                <>
+                  <br />
+                  <a
+                    href="#"
+                    className="govuk-link"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      this.toggleEdit()
+                    }}
+                  >
+                    {i18n('conditions.edit')}
+                  </a>
+                </>
+              )}
+            </li>
+          </ul>
+        )}
         {!editView && (
           <>
             <InlineConditionsDefinition

--- a/designer/client/src/conditions/InlineConditions.tsx
+++ b/designer/client/src/conditions/InlineConditions.tsx
@@ -271,8 +271,8 @@ export class InlineConditions extends Component<Props, State> {
     const hasErrors = !!validationErrors.length
 
     return (
-      <div id="inline-conditions" data-testid={'inline-conditions'}>
-        <div id="inline-condition-header">
+      <>
+        <div>
           <div className="govuk-hint">{i18n('conditions.addOrEditHint')}</div>
           <>
             {hasErrors && <ErrorSummary errorList={validationErrors} />}
@@ -315,18 +315,14 @@ export class InlineConditions extends Component<Props, State> {
             </p>
           </>
           {conditions.hasConditions && (
-            <ul
-              className="govuk-list govuk-list--bullet"
-              id="conditions-display"
-            >
-              <li key="condition-string" id="condition-string">
+            <ul className="govuk-list govuk-list--bullet">
+              <li key="condition-string">
                 <strong>{conditions.toPresentationString()}</strong>
                 {!editView && (
                   <>
                     <br />
                     <a
                       href="#"
-                      id="edit-conditions-link"
                       className="govuk-link"
                       onClick={(e) => {
                         e.preventDefault()
@@ -352,7 +348,6 @@ export class InlineConditions extends Component<Props, State> {
               {conditions.hasConditions && (
                 <>
                   <button
-                    id="save-inline-conditions"
                     className="govuk-button"
                     type="button"
                     onClick={this.onClickSave}
@@ -361,7 +356,6 @@ export class InlineConditions extends Component<Props, State> {
                   </button>
                   {condition && (
                     <button
-                      id="delete-inline-conditions"
                       className="govuk-button govuk-button--warning"
                       type="button"
                       onClick={this.onClickDelete}
@@ -382,7 +376,7 @@ export class InlineConditions extends Component<Props, State> {
             exitCallback={this.toggleEdit}
           />
         )}
-      </div>
+      </>
     )
   }
 }

--- a/designer/client/src/conditions/InlineConditionsDefinition.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinition.tsx
@@ -243,7 +243,7 @@ export class InlineConditionsDefinition extends Component<Props, State> {
       )
 
     return (
-      <div id="condition-definition-group" className="govuk-!-margin-bottom-6">
+      <div className="govuk-!-margin-bottom-6">
         {(expectsCoordinator || !!selectedCoordinator) && (
           <div className="govuk-form-group govuk-!-margin-bottom-3">
             <label className="govuk-label" htmlFor="cond-coordinator">

--- a/designer/client/src/conditions/InlineConditionsEdit.tsx
+++ b/designer/client/src/conditions/InlineConditionsEdit.tsx
@@ -218,7 +218,7 @@ export class InlineConditionsEdit extends Component<Props, State> {
     } = this.state
 
     return (
-      <div id="edit-conditions">
+      <>
         {typeof editingIndex === 'undefined' && (
           <div
             className={classNames({
@@ -332,7 +332,6 @@ export class InlineConditionsEdit extends Component<Props, State> {
         )}
         <div className="govuk-button-group">
           <button
-            id="cancel-edit-inline-conditions-link"
             className="govuk-button"
             type="button"
             onClick={this.onClickCancelEditView}
@@ -340,7 +339,7 @@ export class InlineConditionsEdit extends Component<Props, State> {
             Finished editing
           </button>
         </div>
-      </div>
+      </>
     )
   }
 }

--- a/designer/client/src/conditions/RelativeDateValues.tsx
+++ b/designer/client/src/conditions/RelativeDateValues.tsx
@@ -71,7 +71,6 @@ export class RelativeDateValues extends Component<Props, State> {
                 period: e.currentTarget.value
               })
             }
-            data-testid="cond-value-period"
           />
         </div>
 

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -241,7 +241,7 @@ export class SelectConditions extends Component<Props, State> {
     const hasFields = Object.keys(fields ?? {}).length > 0
 
     return (
-      <div className="conditions" data-testid="select-conditions">
+      <>
         <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
           {i18n('conditions.optional')}
         </h4>
@@ -251,7 +251,6 @@ export class SelectConditions extends Component<Props, State> {
               <Select
                 id="select-condition"
                 name="cond-select"
-                data-testid="select-condition"
                 value={selectedCondition ?? ''}
                 items={[
                   {
@@ -274,7 +273,6 @@ export class SelectConditions extends Component<Props, State> {
               <p className="govuk-body">
                 <a
                   href="#"
-                  id="inline-conditions-link"
                   className="govuk-link"
                   onClick={this.onClickDefineCondition}
                 >
@@ -300,7 +298,7 @@ export class SelectConditions extends Component<Props, State> {
         ) : (
           <p className="govuk-body">{noFieldsHintText}</p>
         )}
-      </div>
+      </>
     )
   }
 }

--- a/designer/client/src/conditions/SelectValues.tsx
+++ b/designer/client/src/conditions/SelectValues.tsx
@@ -41,7 +41,6 @@ export const SelectValues = (props: Props) => {
         name="cond-value"
         defaultValue={value?.value}
         onChange={onChangeSelect}
-        data-testid={'cond-value'}
       >
         <option value="" />
         {fieldDef.values?.map((option) => (

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -176,7 +176,6 @@ export function ListEdit() {
           <a
             href="#createItem"
             className="govuk-link"
-            data-testid="add-list-item"
             onClick={(e) => {
               e.preventDefault()
               createItem()
@@ -187,11 +186,7 @@ export function ListEdit() {
         </p>
 
         <div className="govuk-button-group">
-          <button
-            data-testid="save-list"
-            className="govuk-button"
-            type="submit"
-          >
+          <button className="govuk-button" type="submit">
             {i18n('save')}
           </button>
 

--- a/designer/client/src/list/ListItemEdit.tsx
+++ b/designer/client/src/list/ListItemEdit.tsx
@@ -55,7 +55,6 @@ export function ListItemEdit() {
       <form onSubmit={handleSubmit}>
         <Input
           id="title"
-          data-testid="list-item-text"
           name="list-item-text"
           label={{
             className: 'govuk-label--s',
@@ -70,7 +69,6 @@ export function ListItemEdit() {
           label={{ children: i18n('list.item.help') }}
           hint={{ children: i18n('list.item.helpHint') }}
           value={hint}
-          data-testid="list-item-hint"
           name="list-item-hint"
           id="hint"
           onChange={handleHintChange}
@@ -79,7 +77,6 @@ export function ListItemEdit() {
           label={{ children: [i18n('list.item.value')] }}
           hint={{ children: [i18n('list.item.valueHint')] }}
           id="value"
-          data-testid="list-item-value"
           name="list-item-value"
           value={value}
           errorMessage={errors.value}
@@ -96,29 +93,19 @@ export function ListItemEdit() {
           id="condition"
           aria-describedby="condition-hint"
           name="options.condition"
-          data-testid="list-condition-select"
           value={condition}
           onChange={handleConditionChange}
         >
-          <option value="" data-testid="list-condition-option" />
+          <option value="" />
           {conditions.map((condition) => (
-            <option
-              key={condition.name}
-              value={condition.name}
-              data-testid="list-condition-option"
-            >
+            <option key={condition.name} value={condition.name}>
               {condition.displayName}
             </option>
           ))}
         </select>
         <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
         <div className="govuk-button-group">
-          <button
-            data-testid="save-list-item"
-            className="govuk-button"
-            type="submit"
-            onClick={handleSubmit}
-          >
+          <button className="govuk-button" type="submit" onClick={handleSubmit}>
             {i18n('save')}
           </button>
         </div>

--- a/designer/client/src/list/ListSelect.tsx
+++ b/designer/client/src/list/ListSelect.tsx
@@ -31,7 +31,6 @@ export function ListSelect() {
         {data.lists.map((list) => (
           <li key={list.name}>
             <a
-              data-testid="edit-list"
               href="#"
               className="govuk-link"
               onClick={(e) => editList(e, list)}
@@ -46,7 +45,6 @@ export function ListSelect() {
         <button
           className="govuk-button"
           type="button"
-          data-testid="add-list"
           onClick={(e) => {
             e.preventDefault()
             listDispatch({ type: ListActions.ADD_NEW_LIST })

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -7,7 +7,6 @@ $govuk-new-organisation-colours: true;
 @import "variables/all";
 @import "helpers/all";
 
-@import "../components/ComponentCreate/ComponentCreate.scss";
 @import "../components/Flyout/Flyout.scss";
 @import "../components/Visualisation/visualisation.scss";
 

--- a/designer/server/src/common/components/breadcrumbs/template.njk
+++ b/designer/server/src/common/components/breadcrumbs/template.njk
@@ -1,14 +1,14 @@
-<div class="app-breadcrumbs" data-testid="app-breadcrumbs">
+<div class="app-breadcrumbs">
   <ol class="app-breadcrumbs__list">
     {% for item in params.items %}
       {% if item.href %}
-        <li class="app-breadcrumbs__list-item" data-testid="app-breadcrumbs-list-item">
-          <a class="app-breadcrumbs__link" href="{{ item.href }}"
-            data-testid="app-breadcrumbs-link">{{ item.text }}</a>
+        <li class="app-breadcrumbs__list-item">
+          <a class="app-breadcrumbs__link" href="{{ item.href }}">{{ item.text }}</a>
         </li>
       {% else %}
-        <li class="app-breadcrumbs__list-item app-breadcrumbs__list-item--current" aria-current="page"
-          data-testid="app-breadcrumbs-list-item">{{ item.text }}</li>
+        <li class="app-breadcrumbs__list-item app-breadcrumbs__list-item--current" aria-current="page">
+          {{ item.text }}
+        </li>
       {% endif %}
     {% endfor %}
   </ol>


### PR DESCRIPTION
This PR removes unnecessary `<></>` wrapper fragments along with unused CSS classes and IDs

With tests now using [`ByRole` queries](https://testing-library.com/docs/queries/byrole/) via https://github.com/DEFRA/forms-designer/pull/402 many more are no longer needed

**Note:** Best viewed with ["Hide whitespace" `?w=1`](https://github.com/DEFRA/forms-designer/pull/403/files?diff=unified&w=1) as lots of lines show indentation only