### PR TITLE
Review dispatch events + payload types

### DIFF
--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -24,7 +24,7 @@ export function ComponentEdit(props) {
     e?.preventDefault()
 
     if (!hasValidated) {
-      dispatch({ type: Meta.VALIDATE })
+      dispatch({ name: Meta.VALIDATE })
       return
     }
 

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -52,8 +52,9 @@ export function FieldEdit() {
           value={selectedComponent.title}
           onChange={(e: ChangeEvent<HTMLInputElement>) => {
             dispatch({
-              type: Fields.EDIT_TITLE,
-              payload: e.target.value
+              name: Fields.EDIT_TITLE,
+              payload: e.target.value,
+              as: selectedComponent
             })
           }}
           errorMessage={errors.title}
@@ -75,8 +76,9 @@ export function FieldEdit() {
           value={selectedComponent.hint}
           onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
             dispatch({
-              type: Fields.EDIT_HELP,
-              payload: e.target.value
+              name: Fields.EDIT_HELP,
+              payload: e.target.value,
+              as: selectedComponent
             })
           }}
         />
@@ -93,8 +95,9 @@ export function FieldEdit() {
               checked={!!selectedComponent.options.hideTitle}
               onChange={(e) =>
                 dispatch({
-                  type: Options.EDIT_OPTIONS_HIDE_TITLE,
-                  payload: e.target.checked
+                  name: Options.EDIT_OPTIONS_HIDE_TITLE,
+                  payload: e.target.checked,
+                  as: selectedComponent
                 })
               }
             />
@@ -146,7 +149,7 @@ export function FieldEdit() {
               value={selectedComponent.name}
               onChange={(e) => {
                 dispatch({
-                  type: Fields.EDIT_NAME,
+                  name: Fields.EDIT_NAME,
                   payload: e.target.value
                 })
               }}
@@ -163,8 +166,9 @@ export function FieldEdit() {
                 checked={!isRequired}
                 onChange={(e) =>
                   dispatch({
-                    type: Options.EDIT_OPTIONS_REQUIRED,
-                    payload: !e.target.checked
+                    name: Options.EDIT_OPTIONS_REQUIRED,
+                    payload: !e.target.checked,
+                    as: selectedComponent
                   })
                 }
               />
@@ -199,8 +203,9 @@ export function FieldEdit() {
                 checked={!!selectedComponent.options.optionalText}
                 onChange={(e) =>
                   dispatch({
-                    type: Options.EDIT_OPTIONS_HIDE_OPTIONAL,
-                    payload: e.target.checked
+                    name: Options.EDIT_OPTIONS_HIDE_OPTIONAL,
+                    payload: e.target.checked,
+                    as: selectedComponent
                   })
                 }
               />

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -158,7 +158,7 @@ export class LinkEdit extends Component<Props, State> {
     )
   }
 
-  conditionSelected = (selectedCondition: string) => {
+  conditionSelected = (selectedCondition?: string) => {
     this.setState({
       selectedCondition
     })

--- a/designer/client/src/MultilineTextFieldEdit.enzyme.test.tsx
+++ b/designer/client/src/MultilineTextFieldEdit.enzyme.test.tsx
@@ -33,7 +33,7 @@ describe('MutlilineTextFieldEdit renders correctly when', () => {
   test('schema rows changes', () => {
     const field = () => wrapper.find('#field-options-rows')
     const newRows = 42
-    field().simulate('change', { target: { value: newRows } })
+    field().simulate('change', { target: { valueAsNumber: newRows } })
     expect(field().props().value).toBe(newRows)
   })
 })

--- a/designer/client/src/MultilineTextFieldEdit.tsx
+++ b/designer/client/src/MultilineTextFieldEdit.tsx
@@ -38,8 +38,9 @@ export function MultilineTextFieldEdit({ context = ComponentContext }) {
           type="number"
           onChange={(e) =>
             dispatch({
-              type: Options.EDIT_OPTIONS_MAX_WORDS,
-              payload: e.target.value
+              name: Options.EDIT_OPTIONS_MAX_WORDS,
+              payload: e.target.valueAsNumber,
+              as: selectedComponent
             })
           }
         />
@@ -65,8 +66,9 @@ export function MultilineTextFieldEdit({ context = ComponentContext }) {
           value={options.rows}
           onChange={(e) =>
             dispatch({
-              type: Options.EDIT_OPTIONS_ROWS,
-              payload: e.target.value
+              name: Options.EDIT_OPTIONS_ROWS,
+              payload: e.target.valueAsNumber,
+              as: selectedComponent
             })
           }
         />

--- a/designer/client/src/components/Autocomplete/Autocomplete.tsx
+++ b/designer/client/src/components/Autocomplete/Autocomplete.tsx
@@ -40,8 +40,9 @@ export function Autocomplete() {
         value={options.autocomplete}
         onChange={(e) =>
           dispatch({
-            type: Options.EDIT_OPTIONS_AUTOCOMPLETE,
-            payload: e.target.value
+            name: Options.EDIT_OPTIONS_AUTOCOMPLETE,
+            payload: e.target.value,
+            as: selectedComponent
           })
         }
       />

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -68,7 +68,7 @@ function useComponentCreate(props) {
     e?.preventDefault()
 
     if (!hasValidated) {
-      dispatch({ type: Meta.VALIDATE })
+      dispatch({ name: Meta.VALIDATE })
       return
     }
 
@@ -93,7 +93,7 @@ function useComponentCreate(props) {
    */
   function handleCreate(component: ComponentDef) {
     dispatch({
-      type: Meta.NEW_COMPONENT,
+      name: Meta.NEW_COMPONENT,
       payload: {
         ...component,
         name: randomId()
@@ -103,7 +103,7 @@ function useComponentCreate(props) {
 
   function reset(e: MouseEvent<HTMLAnchorElement>) {
     e.preventDefault()
-    dispatch({ type: Meta.SET_COMPONENT })
+    dispatch({ name: Meta.SET_COMPONENT })
   }
 
   return {

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -50,7 +50,7 @@ export function ComponentListSelect() {
     try {
       const [foundList] = findList(data, list)
       listDispatch({
-        type: ListActions.SET_SELECTED_LIST,
+        name: ListActions.SET_SELECTED_LIST,
         payload: foundList
       })
     } catch (error) {
@@ -65,30 +65,45 @@ export function ComponentListSelect() {
   useEffect(() => {
     if (!listsEditorState.isEditingList && isAddingNew) {
       dispatch({
-        type: Meta.SET_SELECTED_LIST,
-        payload: selectedList?.name
+        name: Meta.SET_SELECTED_LIST,
+        payload: selectedList?.name,
+        as: selectedComponent
       })
+
       setIsAddingNew(false)
     }
   }, [listsEditorState.isEditingList, selectedList?.name, isAddingNew])
 
   const editList = (e: ChangeEvent<HTMLSelectElement>) => {
     dispatch({
-      type: Meta.SET_SELECTED_LIST,
-      payload: e.target.value
+      name: Meta.SET_SELECTED_LIST,
+      payload: e.target.value,
+      as: selectedComponent
     })
   }
 
   const handleEditListClick = (e: MouseEvent) => {
     e.preventDefault()
-    listsEditorDispatch([ListsEditorStateActions.IS_EDITING_LIST, true])
+
+    listsEditorDispatch({
+      name: ListsEditorStateActions.IS_EDITING_LIST,
+      payload: true
+    })
   }
 
   const handleAddListClick = (e: MouseEvent) => {
     e.preventDefault()
+
     setIsAddingNew(true)
-    listDispatch({ type: ListActions.ADD_NEW_LIST })
-    listsEditorDispatch([ListsEditorStateActions.IS_EDITING_LIST, true])
+
+    listDispatch({
+      name: ListActions.ADD_NEW_LIST
+    })
+
+    listsEditorDispatch({
+      name: ListsEditorStateActions.IS_EDITING_LIST,
+      payload: true
+    })
   }
 
   return (

--- a/designer/client/src/components/CssClasses/CssClasses.tsx
+++ b/designer/client/src/components/CssClasses/CssClasses.tsx
@@ -41,8 +41,9 @@ export function CssClasses() {
         value={options.classes}
         onChange={(e) =>
           dispatch({
-            type: Options.EDIT_OPTIONS_CLASSES,
-            payload: e.target.value
+            name: Options.EDIT_OPTIONS_CLASSES,
+            payload: e.target.value,
+            as: selectedComponent
           })
         }
       />

--- a/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.tsx
+++ b/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.tsx
@@ -47,8 +47,9 @@ export function CustomValidationMessage() {
         value={options.customValidationMessage}
         onChange={(e) =>
           dispatch({
-            type: Options.EDIT_OPTIONS_CUSTOM_MESSAGE,
-            payload: e.target.value
+            name: Options.EDIT_OPTIONS_CUSTOM_MESSAGE,
+            payload: e.target.value,
+            as: selectedComponent
           })
         }
       />

--- a/designer/client/src/components/FieldEditors/ConditionEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ConditionEdit.tsx
@@ -39,8 +39,9 @@ export function ConditionEdit({ context = ComponentContext }: Props) {
         value={options.condition}
         onChange={(e) =>
           dispatch({
-            type: Options.EDIT_OPTIONS_CONDITION,
-            payload: e.target.value
+            name: Options.EDIT_OPTIONS_CONDITION,
+            payload: e.target.value,
+            as: selectedComponent
           })
         }
       >

--- a/designer/client/src/components/FieldEditors/ContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ContentEdit.tsx
@@ -52,8 +52,9 @@ export function ContentEdit({ context = ComponentContext }: Props) {
         value={selectedComponent.content}
         onValueChange={(content) => {
           dispatch({
-            type: Fields.EDIT_CONTENT,
-            payload: content
+            name: Fields.EDIT_CONTENT,
+            payload: content,
+            as: selectedComponent
           })
         }}
       />

--- a/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
@@ -54,8 +54,9 @@ export function DateFieldEdit({ context = ComponentContext }: Props) {
             type="number"
             onChange={(e) =>
               dispatch({
-                type: Options.EDIT_OPTIONS_MAX_DAYS_IN_PAST,
-                payload: e.target.value
+                name: Options.EDIT_OPTIONS_MAX_DAYS_IN_PAST,
+                payload: e.target.valueAsNumber,
+                as: selectedComponent
               })
             }
           />
@@ -81,8 +82,9 @@ export function DateFieldEdit({ context = ComponentContext }: Props) {
             type="number"
             onChange={(e) =>
               dispatch({
-                type: Options.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE,
-                payload: e.target.value
+                name: Options.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE,
+                payload: e.target.valueAsNumber,
+                as: selectedComponent
               })
             }
           />

--- a/designer/client/src/components/FieldEditors/ListContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.tsx
@@ -54,8 +54,9 @@ export function ListContentEdit({ context = ComponentContext }: Props) {
                       }
                       onClick={() => {
                         dispatch({
-                          type: Options.EDIT_OPTIONS_TYPE,
-                          payload: bullet
+                          name: Options.EDIT_OPTIONS_TYPE,
+                          payload: bullet,
+                          as: selectedComponent
                         })
                       }}
                     />

--- a/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
@@ -49,8 +49,9 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
             type="number"
             onChange={(e) =>
               dispatch({
-                type: Schema.EDIT_SCHEMA_MIN,
-                payload: e.target.value
+                name: Schema.EDIT_SCHEMA_MIN,
+                payload: e.target.valueAsNumber,
+                as: selectedComponent
               })
             }
           />
@@ -76,8 +77,9 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
             type="string"
             onBlur={(e) =>
               dispatch({
-                type: Options.EDIT_OPTIONS_PREFIX,
-                payload: e.target.value
+                name: Options.EDIT_OPTIONS_PREFIX,
+                payload: e.target.value,
+                as: selectedComponent
               })
             }
           />
@@ -103,8 +105,9 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
             type="string"
             onBlur={(e) =>
               dispatch({
-                type: Options.EDIT_OPTIONS_SUFFIX,
-                payload: e.target.value
+                name: Options.EDIT_OPTIONS_SUFFIX,
+                payload: e.target.value,
+                as: selectedComponent
               })
             }
           />
@@ -130,8 +133,9 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
             type="number"
             onBlur={(e) =>
               dispatch({
-                type: Schema.EDIT_SCHEMA_MAX,
-                payload: e.target.value
+                name: Schema.EDIT_SCHEMA_MAX,
+                payload: e.target.valueAsNumber,
+                as: selectedComponent
               })
             }
           />
@@ -157,8 +161,9 @@ export function NumberFieldEdit({ context = ComponentContext }: Props) {
             type="number"
             onBlur={(e) =>
               dispatch({
-                type: Schema.EDIT_SCHEMA_PRECISION,
-                payload: e.target.value
+                name: Schema.EDIT_SCHEMA_PRECISION,
+                payload: e.target.valueAsNumber,
+                as: selectedComponent
               })
             }
           />

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.enzyme.test.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.enzyme.test.tsx
@@ -33,21 +33,21 @@ describe('TextField renders correctly when', () => {
   test('schema length changes', () => {
     const field = () => wrapper.find('#field-schema-length').first()
     const length = 1337
-    field().simulate('change', { target: { value: length } })
+    field().simulate('change', { target: { valueAsNumber: length } })
     expect(field().props().value).toBe(length)
   })
 
   test('schema min length changes', () => {
     const field = () => wrapper.find('#field-schema-min').first()
     const length = 42
-    field().simulate('change', { target: { value: length } })
+    field().simulate('change', { target: { valueAsNumber: length } })
     expect(field().props().value).toBe(length)
   })
 
   test('schema max length changes', () => {
     const field = () => wrapper.find('#field-schema-max').first()
     const length = 42
-    field().simulate('change', { target: { value: length } })
+    field().simulate('change', { target: { valueAsNumber: length } })
     expect(field().props().value).toBe(length)
   })
 

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -63,8 +63,9 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
                 type="number"
                 onChange={(e) =>
                   dispatch({
-                    type: Schema.EDIT_SCHEMA_MIN,
-                    payload: e.target.value
+                    name: Schema.EDIT_SCHEMA_MIN,
+                    payload: e.target.valueAsNumber,
+                    as: selectedComponent
                   })
                 }
               />
@@ -90,8 +91,9 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
                 type="number"
                 onChange={(e) =>
                   dispatch({
-                    type: Schema.EDIT_SCHEMA_MAX,
-                    payload: e.target.value
+                    name: Schema.EDIT_SCHEMA_MAX,
+                    payload: e.target.valueAsNumber,
+                    as: selectedComponent
                   })
                 }
               />
@@ -117,8 +119,9 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
                 type="number"
                 onChange={(e) =>
                   dispatch({
-                    type: Schema.EDIT_SCHEMA_LENGTH,
-                    payload: e.target.value
+                    name: Schema.EDIT_SCHEMA_LENGTH,
+                    payload: e.target.valueAsNumber,
+                    as: selectedComponent
                   })
                 }
               />
@@ -147,8 +150,9 @@ export function TextFieldEdit({ children, context = ComponentContext }: Props) {
               value={selectedComponent.schema.regex}
               onChange={(e) =>
                 dispatch({
-                  type: Schema.EDIT_SCHEMA_REGEX,
-                  payload: e.target.value
+                  name: Schema.EDIT_SCHEMA_REGEX,
+                  payload: e.target.value,
+                  as: selectedComponent
                 })
               }
             />

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -31,7 +31,7 @@ import { i18n } from '~/src/i18n/i18n.jsx'
 export interface Props {
   path?: string
   selectedCondition?: string
-  conditionsChange: (selectedCondition: string) => void
+  conditionsChange: (selectedCondition?: string) => void
   noFieldsHintText?: string
 }
 
@@ -206,7 +206,7 @@ export class SelectConditions extends Component<Props, State> {
   setState(state: State, callback?: () => void) {
     const { conditionsChange } = this.props
 
-    conditionsChange(state.selectedCondition ?? '')
+    conditionsChange(state.selectedCondition)
     super.setState(state, callback)
   }
 

--- a/designer/client/src/hooks/list/useListItem/useListItem.tsx
+++ b/designer/client/src/hooks/list/useListItem/useListItem.tsx
@@ -21,28 +21,28 @@ export function useListItem(
 
   const handleTitleChange: ListItemHook['handleTitleChange'] = (e) => {
     dispatch({
-      type: ListActions.EDIT_LIST_ITEM_TEXT,
+      name: ListActions.EDIT_LIST_ITEM_TEXT,
       payload: e.target.value
     })
   }
 
   const handleConditionChange: ListItemHook['handleConditionChange'] = (e) => {
     dispatch({
-      type: ListActions.EDIT_LIST_ITEM_CONDITION,
+      name: ListActions.EDIT_LIST_ITEM_CONDITION,
       payload: e.target.value
     })
   }
 
   const handleValueChange: ListItemHook['handleValueChange'] = (e) => {
     dispatch({
-      type: ListActions.EDIT_LIST_ITEM_VALUE,
+      name: ListActions.EDIT_LIST_ITEM_VALUE,
       payload: e.target.value
     })
   }
 
   const handleHintChange: ListItemHook['handleHintChange'] = (e) => {
     dispatch({
-      type: ListActions.EDIT_LIST_ITEM_DESCRIPTION,
+      name: ListActions.EDIT_LIST_ITEM_DESCRIPTION,
       payload: e.target.value
     })
   }
@@ -61,7 +61,7 @@ export function useListItem(
     })
 
     dispatch({
-      type: ListActions.LIST_ITEM_VALIDATION_ERRORS,
+      name: ListActions.LIST_ITEM_VALIDATION_ERRORS,
       payload: errors
     })
 

--- a/designer/client/src/list/ListItemEdit.tsx
+++ b/designer/client/src/list/ListItemEdit.tsx
@@ -51,7 +51,11 @@ export function ListItemEdit() {
 
     const copy = { ...data }
     await save(prepareForSubmit(copy))
-    listsEditorDispatch([ListsEditorStateActions.IS_EDITING_LIST_ITEM, false])
+
+    listsEditorDispatch({
+      name: ListsEditorStateActions.IS_EDITING_LIST_ITEM,
+      payload: false
+    })
   }
 
   return (

--- a/designer/client/src/list/ListItems.tsx
+++ b/designer/client/src/list/ListItems.tsx
@@ -1,4 +1,4 @@
-import { clone } from '@defra/forms-model'
+import { clone, type Item } from '@defra/forms-model'
 import React, { useContext } from 'react'
 
 import { DataContext } from '~/src/context/DataContext.js'
@@ -50,9 +50,16 @@ export function ListItems() {
   const { data, save } = useContext(DataContext)
   const { state, dispatch } = useContext(ListContext)
 
-  const selectListItem = (payload) => {
-    dispatch({ type: ListActions.EDIT_LIST_ITEM, payload })
-    listsEditorDispatch([ListsEditorStateActions.IS_EDITING_LIST_ITEM, true])
+  const selectListItem = (payload: Item) => {
+    dispatch({
+      name: ListActions.EDIT_LIST_ITEM,
+      payload
+    })
+
+    listsEditorDispatch({
+      name: ListsEditorStateActions.IS_EDITING_LIST_ITEM,
+      payload: true
+    })
   }
 
   const { prepareForDelete } = useListItem(state, dispatch)

--- a/designer/client/src/list/ListSelect.tsx
+++ b/designer/client/src/list/ListSelect.tsx
@@ -16,11 +16,16 @@ export function ListSelect() {
 
   const editList = (e, list) => {
     e.preventDefault()
+
     listDispatch({
-      type: ListActions.SET_SELECTED_LIST,
+      name: ListActions.SET_SELECTED_LIST,
       payload: list
     })
-    listsEditorDispatch([ListsEditorStateActions.IS_EDITING_LIST, true])
+
+    listsEditorDispatch({
+      name: ListsEditorStateActions.IS_EDITING_LIST,
+      payload: true
+    })
   }
 
   return (
@@ -47,8 +52,15 @@ export function ListSelect() {
           type="button"
           onClick={(e) => {
             e.preventDefault()
-            listDispatch({ type: ListActions.ADD_NEW_LIST })
-            listsEditorDispatch([ListsEditorStateActions.IS_EDITING_LIST, true])
+
+            listDispatch({
+              name: ListActions.ADD_NEW_LIST
+            })
+
+            listsEditorDispatch({
+              name: ListsEditorStateActions.IS_EDITING_LIST,
+              payload: true
+            })
           }}
         >
           {i18n('list.newTitle')}

--- a/designer/client/src/list/ListsEdit.tsx
+++ b/designer/client/src/list/ListsEdit.tsx
@@ -23,8 +23,8 @@ const useListsEdit = () => {
   const { state } = useContext(ListContext)
   const { selectedList, selectedItem } = state
 
-  const closeFlyout = (action: ListsEditorStateActions) => {
-    return () => listsEditorDispatch([action, false])
+  const closeFlyout = (type: ListsEditorStateActions) => {
+    return () => listsEditorDispatch({ name: type, payload: false })
   }
 
   const listTitle = selectedList?.isNew

--- a/designer/client/src/reducers/component/componentReducer.meta.ts
+++ b/designer/client/src/reducers/component/componentReducer.meta.ts
@@ -1,37 +1,61 @@
-import { type ComponentState } from '~/src/reducers/component/componentReducer.jsx'
-import { validateComponent } from '~/src/reducers/component/componentReducer.validations.js'
+import { type ComponentDef } from '@defra/forms-model'
+
+import {
+  type ComponentState,
+  type ReducerActions
+} from '~/src/reducers/component/componentReducer.jsx'
+import { fieldComponentValidations } from '~/src/reducers/component/componentReducer.validations.js'
 import { Meta } from '~/src/reducers/component/types.js'
 
-export function metaReducer(
-  state: ComponentState,
-  action: {
-    type: Meta
-    payload?: unknown
-  }
-): ComponentState {
-  const { type, payload } = action
-  const { selectedComponent } = state
+export type MetaReducerActions =
+  | {
+      name: Meta.NEW_COMPONENT
+      payload: ComponentDef
+      as?: undefined
+    }
+  | {
+      name: Meta.SET_COMPONENT | Meta.VALIDATE
+      payload?: undefined
+      as?: undefined
+    }
+  | {
+      name: Meta.SET_SELECTED_LIST
+      payload?: string
+      as: Extract<ComponentDef, { list: string }>
+    }
 
-  switch (type) {
-    case Meta.SET_SELECTED_LIST:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          list: payload
-        }
-      }
+export function metaReducer(state: ComponentState, action: ReducerActions) {
+  const stateNew = structuredClone(state)
 
+  const { selectedComponent } = stateNew
+  const { as, name, payload } = action
+
+  // Require validation on every meta change
+  stateNew.hasValidated = false
+
+  switch (name) {
     case Meta.NEW_COMPONENT:
-      return { ...state, selectedComponent: payload }
+      stateNew.selectedComponent = payload
+      break
 
     case Meta.SET_COMPONENT:
-      return { ...state, selectedComponent: payload, errors: {} }
+      stateNew.selectedComponent = undefined
+      stateNew.errors = {}
+      break
 
     case Meta.VALIDATE:
-      return {
-        ...state,
-        ...validateComponent(selectedComponent)
+      stateNew.errors = fieldComponentValidations(selectedComponent)
+      stateNew.hasValidated = true
+      break
+
+    case Meta.SET_SELECTED_LIST: {
+      if (selectedComponent?.type === as.type) {
+        selectedComponent.list = payload ?? ''
       }
+
+      break
+    }
   }
+
+  return stateNew
 }

--- a/designer/client/src/reducers/component/componentReducer.options.ts
+++ b/designer/client/src/reducers/component/componentReducer.options.ts
@@ -1,121 +1,220 @@
-import { type ComponentState } from '~/src/reducers/component/componentReducer.jsx'
+import {
+  type ComponentDef,
+  type ListTypeOption,
+  type ListTypeContent
+} from '@defra/forms-model'
+
+import {
+  type ComponentState,
+  type ReducerActions
+} from '~/src/reducers/component/componentReducer.jsx'
 import { Options } from '~/src/reducers/component/types.js'
 
-export function optionsReducer(
-  state: ComponentState,
-  action: {
-    type: Options
-    payload?: unknown
+export type OptionsReducerActions =
+  | {
+      name: Options.EDIT_OPTIONS_HIDE_TITLE
+      payload?: boolean
+      as: Extract<ComponentDef, { options: { hideTitle?: boolean } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_REQUIRED
+      payload?: boolean
+      as: Extract<ComponentDef, { options: { required?: boolean } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_HIDE_OPTIONAL
+      payload?: boolean
+      as: Extract<ComponentDef, { options: { optionalText?: boolean } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_ROWS
+      payload?: number
+      as: Extract<ComponentDef, { options: { rows?: number } }>
+    }
+  | {
+      name:
+        | Options.EDIT_OPTIONS_MAX_DAYS_IN_PAST
+        | Options.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE
+      payload?: number
+      as: Extract<
+        ComponentDef,
+        { options: { maxDaysInPast?: number; maxDaysInFuture?: number } }
+      >
+    }
+  | {
+      name: Options.EDIT_OPTIONS_MAX_WORDS
+      payload?: number
+      as: Extract<ComponentDef, { options: { maxWords?: number } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_CLASSES
+      payload?: string
+      as: Extract<ComponentDef, { options: { classes?: string } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_CONDITION
+      payload?: string
+      as: Extract<ComponentDef, { options: { condition?: string } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_TYPE
+      payload?: ListTypeContent
+      as: Extract<ComponentDef, { options: { type?: ListTypeContent } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_TYPE
+      payload?: ListTypeOption
+      as: Extract<ComponentDef, { options: { type?: ListTypeOption } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_AUTOCOMPLETE
+      payload?: string
+      as: Extract<ComponentDef, { options: { autocomplete?: string } }>
+    }
+  | {
+      name: Options.EDIT_OPTIONS_PREFIX | Options.EDIT_OPTIONS_SUFFIX
+      payload?: string
+      as: Extract<
+        ComponentDef,
+        { options: { prefix?: string; suffix?: string } }
+      >
+    }
+  | {
+      name: Options.EDIT_OPTIONS_CUSTOM_MESSAGE
+      payload?: string
+      as: Extract<
+        ComponentDef,
+        { options: { customValidationMessage?: string } }
+      >
+    }
+
+export function optionsReducer(state: ComponentState, action: ReducerActions) {
+  const stateNew = structuredClone(state)
+  const { selectedComponent } = stateNew
+
+  if (!selectedComponent) {
+    throw new Error('No component selected')
   }
-): ComponentState {
-  const { type, payload } = action
-  const { selectedComponent } = state
-  const { options = {} } = selectedComponent ?? {}
 
-  switch (type) {
-    case Options.EDIT_OPTIONS_HIDE_TITLE:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, hideTitle: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_REQUIRED:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, required: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_ROWS:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, rows: payload }
-        }
+  const { as, name, payload } = action
+  const { type } = selectedComponent
+
+  // Require validation on every option change
+  stateNew.hasValidated = false
+
+  switch (name) {
+    case Options.EDIT_OPTIONS_HIDE_TITLE: {
+      if (type === as.type) {
+        selectedComponent.options.hideTitle = payload
       }
 
-    case Options.EDIT_OPTIONS_HIDE_OPTIONAL:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, optionalText: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_CLASSES:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, classes: payload }
-        }
+      break
+    }
+
+    case Options.EDIT_OPTIONS_REQUIRED: {
+      if (type === as.type) {
+        selectedComponent.options.required = payload
       }
 
-    case Options.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, maxDaysInFuture: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_MAX_DAYS_IN_PAST:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, maxDaysInPast: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_CONDITION:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, condition: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_TYPE:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, type: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_AUTOCOMPLETE:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, autocomplete: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_PREFIX:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, prefix: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_SUFFIX:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, suffix: payload }
-        }
-      }
-    case Options.EDIT_OPTIONS_CUSTOM_MESSAGE:
-      return {
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, customValidationMessage: payload }
-        }
+      break
+    }
+
+    case Options.EDIT_OPTIONS_HIDE_OPTIONAL: {
+      if (type === as.type) {
+        selectedComponent.options.optionalText = payload
       }
 
-    case Options.EDIT_OPTIONS_MAX_WORDS:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          options: { ...options, maxWords: payload }
-        }
+      break
+    }
+
+    case Options.EDIT_OPTIONS_ROWS: {
+      if (type === as.type) {
+        selectedComponent.options.rows = payload
       }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_MAX_DAYS_IN_PAST: {
+      if (type === as.type) {
+        selectedComponent.options.maxDaysInPast = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_MAX_DAYS_IN_FUTURE: {
+      if (type === as.type) {
+        selectedComponent.options.maxDaysInFuture = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_MAX_WORDS: {
+      if (type === as.type) {
+        selectedComponent.options.maxWords = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_CLASSES: {
+      if (type === as.type) {
+        selectedComponent.options.classes = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_CONDITION: {
+      if (type === as.type) {
+        selectedComponent.options.condition = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_TYPE: {
+      if (type === as.type) {
+        selectedComponent.options.type = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_AUTOCOMPLETE: {
+      if (type === as.type) {
+        selectedComponent.options.autocomplete = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_PREFIX: {
+      if (type === as.type) {
+        selectedComponent.options.prefix = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_SUFFIX: {
+      if (type === as.type) {
+        selectedComponent.options.suffix = payload
+      }
+
+      break
+    }
+
+    case Options.EDIT_OPTIONS_CUSTOM_MESSAGE: {
+      if (type === as.type) {
+        selectedComponent.options.customValidationMessage = payload
+      }
+
+      break
+    }
   }
+
+  return stateNew
 }

--- a/designer/client/src/reducers/component/componentReducer.schema.ts
+++ b/designer/client/src/reducers/component/componentReducer.schema.ts
@@ -1,63 +1,88 @@
-import { type ComponentState } from '~/src/reducers/component/componentReducer.jsx'
+import { type ComponentDef } from '@defra/forms-model'
+
+import {
+  type ComponentState,
+  type ReducerActions
+} from '~/src/reducers/component/componentReducer.jsx'
 import { Schema } from '~/src/reducers/component/types.js'
 
-export function schemaReducer(
-  state: ComponentState,
-  action: {
-    type: Schema
-    payload?: unknown
+export type SchemaReducerActions =
+  | {
+      name: Schema.EDIT_SCHEMA_MIN | Schema.EDIT_SCHEMA_MAX
+      payload?: number
+      as: Extract<ComponentDef, { schema: { min?: number; max?: number } }>
+    }
+  | {
+      name: Schema.EDIT_SCHEMA_PRECISION
+      payload?: number
+      as: Extract<ComponentDef, { schema: { precision?: number } }>
+    }
+  | {
+      name: Schema.EDIT_SCHEMA_LENGTH
+      payload?: number
+      as: Extract<ComponentDef, { schema: { length?: number } }>
+    }
+  | {
+      name: Schema.EDIT_SCHEMA_REGEX
+      payload?: string
+      as: Extract<ComponentDef, { schema: { regex?: string } }>
+    }
+
+export function schemaReducer(state: ComponentState, action: ReducerActions) {
+  const stateNew = structuredClone(state)
+  const { selectedComponent } = stateNew
+
+  if (!selectedComponent) {
+    throw new Error('No component selected')
   }
-): ComponentState {
-  const { type, payload } = action
-  const { selectedComponent } = state
 
-  const { schema } = selectedComponent ?? {}
+  const { as, name, payload } = action
+  const { type } = selectedComponent
 
-  switch (type) {
-    case Schema.EDIT_SCHEMA_MIN:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          schema: {
-            ...schema,
-            min: payload
-          }
-        }
+  // Require validation on every schema change
+  stateNew.hasValidated = false
+
+  switch (name) {
+    case Schema.EDIT_SCHEMA_MIN: {
+      if (type === as.type) {
+        selectedComponent.schema.min = payload
       }
 
-    case Schema.EDIT_SCHEMA_MAX:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          schema: { ...schema, max: payload }
-        }
+      break
+    }
+
+    case Schema.EDIT_SCHEMA_MAX: {
+      if (type === as.type) {
+        selectedComponent.schema.max = payload
       }
 
-    case Schema.EDIT_SCHEMA_PRECISION:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          schema: { ...schema, precision: payload }
-        }
+      break
+    }
+
+    case Schema.EDIT_SCHEMA_PRECISION: {
+      if (type === as.type) {
+        selectedComponent.schema.precision = payload
       }
-    case Schema.EDIT_SCHEMA_LENGTH:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          schema: { ...schema, length: payload }
-        }
+
+      break
+    }
+
+    case Schema.EDIT_SCHEMA_LENGTH: {
+      if (type === as.type) {
+        selectedComponent.schema.length = payload
       }
-    case Schema.EDIT_SCHEMA_REGEX:
-      return {
-        ...state,
-        selectedComponent: {
-          ...selectedComponent,
-          schema: { ...schema, regex: payload }
-        }
+
+      break
+    }
+
+    case Schema.EDIT_SCHEMA_REGEX: {
+      if (type === as.type) {
+        selectedComponent.schema.regex = payload
       }
+
+      break
+    }
   }
+
+  return stateNew
 }

--- a/designer/client/src/reducers/component/componentReducer.test.tsx
+++ b/designer/client/src/reducers/component/componentReducer.test.tsx
@@ -4,7 +4,8 @@ import { fieldsReducer } from '~/src/reducers/component/componentReducer.fields.
 import {
   componentReducer,
   getSubReducer,
-  type ComponentState
+  type ComponentState,
+  type ReducerActions
 } from '~/src/reducers/component/componentReducer.jsx'
 import { metaReducer } from '~/src/reducers/component/componentReducer.meta.js'
 import { optionsReducer } from '~/src/reducers/component/componentReducer.options.js'
@@ -17,19 +18,44 @@ import {
 } from '~/src/reducers/component/types.js'
 
 describe('Component reducer', () => {
-  const component: ComponentDef = {
-    name: 'field',
-    title: 'Title',
+  const component1: ComponentDef = {
+    name: 'field1',
+    title: 'Text field',
     type: ComponentType.TextField,
     options: {},
     schema: {}
   }
 
+  const component2: ComponentDef = {
+    name: 'field2',
+    title: 'UK address field',
+    type: ComponentType.UkAddressField,
+    options: {}
+  }
+
   test('getSubReducer returns correct reducer', () => {
-    const metaAction = Meta.NEW_COMPONENT
-    const schemaAction = Schema.EDIT_SCHEMA_MIN
-    const fieldsAction = Fields.EDIT_TITLE
-    const optionsAction = Options.EDIT_OPTIONS_HIDE_TITLE
+    const metaAction: ReducerActions = {
+      name: Meta.NEW_COMPONENT,
+      payload: component1
+    }
+
+    const schemaAction: ReducerActions = {
+      name: Schema.EDIT_SCHEMA_MIN,
+      payload: 2,
+      as: component1
+    }
+
+    const optionsAction: ReducerActions = {
+      name: Options.EDIT_OPTIONS_HIDE_TITLE,
+      payload: true,
+      as: component2
+    }
+
+    const fieldsAction: ReducerActions = {
+      name: Fields.EDIT_TITLE,
+      payload: 'Updated title',
+      as: component2
+    }
 
     expect(getSubReducer(metaAction)).toEqual(metaReducer)
     expect(getSubReducer(schemaAction)).toEqual(schemaReducer)
@@ -40,38 +66,42 @@ describe('Component reducer', () => {
   test('componentReducer sets hasValidated: false', () => {
     const title = 'Updated title'
 
-    const action = {
-      type: Fields.EDIT_TITLE,
-      payload: title
+    const action: ReducerActions = {
+      name: Fields.EDIT_TITLE,
+      payload: title,
+      as: component1
     }
 
     const state: ComponentState = {
-      initialName: component.name,
-      selectedComponent: component,
-      hasValidated: true
+      initialName: component1.name,
+      selectedComponent: component1,
+      hasValidated: true,
+      errors: {}
     }
 
     expect(componentReducer(state, action)).toEqual({
-      initialName: component.name,
-      selectedComponent: { ...component, title },
+      initialName: component1.name,
+      selectedComponent: { ...component1, title },
+      errors: expect.any(Object),
       hasValidated: false
     })
   })
 
   test('componentReducer sets hasValidated: true', () => {
-    const action = {
-      type: Meta.VALIDATE
+    const action: ReducerActions = {
+      name: Meta.VALIDATE
     }
 
     const state: ComponentState = {
-      initialName: component.name,
-      selectedComponent: component,
-      hasValidated: false
+      initialName: component1.name,
+      selectedComponent: component1,
+      hasValidated: false,
+      errors: {}
     }
 
     expect(componentReducer(state, action)).toEqual({
-      initialName: component.name,
-      selectedComponent: component,
+      initialName: component1.name,
+      selectedComponent: component1,
       errors: expect.any(Object),
       hasValidated: true
     })

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -9,16 +9,27 @@ import React, {
 import { type ErrorList } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import randomId from '~/src/randomId.js'
-import { fieldsReducer } from '~/src/reducers/component/componentReducer.fields.js'
-import { metaReducer } from '~/src/reducers/component/componentReducer.meta.js'
-import { optionsReducer } from '~/src/reducers/component/componentReducer.options.js'
-import { schemaReducer } from '~/src/reducers/component/componentReducer.schema.js'
+import {
+  fieldsReducer,
+  type FieldsReducerActions
+} from '~/src/reducers/component/componentReducer.fields.js'
+import {
+  metaReducer,
+  type MetaReducerActions
+} from '~/src/reducers/component/componentReducer.meta.js'
+import {
+  optionsReducer,
+  type OptionsReducerActions
+} from '~/src/reducers/component/componentReducer.options.js'
+import {
+  schemaReducer,
+  type SchemaReducerActions
+} from '~/src/reducers/component/componentReducer.schema.js'
 import {
   Fields,
   Meta,
   Options,
   Schema,
-  type Action,
   type Actions
 } from '~/src/reducers/component/types.js'
 
@@ -31,10 +42,10 @@ export interface ComponentState {
 }
 
 export type ReducerActions =
-  | Parameters<typeof metaReducer>[1]
-  | Parameters<typeof optionsReducer>[1]
-  | Parameters<typeof fieldsReducer>[1]
-  | Parameters<typeof schemaReducer>[1]
+  | MetaReducerActions
+  | OptionsReducerActions
+  | FieldsReducerActions
+  | SchemaReducerActions
 
 export interface ComponentContextType {
   state: ComponentState
@@ -59,32 +70,29 @@ const reducerByActionType = [
   [Schema, schemaReducer]
 ] as const
 
-export function valueIsInEnum(type: Action, collection: Actions) {
-  return Object.values(collection).includes(type)
+export function valueIsInEnum<
+  ActionType extends ReducerActions = ReducerActions
+>(action: ActionType, collection: Actions): action is ActionType {
+  return Object.values(collection).includes(action.name)
 }
 
 /**
  * when an enum is passed to getSubReducer, it will return the associated reducer defined in {@link reducerByActionType}
  */
-export function getSubReducer(type: Action) {
-  return reducerByActionType.find((a) => valueIsInEnum(type, a[0]))?.[1]
+export function getSubReducer(action: ReducerActions) {
+  return reducerByActionType.find((a) => valueIsInEnum(action, a[0]))?.[1]
 }
 
 export function componentReducer(
   state: ComponentState,
   action: ReducerActions
 ): ComponentState {
-  const { type } = action
   const { selectedComponent } = state
 
-  if (type !== Meta.VALIDATE) {
-    state.hasValidated = false
-  }
-
-  const subReducer = getSubReducer(type)
+  const subReducer = getSubReducer(action)
 
   if (!subReducer) {
-    logger.warn(`Unrecognised action: ${action.type}`)
+    logger.warn(`Unrecognised action: ${action.name}`)
     return { ...state, selectedComponent }
   }
 

--- a/designer/client/src/reducers/component/componentReducer.validations.ts
+++ b/designer/client/src/reducers/component/componentReducer.validations.ts
@@ -39,10 +39,3 @@ export function fieldComponentValidations(component?: ComponentDef) {
 
   return errors
 }
-
-export function validateComponent(selectedComponent?: ComponentDef) {
-  return {
-    errors: fieldComponentValidations(selectedComponent),
-    hasValidated: true
-  }
-}

--- a/designer/client/src/reducers/list/listsEditorReducer.tsx
+++ b/designer/client/src/reducers/list/listsEditorReducer.tsx
@@ -1,4 +1,9 @@
-import React, { createContext, useReducer, type Dispatch } from 'react'
+import React, {
+  createContext,
+  useReducer,
+  type Dispatch,
+  type ReactNode
+} from 'react'
 
 import { type ListsEdit } from '~/src/list/ListsEdit.jsx'
 
@@ -10,9 +15,6 @@ export enum ListsEditorStateActions {
 export interface ListsEditorState {
   isEditingList: boolean
   isEditingListItem: boolean
-  listTitle?: string
-  listItemTitle?: string
-  initialName?: string
 }
 
 export function initListsEditingState(): ListsEditorState {
@@ -22,9 +24,14 @@ export function initListsEditingState(): ListsEditorState {
   }
 }
 
+export interface ReducerActions {
+  name: ListsEditorStateActions
+  payload: boolean
+}
+
 export interface ListsEditorContextType {
   state: ListsEditorState
-  dispatch: Dispatch<[ListsEditorStateActions, boolean | string]>
+  dispatch: Dispatch<ReducerActions>
 }
 
 export const ListsEditorContext = createContext<ListsEditorContextType>({
@@ -38,20 +45,31 @@ ListsEditorContext.displayName = 'ListsEditorContext'
  * Responsible for which list editing screens should be open in {@link ListsEdit} component.
  */
 export function listsEditorReducer(
-  state,
-  action: [ListsEditorStateActions, boolean | string]
+  state: ListsEditorState,
+  action: ReducerActions
 ): ListsEditorState {
-  const [type, payload] = action
+  const stateNew = structuredClone(state)
 
-  switch (type) {
+  const { name, payload } = action
+
+  switch (name) {
     case ListsEditorStateActions.IS_EDITING_LIST:
-      return { ...state, isEditingList: payload }
+      stateNew.isEditingList = payload
+      break
+
     case ListsEditorStateActions.IS_EDITING_LIST_ITEM:
-      return { ...state, isEditingListItem: payload }
+      stateNew.isEditingListItem = payload
+      break
   }
+
+  return stateNew
 }
 
-export const ListsEditorContextProvider = (props) => {
+interface Props {
+  children: ReactNode
+}
+
+export const ListsEditorContextProvider = (props: Props) => {
   const [state, dispatch] = useReducer(
     listsEditorReducer,
     initListsEditingState()


### PR DESCRIPTION
This PR ensures state reducers always clone state before modification and adds types

We have a few bugs that appear to be caused by `{ ...data }` copying props by references