### PR TITLE
Update link helpers to clone before modifying data

### DIFF
--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -263,8 +263,8 @@ export const Component: FunctionComponent<Props> = (props) => {
   const componentButtonLabel = `${componentFlyoutTitle}${suffix}`
 
   const move = async (oldIndex: number, newIndex: number) => {
-    const copy = { ...data }
-    const [copyPage, index] = findPage(data, page.path)
+    const copy = structuredClone(data)
+    const copyPage = findPage(copy, page.path)
 
     if (!copyPage.components?.length) {
       return false
@@ -279,8 +279,6 @@ export const Component: FunctionComponent<Props> = (props) => {
     }
 
     copyPage.components = arrayMove(copyPage.components, oldIndex, newIndex)
-
-    copy.pages[index] = copyPage
 
     await save(copy)
   }

--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -9,6 +9,7 @@ import { ComponentTypeEdit } from '~/src/ComponentTypeEdit.jsx'
 import { ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { updateComponent } from '~/src/data/component/updateComponent.js'
+import { findPage } from '~/src/data/page/findPage.js'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
 import { Meta } from '~/src/reducers/component/types.js'
 import { hasValidationErrors } from '~/src/validations.js'
@@ -49,12 +50,20 @@ export function ComponentEdit(props) {
       return
     }
 
-    const copy = { ...data }
-    const indexOfPage = copy.pages.findIndex((p) => p.path === page.path)
-    const indexOfComponent = copy.pages[indexOfPage]?.components?.findIndex(
+    const copy = structuredClone(data)
+    const pageEdit = findPage(copy, page.path)
+
+    const { components = [] } = pageEdit
+    const componentIndex = components.findIndex(
       ({ name }) => name === selectedComponent.name
     )
-    copy.pages[indexOfPage].components.splice(indexOfComponent, 1)
+
+    if (componentIndex < 0) {
+      return
+    }
+
+    components.splice(componentIndex, 1)
+
     await save(copy)
     toggleShowEditor()
   }

--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -52,7 +52,7 @@ export function ComponentEdit(props) {
     const copy = { ...data }
     const indexOfPage = copy.pages.findIndex((p) => p.path === page.path)
     const indexOfComponent = copy.pages[indexOfPage]?.components?.findIndex(
-      (component) => component.type === selectedComponent.type
+      ({ name }) => name === selectedComponent.name
     )
     copy.pages[indexOfPage].components.splice(indexOfComponent, 1)
     await save(copy)

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -27,9 +27,8 @@ describe('ComponentTypeEdit', () => {
         {
           title: 'First page',
           path: '/first-page',
-          components: [],
-          controller: 'SummaryPageController',
-          section: 'home'
+          next: [],
+          components: []
         }
       ],
       lists: [

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -29,6 +29,7 @@ describe('Field Edit', () => {
         {
           title: 'First page',
           path: '/first-page',
+          next: [],
           components: [selectedComponent]
         }
       ],

--- a/designer/client/src/LinkCreate.test.tsx
+++ b/designer/client/src/LinkCreate.test.tsx
@@ -17,6 +17,7 @@ const data = {
     {
       title: 'First page',
       path: '/first-page',
+      next: [],
       components: [
         {
           name: 'ukPassport',
@@ -31,13 +32,13 @@ const data = {
     {
       title: 'Second page',
       path: '/second-page',
+      next: [],
       components: []
     },
     {
       title: 'Summary',
       path: '/summary',
-      controller: 'SummaryPageController',
-      components: []
+      controller: 'SummaryPageController'
     }
   ],
   lists: [],
@@ -216,8 +217,8 @@ describe('LinkCreate', () => {
       ])
     )
 
-    await act(() => userEvent.selectOptions($source, '/summary'))
-    await act(() => userEvent.selectOptions($target, '/first-page'))
+    await act(() => userEvent.selectOptions($source, '/first-page'))
+    await act(() => userEvent.selectOptions($target, '/second-page'))
 
     await act(() => userEvent.selectOptions($condition, ''))
     await act(() => userEvent.click($button))
@@ -231,7 +232,10 @@ describe('LinkCreate', () => {
           pages: [
             expect.objectContaining({
               title: 'First page',
-              path: '/first-page'
+              path: '/first-page',
+
+              // Paths are correctly generated
+              next: [{ path: '/second-page' }]
             }),
             expect.objectContaining({
               title: 'Second page',
@@ -239,10 +243,7 @@ describe('LinkCreate', () => {
             }),
             expect.objectContaining({
               title: 'Summary',
-              path: '/summary',
-
-              // Paths are correctly generated
-              next: [{ path: '/first-page' }]
+              path: '/summary'
             })
           ]
         }

--- a/designer/client/src/LinkCreate.tsx
+++ b/designer/client/src/LinkCreate.tsx
@@ -11,6 +11,7 @@ import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { SelectConditions } from '~/src/conditions/SelectConditions.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { addLink } from '~/src/data/page/addLink.js'
+import { findPage } from '~/src/data/page/findPage.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { validateRequired, hasValidationErrors } from '~/src/validations.js'
 
@@ -50,12 +51,13 @@ export class LinkCreate extends Component<Props, State> {
       return
     }
 
-    const definition = addLink(
-      data,
-      payload.from,
-      payload.to,
-      selectedCondition
-    )
+    const pageFrom = findPage(data, payload.from)
+    const pageTo = findPage(data, payload.to)
+
+    // Add link from the selected page
+    const definition = addLink(data, pageFrom, pageTo, {
+      condition: selectedCondition
+    })
 
     await save(definition)
     onSave()

--- a/designer/client/src/LinkEdit.test.tsx
+++ b/designer/client/src/LinkEdit.test.tsx
@@ -18,6 +18,7 @@ describe('LinkEdit', () => {
       {
         path: '/1',
         title: 'Page 1',
+        next: [{ path: '/2' }],
         components: [
           {
             name: 'field1',
@@ -25,10 +26,14 @@ describe('LinkEdit', () => {
             type: ComponentType.YesNoField,
             options: {}
           }
-        ],
-        next: [{ path: '/2' }]
+        ]
       },
-      { path: '/2', title: 'Page 2' }
+      {
+        path: '/2',
+        title: 'Page 2',
+        next: [],
+        components: []
+      }
     ],
     lists: [],
     sections: [],

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -11,6 +11,7 @@ import { type Edge } from '~/src/components/Visualisation/getLayout.js'
 import { SelectConditions } from '~/src/conditions/SelectConditions.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { deleteLink } from '~/src/data/page/deleteLink.js'
+import { findLink } from '~/src/data/page/findLink.js'
 import { findPage } from '~/src/data/page/findPage.js'
 import { updateLink } from '~/src/data/page/updateLink.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
@@ -37,13 +38,9 @@ export class LinkEdit extends Component<Props, State> {
     const { data } = this.context
 
     const [page] = findPage(data, edge.source)
-    const link = page.next?.find((n) => n.path === edge.target)
 
-    if (!link) {
-      throw new Error(
-        `Link not found from '${edge.source}' to '${edge.target}'`
-      )
-    }
+    // Find initial link from edge
+    const link = findLink(pageFrom, pageTo)
 
     this.state = {
       page,

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -1,4 +1,4 @@
-import { type Link, type Page } from '@defra/forms-model'
+import { type Page } from '@defra/forms-model'
 import React, {
   Component,
   type ContextType,
@@ -22,8 +22,8 @@ interface Props {
 }
 
 interface State {
-  page: Page
-  link: Link
+  pageFrom: Page
+  pageTo: Page
   selectedCondition?: string
 }
 
@@ -37,14 +37,16 @@ export class LinkEdit extends Component<Props, State> {
     const { edge } = this.props
     const { data } = this.context
 
-    const [page] = findPage(data, edge.source)
+    // Find initial pages from edge
+    const pageFrom = findPage(data, edge.source)
+    const pageTo = findPage(data, edge.target)
 
     // Find initial link from edge
     const link = findLink(pageFrom, pageTo)
 
     this.state = {
-      page,
-      link,
+      pageFrom,
+      pageTo,
       selectedCondition: link.condition
     }
   }
@@ -53,10 +55,16 @@ export class LinkEdit extends Component<Props, State> {
     e.preventDefault()
 
     const { onSave } = this.props
-    const { link, page, selectedCondition } = this.state
     const { data, save } = this.context
+    const { pageFrom, pageTo, selectedCondition } = this.state
 
-    const definition = updateLink(data, page.path, link.path, selectedCondition)
+    // Update link
+    const definition = updateLink(
+      data,
+      pageFrom.path,
+      pageTo.path,
+      selectedCondition
+    )
 
     try {
       await save(definition)
@@ -74,10 +82,11 @@ export class LinkEdit extends Component<Props, State> {
     }
 
     const { onSave } = this.props
-    const { link, page } = this.state
     const { data, save } = this.context
+    const { pageFrom, pageTo } = this.state
 
-    const definition = deleteLink(data, page.path, link.path)
+    // Delete link
+    const definition = deleteLink(data, pageFrom.path, pageTo.path)
 
     try {
       await save(definition)

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -86,7 +86,7 @@ export class LinkEdit extends Component<Props, State> {
     const { pageFrom, pageTo } = this.state
 
     // Delete link
-    const definition = deleteLink(data, pageFrom.path, pageTo.path)
+    const definition = deleteLink(data, pageFrom, pageTo)
 
     try {
       await save(definition)

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -145,7 +145,7 @@ export class PageCreate extends Component<Props, State> {
     const { value: linkFrom } = e.target
 
     this.setState({
-      linkFrom
+      linkFrom: linkFrom || undefined
     })
   }
 

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -18,6 +18,7 @@ import { SelectConditions } from '~/src/conditions/SelectConditions.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { addLink } from '~/src/data/page/addLink.js'
 import { addPage } from '~/src/data/page/addPage.js'
+import { findPage } from '~/src/data/page/findPage.js'
 import { findSection } from '~/src/data/section/findSection.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
@@ -79,7 +80,7 @@ export class PageCreate extends Component<Props, State> {
       return
     }
 
-    const newPage: Page = {
+    const pageNew: Page = {
       path: payload.path,
       title: payload.title,
       controller,
@@ -88,10 +89,15 @@ export class PageCreate extends Component<Props, State> {
       next: []
     }
 
-    let copy = addPage({ ...data }, newPage)
+    let copy = addPage(data, pageNew)
 
     if (linkFrom) {
-      copy = addLink(copy, linkFrom, payload.path, selectedCondition)
+      const pageFrom = findPage(copy, linkFrom)
+
+      // Add link from the selected page
+      copy = addLink(copy, pageFrom, pageNew, {
+        condition: selectedCondition
+      })
     }
 
     try {

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -94,8 +94,9 @@ export class PageEdit extends Component<Props, State> {
     pageEdit.section = section?.name
 
     if (payload.path !== page.path) {
-      copy = updateLinksTo(copy, page.path, payload.path)
-      pageEdit.path = payload.path
+      copy = updateLinksTo(copy, pageEdit, {
+        path: payload.path
+      })
     }
 
     try {

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -9,7 +9,14 @@ import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
 describe('ComponentCreate:', () => {
   const data = {
-    pages: [{ path: '/1', title: '', section: '' }],
+    pages: [
+      {
+        path: '/1',
+        title: '',
+        next: [],
+        components: []
+      }
+    ],
     lists: [],
     sections: [],
     conditions: []

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
@@ -27,6 +27,7 @@ describe('ComponentListSelect', () => {
       {
         title: 'First page',
         path: '/first-page',
+        next: [],
         components: [selectedComponent]
       }
     ],

--- a/designer/client/src/components/FieldEditors/ContentEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ContentEdit.test.tsx
@@ -24,6 +24,7 @@ describe('ContentEdit', () => {
       {
         title: 'First page',
         path: '/first-page',
+        next: [],
         components: [selectedComponent]
       }
     ],

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -13,6 +13,7 @@ const data = {
     {
       title: 'my first page',
       path: '/1',
+      next: [{ path: '/2' }],
       components: [
         {
           name: 'firstName',
@@ -47,7 +48,9 @@ const data = {
     },
     {
       title: 'my second page',
-      path: '/2'
+      path: '/2',
+      next: [],
+      components: []
     }
   ],
   lists: [],

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -15,9 +15,16 @@ describe('Visualisation', () => {
       pages: [
         {
           title: 'my first page',
-          path: '/1'
+          path: '/1',
+          next: [],
+          components: []
         },
-        { title: 'my second page', path: '/2' }
+        {
+          title: 'my second page',
+          path: '/2',
+          next: [],
+          components: []
+        }
       ],
       lists: [],
       sections: [],
@@ -40,7 +47,9 @@ describe('Visualisation', () => {
         ...data.pages,
         {
           title: 'my third page',
-          path: '/3'
+          path: '/3',
+          next: [],
+          components: []
         }
       ]
     }
@@ -60,11 +69,14 @@ describe('Visualisation', () => {
         {
           title: 'link source',
           path: '/link-source',
-          next: [{ path: '/link-target' }]
+          next: [{ path: '/link-target' }],
+          components: []
         },
         {
           title: 'link target',
-          path: '/link-target'
+          path: '/link-target',
+          next: [],
+          components: []
         }
       ],
       lists: [],

--- a/designer/client/src/components/Visualisation/getLayout.ts
+++ b/designer/client/src/components/Visualisation/getLayout.ts
@@ -1,6 +1,8 @@
 import { graphlib, layout, type GraphEdge, type Node } from '@dagrejs/dagre'
 import { type FormDefinition } from '@defra/forms-model'
 
+import { findPage } from '~/src/data/page/findPage.js'
+
 export interface Point {
   node: Node
   top: string
@@ -61,14 +63,10 @@ export const getLayout = (data: FormDefinition, el: HTMLDivElement) => {
     }
 
     page.next.forEach((next) => {
-      const hasNext = pages.some(({ path }) => path === next.path)
-      if (!hasNext) {
-        return
-      }
-
+      const pageNext = findPage(data, next.path)
       const condition = conditions.find(({ name }) => name === next.condition)
 
-      g.setEdge(page.path, next.path, {
+      g.setEdge(page.path, pageNext.path, {
         label: condition?.displayName,
         width: condition?.displayName ? 270 : undefined
       })

--- a/designer/client/src/conditions/ConditionsEdit.test.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.test.tsx
@@ -19,11 +19,13 @@ describe('ConditionsEdit', () => {
       {
         title: 'page1',
         path: '/1',
-        next: [{ path: '/2' }]
+        next: [{ path: '/2' }],
+        components: []
       },
       {
         title: 'page2',
         path: '/2',
+        next: [{ path: '/3' }],
         components: [
           {
             name: 'field1',
@@ -32,12 +34,12 @@ describe('ConditionsEdit', () => {
             options: {},
             schema: {}
           }
-        ],
-        next: [{ path: '/3' }]
+        ]
       },
       {
         title: 'page3',
         path: '/3',
+        next: [],
         components: [
           {
             name: 'field2',

--- a/designer/client/src/conditions/InlineConditions.test.tsx
+++ b/designer/client/src/conditions/InlineConditions.test.tsx
@@ -21,7 +21,8 @@ describe('InlineConditions', () => {
         {
           title: 'page1',
           path: '/1',
-          next: [{ path: '/2' }]
+          next: [{ path: '/2' }],
+          components: []
         },
         {
           title: 'page2',
@@ -40,6 +41,7 @@ describe('InlineConditions', () => {
         {
           title: 'page3',
           path: '/3',
+          next: [],
           components: [
             {
               name: 'field2',

--- a/designer/client/src/conditions/SelectConditions.test.tsx
+++ b/designer/client/src/conditions/SelectConditions.test.tsx
@@ -80,6 +80,7 @@ describe('SelectConditions', () => {
         {
           path: '/no-uk-passport',
           title: "You're not eligible for this service",
+          next: [],
           components: [
             {
               name: 'notEligible',
@@ -89,8 +90,7 @@ describe('SelectConditions', () => {
                 '<p class="govuk-body">If you still think you’re eligible please contact the Foreign and Commonwealth Office.</p>',
               options: {}
             }
-          ],
-          next: []
+          ]
         },
         {
           path: '/how-many-people',

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -214,7 +214,7 @@ export class SelectConditions extends Component<Props, State> {
     const { value: selectedCondition } = e.target
 
     this.setState({
-      selectedCondition
+      selectedCondition: selectedCondition || undefined
     })
   }
 

--- a/designer/client/src/data/component/addComponent.test.ts
+++ b/designer/client/src/data/component/addComponent.test.ts
@@ -20,6 +20,7 @@ test('addComponent adds a component to the correct page', () => {
       {
         title: 'first page',
         path: '/1',
+        next: [],
         components: [
           {
             name: 'firstName',
@@ -33,6 +34,7 @@ test('addComponent adds a component to the correct page', () => {
       {
         title: 'second page',
         path: '/2',
+        next: [],
         components: [
           {
             name: 'lastName',
@@ -62,6 +64,7 @@ test('addComponent adds a component to the correct page', () => {
       {
         title: 'first page',
         path: '/1',
+        next: [],
         components: [
           {
             name: 'firstName',
@@ -82,6 +85,7 @@ test('addComponent adds a component to the correct page', () => {
       {
         title: 'second page',
         path: '/2',
+        next: [],
         components: [
           {
             name: 'lastName',

--- a/designer/client/src/data/component/addComponent.ts
+++ b/designer/client/src/data/component/addComponent.ts
@@ -8,7 +8,8 @@ export function addComponent(
   pagePath: Path,
   component: ComponentDef
 ): FormDefinition {
-  const [page, index] = findPage(data, pagePath)
+  const page = findPage(data, pagePath)
+  const index = data.pages.indexOf(page)
 
   const { components = [] } = page
   const updatedPage = { ...page, components: [...components, component] }

--- a/designer/client/src/data/component/inputs.test.ts
+++ b/designer/client/src/data/component/inputs.test.ts
@@ -10,6 +10,7 @@ test('should return all inputs from the page model', () => {
         title: 'page1',
         path: '/1',
         section: 'section1',
+        next: [],
         components: [
           {
             name: 'name1',
@@ -31,6 +32,7 @@ test('should return all inputs from the page model', () => {
         title: 'page2',
         path: '/2',
         section: 'section1',
+        next: [],
         components: [
           {
             name: 'name3',
@@ -143,6 +145,8 @@ test('should handle pages with no components', () => {
       {
         title: 'No components',
         path: '/start',
+        controller: 'StartPageController',
+        next: [],
         components: []
       }
     ],

--- a/designer/client/src/data/component/updateComponent.test.ts
+++ b/designer/client/src/data/component/updateComponent.test.ts
@@ -20,7 +20,12 @@ test('updateComponent throws an error when the target component cannot be found'
           }
         ]
       },
-      { title: '2', path: '/2' }
+      {
+        title: '2',
+        path: '/2',
+        next: [],
+        components: []
+      }
     ],
     lists: [],
     sections: [],
@@ -55,6 +60,7 @@ test('addComponent adds a component to the correct page', () => {
       {
         title: 'second page',
         path: '/2',
+        next: [],
         components: [
           {
             name: 'lastName',
@@ -99,6 +105,7 @@ test('addComponent adds a component to the correct page', () => {
       {
         title: 'second page',
         path: '/2',
+        next: [],
         components: [
           {
             name: 'lastName',

--- a/designer/client/src/data/component/updateComponent.ts
+++ b/designer/client/src/data/component/updateComponent.ts
@@ -9,7 +9,7 @@ export function updateComponent(
   componentName: ComponentDef['name'],
   component: ComponentDef
 ) {
-  const [page] = findPage(data, pagePath)
+  const page = findPage(data, pagePath)
   const components = [...(page.components ?? [])]
   const componentIndex =
     page.components?.findIndex(

--- a/designer/client/src/data/condition/removeCondition.test.ts
+++ b/designer/client/src/data/condition/removeCondition.test.ts
@@ -11,21 +11,21 @@ const data = {
   pages: [
     {
       title: 'start',
-      next: [],
-      path: '/'
+      path: '/start',
+      controller: 'StartPageController',
+      next: [{ path: '/badgers' }],
+      components: []
     },
     {
       title: 'badgers',
       path: '/badgers',
       next: [
         {
-          path: '/summary'
-        },
-        {
           path: '/disaster',
           condition: 'isBadger'
         }
-      ]
+      ],
+      components: []
     }
   ],
   lists: [],
@@ -84,20 +84,20 @@ test('removeCondition should remove conditions from the conditions key and in pa
     pages: [
       {
         title: 'start',
-        next: [],
-        path: '/'
+        path: '/start',
+        controller: 'StartPageController',
+        next: [{ path: '/badgers' }],
+        components: []
       },
       {
         title: 'badgers',
         path: '/badgers',
         next: [
           expect.objectContaining({
-            path: '/summary'
-          }),
-          expect.objectContaining({
             path: '/disaster'
           })
-        ]
+        ],
+        components: []
       }
     ],
     lists: [],

--- a/designer/client/src/data/page/addLink.test.ts
+++ b/designer/client/src/data/page/addLink.test.ts
@@ -4,23 +4,30 @@ import { addLink } from '~/src/data/page/addLink.js'
 
 const page404 = {
   title: 'Page not found',
-  path: '/404'
+  path: '/404',
+  next: [],
+  components: []
 } satisfies Page
 
 const pageEggScrambed = {
   title: 'Egg scrambled',
   path: '/scrambled',
-  next: [{ path: '/poached' }]
+  next: [{ path: '/poached' }],
+  components: []
 } satisfies Page
 
 const pageEggPoached = {
   title: 'Egg poached',
-  path: '/poached'
+  path: '/poached',
+  next: [],
+  components: []
 } satisfies Page
 
 const pageEggSunny = {
   title: 'Egg sunny side up',
-  path: '/sunny'
+  path: '/sunny',
+  next: [],
+  components: []
 } satisfies Page
 
 const data = {
@@ -60,16 +67,20 @@ test('addLink successfully adds a new link', () => {
       {
         title: 'Egg scrambled',
         path: '/scrambled',
-        next: [{ path: '/poached' }]
+        next: [{ path: '/poached' }],
+        components: []
       },
       {
         title: 'Egg poached',
         path: '/poached',
-        next: [{ path: '/sunny' }]
+        next: [{ path: '/sunny' }],
+        components: []
       },
       {
         title: 'Egg sunny side up',
-        path: '/sunny'
+        path: '/sunny',
+        next: [],
+        components: []
       }
     ],
     lists: [],

--- a/designer/client/src/data/page/addLink.test.ts
+++ b/designer/client/src/data/page/addLink.test.ts
@@ -18,13 +18,21 @@ const data = {
 } satisfies FormDefinition
 
 test('addLink throws if to, from or both are not found', () => {
-  expect(() => addLink(data, '404', '4004')).toThrow(/no page found/)
-  expect(() => addLink(data, '404', '/scrambled')).toThrow(/no page found/)
-  expect(() => addLink(data, '/scrambled', '404')).toThrow(/no page found/)
+  expect(() => addLink(data, '/404', '/4004')).toThrow(
+    "Page not found for path '/404'"
+  )
+
+  expect(() => addLink(data, '/404', '/scrambled')).toThrow(
+    "Page not found for path '/404'"
+  )
+
+  expect(() => addLink(data, '/scrambled', '/404')).toThrow(
+    "Page not found for path '/404'"
+  )
 })
 
 test('addLink throws if to and from are equal', () => {
-  expect(() => addLink(data, '404', '404')).toThrow(
+  expect(() => addLink(data, '/404', '/404')).toThrow(
     /cannot link a page to itself/
   )
 })

--- a/designer/client/src/data/page/addLink.test.ts
+++ b/designer/client/src/data/page/addLink.test.ts
@@ -1,52 +1,76 @@
-import { type FormDefinition } from '@defra/forms-model'
+import { type FormDefinition, type Page } from '@defra/forms-model'
 
 import { addLink } from '~/src/data/page/addLink.js'
 
+const page404 = {
+  title: 'Page not found',
+  path: '/404'
+} satisfies Page
+
+const pageEggScrambed = {
+  title: 'Egg scrambled',
+  path: '/scrambled',
+  next: [{ path: '/poached' }]
+} satisfies Page
+
+const pageEggPoached = {
+  title: 'Egg poached',
+  path: '/poached'
+} satisfies Page
+
+const pageEggSunny = {
+  title: 'Egg sunny side up',
+  path: '/sunny'
+} satisfies Page
+
 const data = {
-  pages: [
-    {
-      title: 'scrambled',
-      path: '/scrambled',
-      next: [{ path: '/poached' }]
-    },
-    { title: 'poached', path: '/poached' },
-    { title: 'sunny', path: '/sunny' }
-  ],
+  pages: [pageEggScrambed, pageEggPoached, pageEggSunny],
   lists: [],
   sections: [],
   conditions: []
 } satisfies FormDefinition
 
 test('addLink throws if to, from or both are not found', () => {
-  expect(() => addLink(data, '/404', '/4004')).toThrow(
+  expect(() => addLink(data, page404, pageEggScrambed)).toThrow(
     "Page not found for path '/404'"
   )
 
-  expect(() => addLink(data, '/404', '/scrambled')).toThrow(
+  expect(() => addLink(data, pageEggScrambed, page404)).toThrow(
     "Page not found for path '/404'"
   )
 
-  expect(() => addLink(data, '/scrambled', '/404')).toThrow(
-    "Page not found for path '/404'"
-  )
+  expect(() =>
+    addLink(data, pageEggScrambed, page404, {
+      condition: 'isUnknown'
+    })
+  ).toThrow("Page not found for path '/404'")
 })
 
 test('addLink throws if to and from are equal', () => {
-  expect(() => addLink(data, '/404', '/404')).toThrow(
-    /cannot link a page to itself/
+  expect(() => addLink(data, pageEggPoached, pageEggPoached)).toThrow(
+    'Link must be between different pages'
   )
 })
 
 test('addLink successfully adds a new link', () => {
-  expect(addLink(data, '/poached', '/sunny')).toEqual<FormDefinition>({
+  const definition = addLink(data, pageEggPoached, pageEggSunny)
+
+  expect(definition).toEqual<FormDefinition>({
     pages: [
       {
-        title: 'scrambled',
+        title: 'Egg scrambled',
         path: '/scrambled',
         next: [{ path: '/poached' }]
       },
-      { title: 'poached', path: '/poached', next: [{ path: '/sunny' }] },
-      { title: 'sunny', path: '/sunny' }
+      {
+        title: 'Egg poached',
+        path: '/poached',
+        next: [{ path: '/sunny' }]
+      },
+      {
+        title: 'Egg sunny side up',
+        path: '/sunny'
+      }
     ],
     lists: [],
     sections: [],
@@ -55,18 +79,8 @@ test('addLink successfully adds a new link', () => {
 })
 
 test('addLink does nothing happens if the link already exists', () => {
-  expect(addLink(data, '/scrambled', '/poached')).toEqual({
-    pages: [
-      {
-        title: 'scrambled',
-        path: '/scrambled',
-        next: [{ path: '/poached' }]
-      },
-      { title: 'poached', path: '/poached' },
-      { title: 'sunny', path: '/sunny' }
-    ],
-    lists: [],
-    sections: [],
-    conditions: []
-  })
+  const definition = addLink(data, pageEggScrambed, pageEggPoached)
+
+  expect(definition).toEqual(data)
+  expect(definition).toBe(data)
 })

--- a/designer/client/src/data/page/addLink.ts
+++ b/designer/client/src/data/page/addLink.ts
@@ -19,8 +19,11 @@ export function addLink(
   if (from === to) {
     throw Error('cannot link a page to itself')
   }
-  const [fromPage, index] = findPage(data, from)
+  const fromPage = findPage(data, from)
+  const index = data.pages.indexOf(fromPage)
+
   findPage(data, to)
+
   const pages = [...data.pages]
 
   const existingLink = fromPage.next?.find((page) => page.path === to)

--- a/designer/client/src/data/page/addLink.ts
+++ b/designer/client/src/data/page/addLink.ts
@@ -1,52 +1,45 @@
-import { type FormDefinition, type Link } from '@defra/forms-model'
+import { type FormDefinition, type Link, type Page } from '@defra/forms-model'
 
+import { findLink } from '~/src/data/page/findLink.js'
 import { findPage } from '~/src/data/page/findPage.js'
-import { type Path } from '~/src/data/types.js'
+import { hasNext } from '~/src/data/page/hasNext.js'
 
 /**
- * @param data - Data from DataContext
- * @param from - path to link from
- * @param to - path to link to
- * @param condition - condition for path branching
- * @throws Error - if a page has been linked to itself
+ * Add link to page
  */
 export function addLink(
   data: FormDefinition,
-  from: Path,
-  to: Path,
-  condition?: string
-): FormDefinition {
-  if (from === to) {
-    throw Error('cannot link a page to itself')
+  pageFrom: Page,
+  pageTo: Pick<Page, 'path'>,
+  options?: Omit<Link, 'path'>
+) {
+  // Prevent linking to same page
+  if (pageFrom.path === pageTo.path) {
+    throw new Error('Link must be between different pages')
   }
-  const fromPage = findPage(data, from)
-  const index = data.pages.indexOf(fromPage)
 
-  findPage(data, to)
+  const definition = structuredClone(data)
 
-  const pages = [...data.pages]
+  // Confirm pages exist
+  const pageFromCopy = findPage(definition, pageFrom.path)
+  const pageToCopy = findPage(definition, pageTo.path)
 
-  const existingLink = fromPage.next?.find((page) => page.path === to)
-
-  if (!existingLink) {
-    const link: Link = {
-      path: to
-    }
-
-    if (condition) {
-      link.condition = condition
-    }
-
-    const updatedPage = {
-      ...fromPage,
-      next: [...(fromPage.next ?? []), link]
-    }
-
-    return {
-      ...data,
-      pages: pages.map((page, i) => (i === index ? updatedPage : page))
-    }
-  } else {
-    return data
+  if (!hasNext(pageFromCopy)) {
+    throw Error(`Links not found for path '${pageFromCopy.path}'`)
   }
+
+  try {
+    // Throw for missing link
+    findLink(pageFrom, pageTo)
+  } catch {
+    // Add link to page
+    pageFromCopy.next.push({
+      path: pageToCopy.path,
+      ...options
+    })
+
+    return definition
+  }
+
+  return data
 }

--- a/designer/client/src/data/page/addPage.test.ts
+++ b/designer/client/src/data/page/addPage.test.ts
@@ -7,10 +7,21 @@ const data = {
     {
       title: 'scrambled',
       path: '/scrambled',
-      next: [{ path: '/poached' }]
+      next: [{ path: '/poached' }],
+      components: []
     },
-    { title: 'poached', path: '/poached' },
-    { title: 'sunny', path: '/sunny' }
+    {
+      title: 'poached',
+      path: '/poached',
+      next: [],
+      components: []
+    },
+    {
+      title: 'sunny',
+      path: '/sunny',
+      next: [],
+      components: []
+    }
   ],
   lists: [],
   sections: [],
@@ -21,7 +32,9 @@ test('addPage throws if a page with the same path already exists', () => {
   expect(() =>
     addPage(data, {
       title: 'scrambled',
-      path: '/scrambled'
+      path: '/scrambled',
+      next: [],
+      components: []
     })
   ).toThrow(/A page with the path/)
 })
@@ -30,10 +43,14 @@ test('addPage adds a page if one does not exist with the same path', () => {
   expect(
     addPage(data, {
       title: 'soft boiled',
-      path: '/soft-boiled'
+      path: '/soft-boiled',
+      next: [],
+      components: []
     }).pages
   ).toContainEqual({
     title: 'soft boiled',
-    path: '/soft-boiled'
+    path: '/soft-boiled',
+    next: [],
+    components: []
   })
 })

--- a/designer/client/src/data/page/addPage.ts
+++ b/designer/client/src/data/page/addPage.ts
@@ -2,9 +2,11 @@ import { type FormDefinition, type Page } from '@defra/forms-model'
 
 export function addPage(data: FormDefinition, page: Page): FormDefinition {
   const index = data.pages.findIndex((pg) => pg.path === page.path)
+
   if (index > -1) {
     throw Error(`A page with the path ${page.path} already exists`)
   }
+
   return {
     ...data,
     pages: [...data.pages, page]

--- a/designer/client/src/data/page/allPathsLeadingTo.test.ts
+++ b/designer/client/src/data/page/allPathsLeadingTo.test.ts
@@ -8,16 +8,20 @@ test('allPathsLeadingTo should work with cycle in paths', () => {
       {
         title: 'page1',
         path: '/1',
-        next: [{ path: '/2' }]
+        next: [{ path: '/2' }],
+        components: []
       },
       {
         title: 'page2',
         path: '/2',
-        next: [{ path: '/1' }]
+        next: [{ path: '/1' }],
+        components: []
       },
       {
         title: 'page3',
-        path: '/3'
+        path: '/3',
+        next: [],
+        components: []
       }
     ],
     lists: [],
@@ -35,16 +39,20 @@ test('allPathsLeadingTo should work with single parents', () => {
       {
         title: 'page1',
         path: '/1',
-        next: [{ path: '/2' }]
+        next: [{ path: '/2' }],
+        components: []
       },
       {
         title: 'page2',
         path: '/2',
-        next: [{ path: '/3' }]
+        next: [{ path: '/3' }],
+        components: []
       },
       {
         title: 'page3',
-        path: '/3'
+        path: '/3',
+        next: [],
+        components: []
       }
     ],
     lists: [],
@@ -61,21 +69,26 @@ test('allPathsLeadingTo should work with multiple parents', () => {
       {
         title: 'page1',
         path: '/1',
-        next: [{ path: '/2' }, { path: '/3' }]
+        next: [{ path: '/2' }, { path: '/3' }],
+        components: []
       },
       {
         title: 'page2',
         path: '/2',
-        next: [{ path: '/4' }]
+        next: [{ path: '/4' }],
+        components: []
       },
       {
         title: 'page3',
         path: '/3',
-        next: [{ path: '/4' }]
+        next: [{ path: '/4' }],
+        components: []
       },
       {
         title: 'page4',
-        path: '/4'
+        path: '/4',
+        next: [],
+        components: []
       }
     ],
     lists: [],

--- a/designer/client/src/data/page/deleteLink.ts
+++ b/designer/client/src/data/page/deleteLink.ts
@@ -8,7 +8,7 @@ export function deleteLink(
   from: Path,
   to: Path
 ): FormDefinition {
-  const [fromPage] = findPage(data, from)
+  const fromPage = findPage(data, from)
 
   findPage(data, to)
 

--- a/designer/client/src/data/page/findLink.ts
+++ b/designer/client/src/data/page/findLink.ts
@@ -1,0 +1,30 @@
+import { type Page } from '@defra/forms-model'
+
+import { hasNext } from '~/src/data/page/hasNext.js'
+
+/**
+ * Find link by path
+ */
+export function findLink(pageFrom: Page, pageTo: Pick<Page, 'path'>) {
+  const index = findLinkIndex(pageFrom, pageTo)
+  const link = hasNext(pageFrom) ? pageFrom.next[index] : undefined
+
+  if (index < 0 || !link) {
+    throw Error(
+      `Link not found for path '${pageFrom.path}' to '${pageTo.path}'`
+    )
+  }
+
+  return link
+}
+
+/**
+ * Find link index by path
+ */
+export function findLinkIndex(pageFrom: Page, pageTo: Pick<Page, 'path'>) {
+  if (!hasNext(pageFrom)) {
+    return -1
+  }
+
+  return pageFrom.next.findIndex(({ path }) => path === pageTo.path)
+}

--- a/designer/client/src/data/page/findPage.test.ts
+++ b/designer/client/src/data/page/findPage.test.ts
@@ -59,17 +59,14 @@ test('findPage should throw if the page does not exist', () => {
 })
 
 test('findPage should return the page and index if the page exists', () => {
-  expect(findPage(data, '/2')).toEqual([
-    {
-      title: 'page2',
-      section: 'section1',
-      path: '/2',
-      next: [{ path: '/3' }],
-      components: [
-        expect.objectContaining({ name: 'name3' }),
-        expect.objectContaining({ name: 'name4' })
-      ]
-    },
-    1
-  ])
+  expect(findPage(data, '/2')).toEqual({
+    title: 'page2',
+    section: 'section1',
+    path: '/2',
+    next: [{ path: '/3' }],
+    components: [
+      expect.objectContaining({ name: 'name3' }),
+      expect.objectContaining({ name: 'name4' })
+    ]
+  })
 })

--- a/designer/client/src/data/page/findPage.ts
+++ b/designer/client/src/data/page/findPage.ts
@@ -1,16 +1,17 @@
-import { type FormDefinition, type Page } from '@defra/forms-model'
-
-import { type Found, type Path } from '~/src/data/types.js'
+import { type FormDefinition } from '@defra/forms-model'
 
 /**
- * @returns returns a tuple of [Page, number]
+ * Find page by path
  */
-export function findPage(data: FormDefinition, path?: Path): Found<Page> {
-  const index = data.pages.findIndex((page) => page.path === path)
+export function findPage(
+  { pages }: Pick<FormDefinition, 'pages'>,
+  pathSearch?: string
+) {
+  const page = pages.find(({ path }) => path === pathSearch)
 
-  if (index < 0) {
-    throw Error(`no page found with the path ${path}`)
+  if (!page) {
+    throw Error(`Page not found for path '${pathSearch}'`)
   }
 
-  return [{ ...data.pages[index] }, index]
+  return page
 }

--- a/designer/client/src/data/page/hasNext.ts
+++ b/designer/client/src/data/page/hasNext.ts
@@ -1,0 +1,9 @@
+import { type Page, type PageWithNext } from '@defra/forms-model'
+
+/**
+ * Check page has next link
+ */
+export function hasNext(page: Page): page is PageWithNext {
+  const { next = [] } = page
+  return next.length > 0
+}

--- a/designer/client/src/data/page/hasNext.ts
+++ b/designer/client/src/data/page/hasNext.ts
@@ -1,9 +1,8 @@
-import { type Page, type PageWithNext } from '@defra/forms-model'
+import { type Link, type Page } from '@defra/forms-model'
 
 /**
  * Check page has next link
  */
-export function hasNext(page: Page): page is PageWithNext {
-  const { next = [] } = page
-  return next.length > 0
+export function hasNext(page?: Page): page is Extract<Page, { next: Link[] }> {
+  return !!page && 'next' in page
 }

--- a/designer/client/src/data/page/updateLink.test.ts
+++ b/designer/client/src/data/page/updateLink.test.ts
@@ -33,6 +33,7 @@ const page1 = {
 const page2 = {
   title: 'page2',
   path: '/2',
+  next: [],
   components: [
     {
       name: 'name3',
@@ -53,7 +54,9 @@ const page2 = {
 
 const page3 = {
   title: 'page3',
-  path: '/3'
+  path: '/3',
+  next: [],
+  components: []
 } satisfies Page
 
 const data = {
@@ -135,11 +138,9 @@ test('updateLink should remove a condition from a link to the next page', () => 
     path: '/2'
   })
 
-  expect(definition.pages[0].next).toMatchObject([
-    {
-      path: '/2'
-    }
-  ])
+  expect(definition.pages[0]).toMatchObject({
+    next: [{ path: '/2' }]
+  })
 })
 
 test('updateLink should add a condition to a link to the next page', () => {
@@ -148,10 +149,12 @@ test('updateLink should add a condition to a link to the next page', () => {
     condition: 'isKangaroo'
   })
 
-  expect(definition.pages[0].next).toMatchObject([
-    {
-      path: '/2',
-      condition: 'isKangaroo'
-    }
-  ])
+  expect(definition.pages[0]).toMatchObject({
+    next: [
+      {
+        path: '/2',
+        condition: 'isKangaroo'
+      }
+    ]
+  })
 })

--- a/designer/client/src/data/page/updateLink.test.ts
+++ b/designer/client/src/data/page/updateLink.test.ts
@@ -2,59 +2,62 @@ import {
   ComponentType,
   ConditionType,
   OperatorName,
-  type FormDefinition
+  type FormDefinition,
+  type Page
 } from '@defra/forms-model'
 
 import { updateLink } from '~/src/data/page/updateLink.js'
 
-const data = {
-  pages: [
+const page1 = {
+  title: 'page1',
+  path: '/1',
+  next: [{ path: '/2', condition: 'isBadger' }],
+  components: [
     {
-      title: 'page1',
-      path: '/1',
-      next: [{ path: '/2', condition: 'isBadger' }],
-      components: [
-        {
-          name: 'name1',
-          title: 'Name 1',
-          type: ComponentType.TextField,
-          options: {},
-          schema: {}
-        },
-        {
-          name: 'name2',
-          title: 'Name 2',
-          type: ComponentType.TextField,
-          options: {},
-          schema: {}
-        }
-      ]
+      name: 'name1',
+      title: 'Name 1',
+      type: ComponentType.TextField,
+      options: {},
+      schema: {}
     },
     {
-      title: 'page2',
-      path: '/2',
-      components: [
-        {
-          name: 'name3',
-          title: 'Name 3',
-          type: ComponentType.TextField,
-          options: {},
-          schema: {}
-        },
-        {
-          name: 'name4',
-          title: 'Name 4',
-          type: ComponentType.TextField,
-          options: {},
-          schema: {}
-        }
-      ]
-    },
-    {
-      title: 'page3',
-      path: '/3'
+      name: 'name2',
+      title: 'Name 2',
+      type: ComponentType.TextField,
+      options: {},
+      schema: {}
     }
-  ],
+  ]
+} satisfies Page
+
+const page2 = {
+  title: 'page2',
+  path: '/2',
+  components: [
+    {
+      name: 'name3',
+      title: 'Name 3',
+      type: ComponentType.TextField,
+      options: {},
+      schema: {}
+    },
+    {
+      name: 'name4',
+      title: 'Name 4',
+      type: ComponentType.TextField,
+      options: {},
+      schema: {}
+    }
+  ]
+} satisfies Page
+
+const page3 = {
+  title: 'page3',
+  path: '/3'
+} satisfies Page
+
+const data = {
+  pages: [page1, page2, page3],
   lists: [],
   sections: [],
   conditions: [
@@ -106,19 +109,49 @@ const data = {
 } satisfies FormDefinition
 
 test('updateLink throws if from, to, or there is no existing link', () => {
-  expect(() => updateLink(data, '/1', '/3')).toThrow(
-    /Could not find page or links to update/
-  )
+  const save = () =>
+    updateLink(data, page1, page2, {
+      path: '/404'
+    })
+
+  expect(save).toThrow("Page not found for path '/404'")
+})
+
+test('updateLink should skip link update without changes', () => {
+  const link = page1.next[0]
+
+  const definition1 = updateLink(data, page1, page2)
+  const definition2 = updateLink(data, page1, page2, link)
+
+  expect(definition1).toEqual(data)
+  expect(definition2).toEqual(data)
+
+  expect(definition1).toStrictEqual(data)
+  expect(definition2).toStrictEqual(data)
 })
 
 test('updateLink should remove a condition from a link to the next page', () => {
-  expect(updateLink(data, '/1', '/2').pages[0].next).toEqual([
-    expect.objectContaining({ path: '/2' })
+  const definition = updateLink(data, page1, page2, {
+    path: '/2'
+  })
+
+  expect(definition.pages[0].next).toMatchObject([
+    {
+      path: '/2'
+    }
   ])
 })
 
 test('updateLink should add a condition to a link to the next page', () => {
-  expect(updateLink(data, '/1', '/2', 'isKangaroos').pages[0].next).toEqual([
-    expect.objectContaining({ path: '/2', condition: 'isKangaroos' })
+  const definition = updateLink(data, page1, page2, {
+    path: '/2',
+    condition: 'isKangaroo'
+  })
+
+  expect(definition.pages[0].next).toMatchObject([
+    {
+      path: '/2',
+      condition: 'isKangaroo'
+    }
   ])
 })

--- a/designer/client/src/data/page/updateLink.ts
+++ b/designer/client/src/data/page/updateLink.ts
@@ -1,36 +1,58 @@
-import { type FormDefinition } from '@defra/forms-model'
+import { type FormDefinition, type Link, type Page } from '@defra/forms-model'
 
+import { findLink, findLinkIndex } from '~/src/data/page/findLink.js'
 import { findPage } from '~/src/data/page/findPage.js'
-import { type Path } from '~/src/data/types.js'
 
+/**
+ * Update link to page
+ */
 export function updateLink(
   data: FormDefinition,
-  from: Path,
-  to: Path,
-  condition?: string
-): FormDefinition {
-  const fromPage = findPage(data, from)
-  const fromPageIndex = data.pages.indexOf(fromPage)
-
-  findPage(data, to)
-
-  const existingLinkIndex =
-    fromPage.next?.findIndex((next) => next.path === to) ?? -1
-
-  if (!fromPage.next || existingLinkIndex < 0) {
-    throw Error('Could not find page or links to update')
+  pageFrom: Page,
+  pageTo: Pick<Page, 'path'>,
+  options?: Partial<Link>
+) {
+  // Prevent linking to same page
+  if (pageFrom.path === (options?.path ?? pageTo.path)) {
+    throw new Error('Link must be between different pages')
   }
 
-  const updatedNext = [...fromPage.next]
-  updatedNext[existingLinkIndex] = {
-    ...updatedNext[existingLinkIndex],
-    condition
+  // Confirm link exists
+  const link = findLink(pageFrom, pageTo)
+
+  // Skip unnecessary updates
+  if (!options || link === options) {
+    return data
   }
 
-  const updatedPage = { ...fromPage, next: updatedNext }
+  const definition = structuredClone(data)
 
-  const pages = [...data.pages]
-  pages[fromPageIndex] = updatedPage
+  // Confirm pages exist
+  const pageFromCopy = findPage(definition, pageFrom.path)
+  const pageToCopy = findPage(definition, pageTo.path)
 
-  return { ...data, pages }
+  // Confirm updated page exists (optional)
+  const pageToMoved =
+    !!options.path && options.path !== pageTo.path
+      ? findPage(data, options.path)
+      : undefined
+
+  // Throw when changes clash with existing link
+  if (pageToMoved && findLinkIndex(pageFrom, pageToMoved) > -1) {
+    throw new Error(
+      `Link already exists for path '${pageFrom.path}' to '${options.path}'`
+    )
+  }
+
+  // Find existing link
+  const linkCopy = findLink(pageFromCopy, pageToCopy)
+
+  // Reset link properties
+  delete linkCopy.condition
+  delete linkCopy.redirect
+
+  // Update link properties
+  Object.assign(linkCopy, options)
+
+  return definition
 }

--- a/designer/client/src/data/page/updateLink.ts
+++ b/designer/client/src/data/page/updateLink.ts
@@ -9,7 +9,8 @@ export function updateLink(
   to: Path,
   condition?: string
 ): FormDefinition {
-  const [fromPage, fromPageIndex] = findPage(data, from)
+  const fromPage = findPage(data, from)
+  const fromPageIndex = data.pages.indexOf(fromPage)
 
   findPage(data, to)
 

--- a/designer/client/src/data/page/updateLinksTo.test.ts
+++ b/designer/client/src/data/page/updateLinksTo.test.ts
@@ -90,7 +90,7 @@ const data = {
 } satisfies FormDefinition
 
 test('updateLinksTo should update all links pointing to the specified path to the new path', () => {
-  const returned = updateLinksTo(data, '/2', '/3')
+  const returned = updateLinksTo(data, data.pages[2], data.pages[3])
   expect(returned).toEqual<FormDefinition>({
     startPage: '/0',
     pages: [
@@ -146,8 +146,7 @@ test('updateLinksTo should update all links pointing to the specified path to th
         title: 'summary',
         path: '/summary',
         controller: 'SummaryPageController',
-        components: [],
-        next: []
+        components: []
       }
     ],
     lists: [],

--- a/designer/client/src/data/page/updateLinksTo.test.ts
+++ b/designer/client/src/data/page/updateLinksTo.test.ts
@@ -80,8 +80,7 @@ const data = {
     {
       title: 'summary',
       path: '/summary',
-      controller: 'SummaryPageController',
-      components: []
+      controller: 'SummaryPageController'
     }
   ],
   lists: [],
@@ -145,8 +144,7 @@ test('updateLinksTo should update all links pointing to the specified path to th
       {
         title: 'summary',
         path: '/summary',
-        controller: 'SummaryPageController',
-        components: []
+        controller: 'SummaryPageController'
       }
     ],
     lists: [],

--- a/designer/client/src/list/ListItemEdit.test.tsx
+++ b/designer/client/src/list/ListItemEdit.test.tsx
@@ -17,15 +17,14 @@ const data = {
     {
       title: 'start',
       path: '/start',
+      controller: 'StartPageController',
       components: [
         {
           name: 'text',
-          title: 'text',
-          type: ComponentType.TextField,
-          schema: {},
-          options: {
-            required: true
-          }
+          title: 'Start',
+          content: '<p class="govuk-body">Some content</p>',
+          type: ComponentType.Html,
+          options: {}
         }
       ],
       next: [
@@ -37,6 +36,7 @@ const data = {
     {
       title: 'First page',
       path: '/first-page',
+      next: [],
       components: [
         {
           name: 'IDDQl4',

--- a/designer/server/src/routes/forms/api.test.js
+++ b/designer/server/src/routes/forms/api.test.js
@@ -66,8 +66,7 @@ describe('Server API', () => {
           {
             title: 'Summary',
             path: '/summary',
-            controller: 'SummaryPageController',
-            components: []
+            controller: 'SummaryPageController'
           }
         ],
         lists: [],

--- a/model/src/form/utils/update-start-page.test.ts
+++ b/model/src/form/utils/update-start-page.test.ts
@@ -33,8 +33,7 @@ describe('updateStartPage', () => {
         {
           title: 'Summary',
           path: '/summary',
-          controller: 'SummaryPageController',
-          components: []
+          controller: 'SummaryPageController'
         }
       ],
       lists: [],


### PR DESCRIPTION
To unblock https://github.com/DEFRA/forms-designer/pull/419 this PR avoids `{ ...data }` props copied by reference in link helpers

```js
return {
    ...data,
    pages: data.pages.map(…)
}
```

It follows on from:

* https://github.com/DEFRA/forms-designer/pull/411