### PR TITLE
Fix form validation not clearing between pages (e.g. add list)

### DIFF
--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -16,7 +16,7 @@ import { hasValidationErrors } from '~/src/validations.js'
 export function ComponentEdit(props) {
   const { data, save } = useContext(DataContext)
   const { state, dispatch } = useContext(ComponentContext)
-  const { initialName, selectedComponent, errors = {}, hasValidated } = state
+  const { initialName, selectedComponent, errors, hasValidated } = state
   const { page, toggleShowEditor } = props
   const hasErrors = hasValidationErrors(errors)
 

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -17,7 +17,7 @@ import { Fields, Options } from '~/src/reducers/component/types.js'
 
 export function FieldEdit() {
   const { state, dispatch } = useContext(ComponentContext)
-  const { selectedComponent, errors = {} } = state
+  const { selectedComponent, errors } = state
 
   if (!selectedComponent) {
     return null

--- a/designer/client/src/LinkCreate.tsx
+++ b/designer/client/src/LinkCreate.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 interface State extends Partial<Form> {
   selectedCondition?: string
-  errors?: Partial<ErrorList<'from' | 'to' | 'selectedCondition'>>
+  errors: Partial<ErrorList<'from' | 'to' | 'selectedCondition'>>
 }
 
 interface Form {
@@ -32,7 +32,9 @@ export class LinkCreate extends Component<Props, State> {
   declare context: ContextType<typeof DataContext>
   static contextType = DataContext
 
-  state: State = {}
+  state: State = {
+    errors: {}
+  }
 
   onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -85,8 +87,9 @@ export class LinkCreate extends Component<Props, State> {
 
   render() {
     const { data } = this.context
+    const { from, errors } = this.state
+
     const { pages } = data
-    const { from, errors = {} } = this.state
     const hasErrors = hasValidationErrors(errors)
 
     return (

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -29,7 +29,7 @@ function useComponentCreate(props) {
   const [renderTypeEdit, setRenderTypeEdit] = useState<boolean>(false)
   const { data, save } = useContext(DataContext)
   const { state, dispatch } = useContext(ComponentContext)
-  const { selectedComponent, errors = {}, hasValidated } = state
+  const { selectedComponent, errors, hasValidated } = state
   const { page, toggleAddComponent = () => {} } = props
 
   const [isSaving, setIsSaving] = useState(false)

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -28,7 +28,7 @@ export function ComponentListSelect() {
   const { state: listsEditorState, dispatch: listsEditorDispatch } =
     useContext(ListsEditorContext)
 
-  const { selectedComponent, errors = {} } = state
+  const { selectedComponent, errors } = state
 
   if (!hasListField(selectedComponent)) {
     throw new Error('Component must support lists')

--- a/designer/client/src/components/FieldEditors/ContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ContentEdit.tsx
@@ -15,7 +15,7 @@ interface Props {
 export function ContentEdit({ context = ComponentContext }: Props) {
   const { state, dispatch } = useContext(context)
 
-  const { selectedComponent, errors = {} } = state
+  const { selectedComponent, errors } = state
 
   if (!hasContentField(selectedComponent)) {
     return null

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -137,7 +137,7 @@ export function ListEdit() {
   const { state, dispatch } = useContext(ListContext)
   const { selectedList, createItem } = useListItemActions(state, dispatch)
 
-  const { errors = {} } = state
+  const { errors } = state
   const hasErrors = hasValidationErrors(errors)
 
   return (

--- a/designer/client/src/list/ListItemEdit.tsx
+++ b/designer/client/src/list/ListItemEdit.tsx
@@ -32,7 +32,7 @@ export function ListItemEdit() {
   } = useListItem(state, dispatch)
 
   const { conditions } = data
-  const { listItemErrors: errors = {}, selectedItem } = state
+  const { listItemErrors: errors, selectedItem } = state
   const hasErrors = hasValidationErrors(errors)
 
   const handleSubmit = async (

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -27,7 +27,7 @@ export interface ComponentState {
   selectedComponent?: ComponentDef
   hasValidated?: boolean
   showDeleteWarning?: boolean
-  errors?: Partial<ErrorList<'title' | 'name' | 'content' | 'list'>>
+  errors: Partial<ErrorList<'title' | 'name' | 'content' | 'list'>>
 }
 
 export type ReducerActions =
@@ -95,9 +95,9 @@ export function componentReducer(
 }
 
 export const initComponentState = (
-  props?: Omit<ComponentState, 'initialName'>
+  props?: Partial<Omit<ComponentState, 'initialName'>>
 ): ComponentState => {
-  const { selectedComponent, errors } = props ?? {}
+  const { selectedComponent, errors = {} } = props ?? {}
 
   return {
     initialName: selectedComponent?.name ?? randomId(),

--- a/designer/client/src/reducers/listReducer.tsx
+++ b/designer/client/src/reducers/listReducer.tsx
@@ -17,8 +17,8 @@ export interface ListState extends Partial<FormList>, Partial<FormItem> {
   isEditingFromComponent?: boolean
   initialName?: string
   initialTitle?: string
-  errors?: Partial<ErrorList<'title' | 'listItems'>>
-  listItemErrors?: Partial<ErrorList<'title' | 'value'>>
+  errors: Partial<ErrorList<'title' | 'listItems'>>
+  listItemErrors: Partial<ErrorList<'title' | 'value'>>
 }
 
 export interface FormList {
@@ -35,7 +35,7 @@ export interface ListContextType {
 }
 
 export const ListContext = createContext<ListContextType>({
-  state: {},
+  state: {} as ListState,
   dispatch: () => ({})
 })
 
@@ -43,7 +43,7 @@ export const ListContext = createContext<ListContextType>({
  * Allows mutation of the {@link List} from any component that is nested within {@link ListContextProvider}
  */
 export function listReducer(
-  state: ListState = {},
+  state: ListState,
   action: {
     type: ListActions
     payload?: unknown
@@ -63,7 +63,9 @@ export function listReducer(
           items: [],
           isNew: true
         },
-        initialName: listId
+        initialName: listId,
+        errors: {},
+        listItemErrors: {}
       }
     }
 
@@ -72,7 +74,9 @@ export function listReducer(
         ...state,
         selectedList: payload,
         initialName: payload?.name || state.initialName,
-        initialTitle: payload?.title
+        initialTitle: payload?.title,
+        errors: {},
+        listItemErrors: {}
       }
 
     case ListActions.EDIT_TITLE:
@@ -155,7 +159,10 @@ export const ListContextProvider = (props: {
   const { selectedListName } = props
   const { data } = useContext(DataContext)
 
-  let init: ListState = {}
+  let init: ListState = {
+    errors: {},
+    listItemErrors: {}
+  }
 
   if (selectedListName) {
     const selectedList = data.lists.find(
@@ -163,6 +170,7 @@ export const ListContextProvider = (props: {
     )
 
     init = {
+      ...init,
       selectedList,
       initialName: selectedListName,
       initialTitle: selectedList?.title,
@@ -170,7 +178,7 @@ export const ListContextProvider = (props: {
     }
   }
 
-  const [state, dispatch] = useReducer(listReducer, { ...init })
+  const [state, dispatch] = useReducer(listReducer, init)
 
   return (
     <ListContext.Provider value={{ state, dispatch }}>

--- a/designer/client/test/helpers/renderers-lists.tsx
+++ b/designer/client/test/helpers/renderers-lists.tsx
@@ -4,8 +4,7 @@ import { DataContext, type DataContextType } from '~/src/context/DataContext.js'
 import {
   ComponentContext,
   componentReducer,
-  initComponentState,
-  type ComponentContextType
+  initComponentState
 } from '~/src/reducers/component/componentReducer.jsx'
 import { ListsEditorContextProvider } from '~/src/reducers/list/listsEditorReducer.jsx'
 import { ListContextProvider } from '~/src/reducers/listReducer.jsx'
@@ -15,7 +14,7 @@ export interface RenderListEditorWithContextProps {
   selectedListName?: string
   data: DataContextType['data']
   save?: DataContextType['save']
-  state?: Omit<ComponentContextType['state'], 'initialName'>
+  state?: Parameters<typeof initComponentState>[0]
 }
 
 export function RenderListEditorWithContext({

--- a/designer/client/test/helpers/renderers.tsx
+++ b/designer/client/test/helpers/renderers.tsx
@@ -5,13 +5,12 @@ import { FlyoutContext } from '~/src/context/FlyoutContext.js'
 import {
   ComponentContext,
   componentReducer,
-  initComponentState,
-  type ComponentContextType
+  initComponentState
 } from '~/src/reducers/component/componentReducer.jsx'
 
 export interface RenderWithContextProps {
   children?: ReactElement
-  state?: Omit<ComponentContextType['state'], 'initialName'>
+  state?: Parameters<typeof initComponentState>[0]
   data?: DataContextType['data']
   meta?: DataContextType['meta']
   save?: DataContextType['save']


### PR DESCRIPTION
Quick PR to initialise (and reset) `errors` state when necessary

It was possible to submit the "Create list" form with errors, switch to "Edit list", and they were persisted