### PR TITLE
Fix duplicate render + save for component create/edit

### DIFF
--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -243,7 +243,7 @@ export const Component: FunctionComponent<Props> = (props) => {
 
   const { data, save } = useContext(DataContext)
   const [showEditor, setShowEditor] = useState<boolean>(false)
-  const toggleShowEditor = () => setShowEditor(!showEditor)
+  const onSave = () => setShowEditor(!showEditor)
 
   const { title, type } = selectedComponent
   const ComponentIcon = componentTypes[type]
@@ -290,7 +290,7 @@ export const Component: FunctionComponent<Props> = (props) => {
     <>
       <button
         className="component govuk-link"
-        onClick={toggleShowEditor}
+        onClick={onSave}
         aria-label={componentButtonLabel}
         aria-describedby={headingId}
       >
@@ -320,9 +320,9 @@ export const Component: FunctionComponent<Props> = (props) => {
       )}
       {showEditor && (
         <RenderInPortal>
-          <Flyout title={componentFlyoutTitle} onHide={toggleShowEditor}>
+          <Flyout title={componentFlyoutTitle} onHide={onSave}>
             <ComponentContextProvider selectedComponent={selectedComponent}>
-              <ComponentEdit page={page} toggleShowEditor={toggleShowEditor} />
+              <ComponentEdit page={page} onSave={onSave} />
             </ComponentContextProvider>
           </Flyout>
         </RenderInPortal>

--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -1,3 +1,4 @@
+import { type Page } from '@defra/forms-model'
 import React, {
   useContext,
   useLayoutEffect,
@@ -16,11 +17,18 @@ import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
 import { Meta } from '~/src/reducers/component/types.js'
 import { hasValidationErrors } from '~/src/validations.js'
 
-export function ComponentEdit(props) {
+interface Props {
+  page: Page
+  toggleShowEditor: () => void
+}
+
+export function ComponentEdit(props: Props) {
   const { data, save } = useContext(DataContext)
   const { state, dispatch } = useContext(ComponentContext)
-  const { initialName, selectedComponent, errors, hasValidated } = state
+
   const { page, toggleShowEditor } = props
+  const { initialName, selectedComponent, errors, hasValidated = false } = state
+
   const hasErrors = hasValidationErrors(errors)
 
   const handleSubmit = async (e?: FormEvent<HTMLFormElement>) => {

--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -19,14 +19,14 @@ import { hasValidationErrors } from '~/src/validations.js'
 
 interface Props {
   page: Page
-  toggleShowEditor: () => void
+  onSave: () => void
 }
 
 export function ComponentEdit(props: Props) {
   const { data, save } = useContext(DataContext)
   const { state, dispatch } = useContext(ComponentContext)
 
-  const { page, toggleShowEditor } = props
+  const { page, onSave } = props
   const { initialName, selectedComponent, errors, hasValidated = false } = state
 
   const hasErrors = hasValidationErrors(errors)
@@ -49,8 +49,9 @@ export function ComponentEdit(props: Props) {
       initialName,
       selectedComponent
     )
+
     await save(definition)
-    toggleShowEditor()
+    onSave()
   }
 
   const handleDelete = async (e: MouseEvent<HTMLButtonElement>) => {
@@ -74,7 +75,7 @@ export function ComponentEdit(props: Props) {
     components.splice(index, 1)
 
     await save(definition)
-    toggleShowEditor()
+    onSave()
   }
 
   useLayoutEffect(() => {

--- a/designer/client/src/DeclarationEdit.tsx
+++ b/designer/client/src/DeclarationEdit.tsx
@@ -4,20 +4,19 @@ import { Editor } from '~/src/Editor.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import { DataContext } from '~/src/context/DataContext.js'
 
-export class DeclarationEdit extends Component {
+interface Props {
+  onSave: () => void
+}
+
+export class DeclarationEdit extends Component<Props> {
   declare context: ContextType<typeof DataContext>
   static contextType = DataContext
-
-  constructor(props, context) {
-    super(props, context)
-
-    this.onSubmit = this.onSubmit.bind(this)
-  }
 
   onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     e.stopPropagation()
 
+    const { onSave } = this.props
     const { save, data } = this.context
 
     const definition = structuredClone(data)
@@ -27,8 +26,8 @@ export class DeclarationEdit extends Component {
     definition.skipSummary = formData.get('skip-summary') === 'on'
 
     try {
-      const savedData = await save(definition)
-      this.props.onCreate({ data: savedData })
+      await save(definition)
+      onSave()
     } catch (error) {
       logger.error(error, 'DeclarationEdit')
     }

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -29,7 +29,7 @@ describe('ComponentCreate:', () => {
   test('Selecting a component type should display the component edit form', async () => {
     render(
       <RenderWithContext data={data}>
-        <ComponentCreate page={page} />
+        <ComponentCreate page={page} onSave={jest.fn()} />
       </RenderWithContext>
     )
 
@@ -55,7 +55,7 @@ describe('ComponentCreate:', () => {
 
     render(
       <RenderWithContext data={data} save={save}>
-        <ComponentCreate page={page} />
+        <ComponentCreate page={page} onSave={jest.fn()} />
       </RenderWithContext>
     )
 
@@ -108,7 +108,7 @@ describe('ComponentCreate:', () => {
   test("Should have functioning 'Back to create component list' link", async () => {
     render(
       <RenderWithContext data={data}>
-        <ComponentCreate page={page} />
+        <ComponentCreate page={page} onSave={jest.fn()} />
       </RenderWithContext>
     )
 
@@ -138,7 +138,7 @@ describe('ComponentCreate:', () => {
   test('Should display error summary when validation fails', async () => {
     render(
       <RenderWithContext data={data}>
-        <ComponentCreate page={page} />
+        <ComponentCreate page={page} onSave={jest.fn()} />
       </RenderWithContext>
     )
 

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -25,14 +25,21 @@ import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
 import { Meta } from '~/src/reducers/component/types.js'
 import { hasValidationErrors } from '~/src/validations.js'
 
-function useComponentCreate(props) {
-  const [renderTypeEdit, setRenderTypeEdit] = useState<boolean>(false)
+interface Props {
+  page: Page
+  toggleAddComponent: () => void
+}
+
+function useComponentCreate(props: Props) {
   const { data, save } = useContext(DataContext)
   const { state, dispatch } = useContext(ComponentContext)
-  const { selectedComponent, errors, hasValidated } = state
-  const { page, toggleAddComponent = () => {} } = props
 
+  const [renderTypeEdit, setRenderTypeEdit] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+
+  const { page, toggleAddComponent } = props
+  const { selectedComponent, errors, hasValidated = false } = state
+
   const hasErrors = hasValidationErrors(errors)
 
   useEffect(() => {
@@ -78,7 +85,8 @@ function useComponentCreate(props) {
     }
 
     setIsSaving(true)
-    const updatedData = addComponent(data, page as Page, selectedComponent)
+
+    const updatedData = addComponent(data, page, selectedComponent)
 
     await save(updatedData)
     toggleAddComponent()
@@ -115,7 +123,7 @@ function useComponentCreate(props) {
   }
 }
 
-export function ComponentCreate(props) {
+export function ComponentCreate(props: Props) {
   const {
     handleSubmit,
     handleCreate,

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -27,7 +27,7 @@ import { hasValidationErrors } from '~/src/validations.js'
 
 interface Props {
   page: Page
-  toggleAddComponent: () => void
+  onSave: () => void
 }
 
 function useComponentCreate(props: Props) {
@@ -37,7 +37,7 @@ function useComponentCreate(props: Props) {
   const [renderTypeEdit, setRenderTypeEdit] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
 
-  const { page, toggleAddComponent } = props
+  const { page, onSave } = props
   const { selectedComponent, errors, hasValidated = false } = state
 
   const hasErrors = hasValidationErrors(errors)
@@ -86,10 +86,10 @@ function useComponentCreate(props: Props) {
 
     setIsSaving(true)
 
-    const updatedData = addComponent(data, page, selectedComponent)
+    const definition = addComponent(data, page, selectedComponent)
 
-    await save(updatedData)
-    toggleAddComponent()
+    await save(definition)
+    onSave()
   }
 
   /**

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -197,7 +197,7 @@ export function Menu({ slug }: Props) {
       {summary.isVisible && (
         <RenderInPortal>
           <Flyout title="Edit Summary" onHide={summary.hide}>
-            <DeclarationEdit onCreate={() => summary.hide()} />
+            <DeclarationEdit onSave={summary.hide} />
           </Flyout>
         </RenderInPortal>
       )}

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -131,7 +131,7 @@ export const Page = (props: {
           <Flyout onHide={() => setIsCreatingComponent(false)}>
             <ComponentContextProvider>
               <ComponentCreate
-                toggleAddComponent={() => setIsCreatingComponent(false)}
+                onSave={() => setIsCreatingComponent(false)}
                 page={page}
               />
             </ComponentContextProvider>

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -78,7 +78,7 @@ export class SectionsEdit extends Component<Props, State> {
                 section?.name ? `Editing ${section.name}` : 'Add a new section'
               }
               show={isEditingSection}
-              onHide={() => this.closeFlyout()}
+              onHide={this.closeFlyout}
             >
               <SectionEdit section={section} onSave={this.closeFlyout} />
             </Flyout>


### PR DESCRIPTION
This PR is related to https://github.com/DEFRA/forms-designer/pull/412 and fixes an issue where components could be saved multiple times

It prevents multiple renders and now save only when validated and not already saving/deleting

The error in MongoDB due to this race condition is now resolved