### PR TITLE
Consistent UI tweaks

### DIFF
--- a/designer/client/src/LinkEdit.test.tsx
+++ b/designer/client/src/LinkEdit.test.tsx
@@ -102,7 +102,7 @@ describe('LinkEdit', () => {
     )
 
     let $conditions = screen.queryByRole('link', {
-      name: 'Define a new condition'
+      name: 'Add a new condition'
     })
 
     expect($conditions).not.toBeInTheDocument()
@@ -111,7 +111,7 @@ describe('LinkEdit', () => {
     await act(() => userEvent.selectOptions($source, '/first-page'))
 
     $conditions = screen.getByRole('link', {
-      name: 'Define a new condition'
+      name: 'Add a new condition'
     })
 
     expect($conditions).toBeInTheDocument()

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -274,7 +274,7 @@ export class LinkEdit extends Component<Props, State> {
               value={pageFrom?.path}
               onChange={this.onChangeFrom}
             >
-              <option value="" />
+              <option value="">{i18n('addLink.linkFrom.option')}</option>
               {pages.filter(hasNext).map((page) => (
                 <option key={page.path} value={page.path}>
                   {page.title}
@@ -308,7 +308,7 @@ export class LinkEdit extends Component<Props, State> {
               value={pageTo?.path}
               onChange={this.onChangeTo}
             >
-              <option value="" />
+              <option value="">{i18n('addLink.linkTo.option')}</option>
               {pages.map((page) => (
                 <option key={page.path} value={page.path}>
                   {page.title}

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -40,6 +40,7 @@ interface State extends Partial<Form> {
   selectedCondition?: string
   isEditingSection: boolean
   isNewSection: boolean
+  pages: Page[]
   errors: Partial<ErrorList<'path' | 'title'>>
 }
 
@@ -55,9 +56,17 @@ export class PageCreate extends Component<Props, State> {
   constructor(props: Props, context: typeof DataContext) {
     super(props, context)
 
+    const { data } = this.context
+
+    // Sort pages for select menus
+    const pages = structuredClone(data.pages).sort(
+      ({ title: titleA }, { title: titleB }) => titleA.localeCompare(titleB)
+    )
+
     this.state = {
       isEditingSection: false,
       isNewSection: false,
+      pages,
       errors: {}
     }
   }
@@ -210,10 +219,11 @@ export class PageCreate extends Component<Props, State> {
       path,
       isEditingSection,
       isNewSection,
+      pages,
       errors
     } = this.state
 
-    const { sections, pages } = data
+    const { sections } = data
     const hasErrors = hasValidationErrors(errors)
 
     return (
@@ -250,38 +260,6 @@ export class PageCreate extends Component<Props, State> {
               </option>
             </select>
           </div>
-
-          <div className="govuk-form-group">
-            <label className="govuk-label govuk-label--s" htmlFor="link-from">
-              {i18n('addPage.linkFromOption.title')}
-            </label>
-            <div className="govuk-hint" id="link-from-hint">
-              {i18n('addPage.linkFromOption.helpText')}
-            </div>
-            <select
-              className="govuk-select"
-              id="link-from"
-              aria-describedby="link-from-hint"
-              name="from"
-              value={linkFrom ?? ''}
-              onChange={this.onChangeLinkFrom}
-            >
-              <option value="" />
-              {pages.filter(hasNext).map((page) => (
-                <option key={page.path} value={page.path}>
-                  {page.path}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {linkFrom && (
-            <SelectConditions
-              path={linkFrom}
-              conditionsChange={this.conditionSelected}
-              noFieldsHintText={i18n('conditions.noFieldsAvailable')}
-            />
-          )}
 
           <Input
             id="page-title"
@@ -341,7 +319,9 @@ export class PageCreate extends Component<Props, State> {
                   value={section?.name ?? ''}
                   onChange={this.onChangeSection}
                 >
-                  <option value="" />
+                  <option value="">
+                    {i18n('addPage.sectionOption.option')}
+                  </option>
                   {sections.map((section) => (
                     <option key={section.name} value={section.name}>
                       {section.title}
@@ -369,6 +349,38 @@ export class PageCreate extends Component<Props, State> {
               </a>
             </p>
           </div>
+
+          <div className="govuk-form-group">
+            <label className="govuk-label govuk-label--s" htmlFor="link-from">
+              {i18n('addPage.linkFromOption.title')}
+            </label>
+            <div className="govuk-hint" id="link-from-hint">
+              {i18n('addPage.linkFromOption.helpText')}
+            </div>
+            <select
+              className="govuk-select"
+              id="link-from"
+              aria-describedby="link-from-hint"
+              name="from"
+              value={linkFrom ?? ''}
+              onChange={this.onChangeLinkFrom}
+            >
+              <option value="">{i18n('addPage.linkFromOption.option')}</option>
+              {pages.filter(hasNext).map((page) => (
+                <option key={page.path} value={page.path}>
+                  {page.title}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {linkFrom && (
+            <SelectConditions
+              path={linkFrom}
+              conditionsChange={this.conditionSelected}
+              noFieldsHintText={i18n('conditions.noFieldsAvailable')}
+            />
+          )}
 
           <div className="govuk-button-group">
             <button type="submit" className="govuk-button">

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -381,7 +381,7 @@ export class PageCreate extends Component<Props, State> {
             <Flyout
               title={
                 !isNewSection && !!section
-                  ? i18n('section.editingTitle', { title: section.title })
+                  ? i18n('section.editTitle', { title: section.title })
                   : i18n('section.add')
               }
               onHide={this.closeFlyout}

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -321,53 +321,54 @@ export class PageCreate extends Component<Props, State> {
             </>
           )}
 
-          {sections.length > 0 && (
-            <div className="govuk-form-group">
-              <label
-                className="govuk-label govuk-label--s"
-                htmlFor="page-section"
-              >
-                {i18n('addPage.sectionOption.title')}
-              </label>
-              <div className="govuk-hint" id="page-section-hint">
-                {i18n('addPage.sectionOption.helpText')}
-              </div>
-              <select
-                className="govuk-select"
-                id="page-section"
-                aria-describedby="page-section-hint"
-                name="section"
-                value={section?.name ?? ''}
-                onChange={this.onChangeSection}
-              >
-                <option value="" />
-                {sections.map((section) => (
-                  <option key={section.name} value={section.name}>
-                    {section.title}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          <p className="govuk-body">
-            {section && (
+          <div className="govuk-form-group">
+            {sections.length > 0 && (
+              <>
+                <label
+                  className="govuk-label govuk-label--s"
+                  htmlFor="page-section"
+                >
+                  {i18n('addPage.sectionOption.title')}
+                </label>
+                <div className="govuk-hint" id="page-section-hint">
+                  {i18n('addPage.sectionOption.helpText')}
+                </div>
+                <select
+                  className="govuk-select"
+                  id="page-section"
+                  aria-describedby="page-section-hint"
+                  name="section"
+                  value={section?.name ?? ''}
+                  onChange={this.onChangeSection}
+                >
+                  <option value="" />
+                  {sections.map((section) => (
+                    <option key={section.name} value={section.name}>
+                      {section.title}
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
+            <p className="govuk-body govuk-!-margin-top-2">
+              {section && (
+                <a
+                  href="#"
+                  className="govuk-link govuk-!-display-block"
+                  onClick={this.editSection}
+                >
+                  {i18n('section.edit')}
+                </a>
+              )}
               <a
                 href="#"
                 className="govuk-link govuk-!-display-block"
-                onClick={this.editSection}
+                onClick={(e) => this.editSection(e, true)}
               >
-                {i18n('section.edit')}
+                {i18n('section.add')}
               </a>
-            )}
-            <a
-              href="#"
-              className="govuk-link govuk-!-display-block"
-              onClick={this.editSection}
-            >
-              {i18n('section.create')}
-            </a>
-          </p>
+            </p>
+          </div>
 
           <div className="govuk-button-group">
             <button type="submit" className="govuk-button">
@@ -381,7 +382,7 @@ export class PageCreate extends Component<Props, State> {
               title={
                 !isNewSection && !!section
                   ? i18n('section.editingTitle', { title: section.title })
-                  : i18n('section.newTitle')
+                  : i18n('section.add')
               }
               onHide={this.closeFlyout}
             >

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -309,53 +309,54 @@ export class PageEdit extends Component<Props, State> {
             </>
           )}
 
-          {sections.length > 0 && (
-            <div className="govuk-form-group">
-              <label
-                className="govuk-label govuk-label--s"
-                htmlFor="page-section"
-              >
-                {i18n('page.section')}
-              </label>
-              <div className="govuk-hint" id="page-section-hint">
-                {i18n('page.sectionHint')}
-              </div>
-              <select
-                className="govuk-select"
-                id="page-section"
-                aria-describedby="page-section-hint"
-                name="section"
-                value={section?.name ?? ''}
-                onChange={this.onChangeSection}
-              >
-                <option value="" />
-                {sections.map((section) => (
-                  <option key={section.name} value={section.name}>
-                    {section.title}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          <p className="govuk-body">
-            {section && (
+          <div className="govuk-form-group">
+            {sections.length > 0 && (
+              <>
+                <label
+                  className="govuk-label govuk-label--s"
+                  htmlFor="page-section"
+                >
+                  {i18n('page.section')}
+                </label>
+                <div className="govuk-hint" id="page-section-hint">
+                  {i18n('page.sectionHint')}
+                </div>
+                <select
+                  className="govuk-select"
+                  id="page-section"
+                  aria-describedby="page-section-hint"
+                  name="section"
+                  value={section?.name ?? ''}
+                  onChange={this.onChangeSection}
+                >
+                  <option value="" />
+                  {sections.map((section) => (
+                    <option key={section.name} value={section.name}>
+                      {section.title}
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
+            <p className="govuk-body govuk-!-margin-top-2">
+              {section && (
+                <a
+                  href="#"
+                  className="govuk-link govuk-!-display-block"
+                  onClick={this.editSection}
+                >
+                  {i18n('section.edit')}
+                </a>
+              )}
               <a
                 href="#"
                 className="govuk-link govuk-!-display-block"
-                onClick={this.editSection}
+                onClick={(e) => this.editSection(e, true)}
               >
-                {i18n('section.edit')}
+                {i18n('section.add')}
               </a>
-            )}
-            <a
-              href="#"
-              className="govuk-link govuk-!-display-block"
-              onClick={(e) => this.editSection(e, true)}
-            >
-              {i18n('section.create')}
-            </a>
-          </p>
+            </p>
+          </div>
 
           <div className="govuk-button-group">
             <button className="govuk-button" type="submit">
@@ -377,7 +378,7 @@ export class PageEdit extends Component<Props, State> {
               title={
                 !isNewSection && !!section
                   ? i18n('section.editingTitle', { title: section.title })
-                  : i18n('section.newTitle')
+                  : i18n('section.add')
               }
               onHide={this.closeFlyout}
               show={isEditingSection}

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -329,7 +329,7 @@ export class PageEdit extends Component<Props, State> {
                   value={section?.name ?? ''}
                   onChange={this.onChangeSection}
                 >
-                  <option value="" />
+                  <option value="">{i18n('page.sectionOption')}</option>
                   {sections.map((section) => (
                     <option key={section.name} value={section.name}>
                       {section.title}

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -377,7 +377,7 @@ export class PageEdit extends Component<Props, State> {
             <Flyout
               title={
                 !isNewSection && !!section
-                  ? i18n('section.editingTitle', { title: section.title })
+                  ? i18n('section.editTitle', { title: section.title })
                   : i18n('section.add')
               }
               onHide={this.closeFlyout}

--- a/designer/client/src/components/FieldEditors/ConditionEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ConditionEdit.tsx
@@ -45,7 +45,7 @@ export function ConditionEdit({ context = ComponentContext }: Props) {
           })
         }
       >
-        <option value="" />
+        <option value="">{i18n('fieldEdit.conditions.option')}</option>
         {conditions.map((condition) => (
           <option key={condition.name} value={condition.name}>
             {condition.displayName}

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -148,7 +148,7 @@ export function Menu({ slug }: Props) {
 
       {page.isVisible && (
         <RenderInPortal>
-          <Flyout title="Add Page" onHide={page.hide}>
+          <Flyout title={i18n('page.add')} onHide={page.hide}>
             <PageCreate onSave={page.hide} />
           </Flyout>
         </RenderInPortal>
@@ -164,7 +164,7 @@ export function Menu({ slug }: Props) {
 
       {sections.isVisible && (
         <RenderInPortal>
-          <Flyout title="Edit Sections" onHide={sections.hide}>
+          <Flyout title={i18n('sections.edit')} onHide={sections.hide}>
             <SectionsEdit />
           </Flyout>
         </RenderInPortal>
@@ -184,7 +184,7 @@ export function Menu({ slug }: Props) {
 
       {lists.isVisible && (
         <RenderInPortal>
-          <Flyout title="Edit Lists" onHide={lists.hide}>
+          <Flyout title={i18n('list.addOrEdit')} onHide={lists.hide}>
             <ListsEditorContextProvider>
               <ListContextProvider>
                 <ListsEdit showEditLists={false} />
@@ -196,7 +196,7 @@ export function Menu({ slug }: Props) {
 
       {summary.isVisible && (
         <RenderInPortal>
-          <Flyout title="Edit Summary" onHide={summary.hide}>
+          <Flyout title={i18n('summary.edit')} onHide={summary.hide}>
             <DeclarationEdit onSave={summary.hide} />
           </Flyout>
         </RenderInPortal>

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -99,7 +99,7 @@ export const Page = (props: {
           className="govuk-link"
           aria-describedby={headingId}
         >
-          {i18n('Edit page')}
+          {i18n('page.edit')}
         </button>
         <a
           href={new URL(`/preview/draft/${slug}${page.path}`, previewUrl).href}
@@ -108,7 +108,7 @@ export const Page = (props: {
           rel="noreferrer"
           aria-describedby={headingId}
         >
-          {i18n('Preview page')}
+          {i18n('page.preview')}
         </a>
         <button
           onClick={() => setIsCreatingComponent(true)}
@@ -120,7 +120,10 @@ export const Page = (props: {
       </div>
       {isEditingPage && (
         <RenderInPortal>
-          <Flyout title="Edit Page" onHide={() => setIsEditingPage(false)}>
+          <Flyout
+            title={i18n('page.edit')}
+            onHide={() => setIsEditingPage(false)}
+          >
             <PageEdit page={page} onSave={() => setIsEditingPage(false)} />
           </Flyout>
         </RenderInPortal>

--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -8,6 +8,7 @@ import {
   type Pos
 } from '~/src/components/Visualisation/getLayout.js'
 import { DataContext } from '~/src/context/DataContext.js'
+import { i18n } from '~/src/i18n/i18n.jsx'
 
 interface Props {
   layout: Pos
@@ -105,7 +106,7 @@ export class Lines extends Component<Props, State> {
         {this.state.edge && (
           <RenderInPortal>
             <Flyout
-              title="Edit Link"
+              title={i18n('link.edit')}
               onHide={() => this.setState({ edge: undefined })}
             >
               <LinkEdit

--- a/designer/client/src/conditions/ConditionsEdit.test.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.test.tsx
@@ -216,7 +216,10 @@ describe('ConditionsEdit', () => {
         </RenderWithContext>
       )
 
-      const $button = screen.queryByRole('button', { name: 'Add condition' })
+      const $button = screen.queryByRole('button', {
+        name: 'Add a new condition'
+      })
+
       expect($button).toBeInTheDocument()
     })
 

--- a/designer/client/src/conditions/InlineConditionsDefinition.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinition.tsx
@@ -254,7 +254,9 @@ export class InlineConditionsDefinition extends Component<Props, State> {
               value={selectedCoordinator ?? condition?.coordinator ?? ''}
               onChange={this.onChangeCoordinator}
             >
-              <option value="" />
+              <option value="">
+                {i18n('conditions.conditionCoordinatorOption')}
+              </option>
               {Object.values(Coordinator).map((coordinator) => (
                 <option key={coordinator} value={coordinator}>
                   {upperFirst(coordinator)}
@@ -276,7 +278,9 @@ export class InlineConditionsDefinition extends Component<Props, State> {
                 value={hasConditionField(condition) ? condition.field.name : ''}
                 onChange={this.onChangeField}
               >
-                <option value="" />
+                <option value="">
+                  {i18n('conditions.conditionFieldOption')}
+                </option>
                 {fieldInputs.map((input, index) => (
                   <option key={`${input.name}-${index}`} value={input.name}>
                     {input.label}
@@ -298,7 +302,9 @@ export class InlineConditionsDefinition extends Component<Props, State> {
                     value={selectedOperator ?? condition.operator}
                     onChange={this.onChangeOperator}
                   >
-                    <option value="" />
+                    <option value="">
+                      {i18n('conditions.conditionOperatorOption')}
+                    </option>
                     {getOperatorNames(fieldDef.type)
                       .sort()
                       .map((operator) => (

--- a/designer/client/src/conditions/SelectConditions.test.tsx
+++ b/designer/client/src/conditions/SelectConditions.test.tsx
@@ -43,7 +43,7 @@ describe('SelectConditions', () => {
 
     const $paragraphs = screen.queryAllByRole('paragraph')
     const $conditions = screen.queryByRole('link', {
-      name: 'Define a new condition'
+      name: 'Add a new condition'
     })
 
     expect($paragraphs).toHaveLength(1)
@@ -267,7 +267,7 @@ describe('SelectConditions', () => {
 
     const $paragraphs = screen.queryAllByRole('paragraph')
     const $conditions = screen.queryByRole('link', {
-      name: 'Define a new condition'
+      name: 'Add a new condition'
     })
 
     expect($paragraphs).toHaveLength(1)

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -251,6 +251,9 @@ export class SelectConditions extends Component<Props, State> {
                 label={{
                   children: ['Select a condition']
                 }}
+                formGroup={{
+                  className: 'govuk-!-margin-bottom-2'
+                }}
                 onChange={this.onChangeConditionSelection}
                 required={false}
               />
@@ -262,7 +265,7 @@ export class SelectConditions extends Component<Props, State> {
                   className="govuk-link"
                   onClick={this.onClickDefineCondition}
                 >
-                  Define a new condition
+                  {i18n('conditions.add')}
                 </a>
               </p>
             )}

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -272,7 +272,7 @@ export class SelectConditions extends Component<Props, State> {
             {inline && (
               <RenderInPortal>
                 <Flyout
-                  title="Define condition"
+                  title={i18n('conditions.addTitle')}
                   onHide={this.onCancelInlineCondition}
                 >
                   <InlineConditions

--- a/designer/client/src/conditions/SelectValues.tsx
+++ b/designer/client/src/conditions/SelectValues.tsx
@@ -42,7 +42,7 @@ export const SelectValues = (props: Props) => {
         defaultValue={value?.value}
         onChange={onChangeSelect}
       >
-        <option value="" />
+        <option value="">{i18n('conditions.conditionValueOption')}</option>
         {fieldDef.values?.map((option) => (
           <option key={`${option.value}`} value={`${option.value}`}>
             {option.text}

--- a/designer/client/src/i18n/translations/cy.translation.json
+++ b/designer/client/src/i18n/translations/cy.translation.json
@@ -1,6 +1,6 @@
 {
-  "Edit page": "Golygu tudalen",
-  "Persona": "Persona",
-  "Preview": "Rhagolwg",
-  "Preview page": "Tudalen rhagolwg"
+  "page": {
+    "edit": "Golygu tudalen",
+    "preview": "Tudalen rhagolwg"
+  }
 }

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -16,10 +16,12 @@
       "hint": "You can add links between different pages and set conditions for links to control the page that loads next. For example, a question page with a component for yes and no options could have link conditions based on which option a user selects."
     },
     "linkFrom": {
-      "title": "Link from"
+      "title": "Link from",
+      "option": "Select a page"
     },
     "linkTo": {
-      "title": "Link to"
+      "title": "Link to",
+      "option": "Select a page"
     },
     "noFieldsAvailable": "You cannot add any conditions as there are no components on the page you wish to link from. Add a component, such as an Input or a Selection field, and then add a condition."
   },
@@ -46,7 +48,8 @@
     },
     "sectionOption": {
       "helpText": "Use sections to split a form. For example, to add a section per applicant. The section title appears above the page title. However, if these titles are the same, the form will only show the page title.",
-      "title": "Section (optional)"
+      "title": "Section (optional)",
+      "option": "Select a section"
     }
   },
   "cancel": "Cancel",
@@ -120,12 +123,16 @@
     "condition": "Condition",
     "conditionHint": "Set when a condition might be met in the form. For example, when the form asks a question and the user selects Yes instead of No (yes=true).",
     "conditionField": "Component title",
+    "conditionFieldOption": "Select a title",
     "conditionOperator": "Operator",
+    "conditionOperatorOption": "Select an operator",
     "conditionCoordinator": "Coordinator (optional)",
+    "conditionCoordinatorOption": "Select a coordinator",
     "conditionDatePeriod": "Period",
     "conditionDateUnits": "Units",
     "conditionDateDirection": "Direction",
-    "conditionValue": "Value"
+    "conditionValue": "Value",
+    "conditionValueOption": "Select a value"
   },
   "create": "create {{noun}}",
   "dateFieldEditComponent": {
@@ -150,7 +157,8 @@
   "field": "field",
   "fieldEdit": {
     "conditions": {
-      "hint": "Select a condition that determines whether to show the contents of this component. You can create and edit conditions from the Conditions screen."
+      "hint": "Select a condition that determines whether to show the contents of this component. You can create and edit conditions from the Conditions screen.",
+      "option": "Select a condition"
     },
     "details": {
       "hint": "Enter the text you want to show when users expand the title. You can apply basic HTML, such as text formatting and hyperlinks."
@@ -219,6 +227,7 @@
       "conditions": "Conditions (optional)",
       "conditionsHint": "Select a condition that determines whether to show this list item. You can create and edit conditions on the Conditions screen.",
       "createSubcomponent": "Create sub component",
+      "conditionsOption": "Select a condition",
       "editTitle": "Edit list item {{title, lowerFirst}}",
       "help": "Help text (optional)",
       "helpHint": "Enter the description to show for this list item",
@@ -308,6 +317,7 @@
     "pathHint": "Appears in the browser path. The value you enter in the page title field automatically populates the path name. To override it, enter your own path name, relevant to the page, and use lowercase text and hyphens between words. For example, '/personal-details'.",
     "section": "Section (optional)",
     "sectionHint": "Use sections to split a form. For example, to add a section per applicant. The section title appears above the page title. However, if these titles are the same, the form will only show the page title.",
+    "sectionOption": "Select a section",
     "title": "Page title"
   },
   "save": "Save",

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -105,7 +105,7 @@
     "moveDown_label": "Move {{name, lowerFirst}} component down"
   },
   "conditions": {
-    "add": "Add condition",
+    "add": "Add a new condition",
     "addOrEdit": "Add or edit condition",
     "addOrEditHint": "Set the rules that determine the conditional behaviour in the form flow. For example, a question page might have a component for yes and no options that need two conditions - one to control what happens if a user selects yes and one for when a user selects no.",
     "displayName": "Display name",
@@ -304,10 +304,9 @@
   },
   "save": "Save",
   "section": {
-    "create": "Create section",
+    "add": "Add a new section",
     "edit": "Edit section",
     "editingTitle": "Edit {{title, lowerFirst}}",
-    "newTitle": "Add a new section",
     "noun": "section",
     "noun_plural": "sections"
   },

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -106,6 +106,7 @@
   },
   "conditions": {
     "add": "Add a new condition",
+    "addTitle": "Add condition",
     "addOrEdit": "Add or edit condition",
     "addOrEditHint": "Set the rules that determine the conditional behaviour in the form flow. For example, a question page might have a component for yes and no options that need two conditions - one to control what happens if a user selects yes and one for when a user selects no.",
     "displayName": "Display name",
@@ -196,6 +197,9 @@
     "FileUploadField_info": "Allows a user to upload files"
   },
   "leaveDesigner": "Are you sure you want to leave the Designer? If you have unsaved changes they will be lost.",
+  "link": {
+    "edit": "Edit link"
+  },
   "list": {
     "add": "Add a new list",
     "addOrEdit": "Add or edit lists",
@@ -286,6 +290,9 @@
   },
   "optional": "{{noun}} (optional)",
   "page": {
+    "add": "Add page",
+    "edit": "Edit page",
+    "preview": "Preview page",
     "controller": "Page type",
     "controllerHint": "Select a Start Page to start a form, a Question Page to request information, and a Summary Page at the end of a section or form. For example, use a Summary to let users check their answers to questions before they submit the form.",
     "controllers": {
@@ -308,7 +315,8 @@
     "edit": "Edit section",
     "editingTitle": "Edit {{title, lowerFirst}}",
     "noun": "section",
-    "noun_plural": "sections"
+    "noun_plural": "sections",
+    "editTitle": "Edit {{title, lowerFirst}}"
   },
   "textFieldEditComponent": {
     "lengthField": {
@@ -347,6 +355,12 @@
       "helpText": "Tick this box if you do not want the section title to show on any pages in this section",
       "title": "Hide section title"
     }
+  },
+  "sections": {
+    "edit": "Edit sections"
+  },
+  "summary": {
+    "edit": "Edit summary"
   },
   "warning": "Warning",
   "wontShow": "This will not show on the page.",

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -30,7 +30,8 @@
     },
     "linkFromOption": {
       "helpText": "Add a link to this page from a different page in the form.",
-      "title": "Link from (optional)"
+      "title": "Link from (optional)",
+      "option": "Select a page"
     },
     "pageTitleField": {
       "title": "Page title"

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -1,15 +1,5 @@
 {
-  "A form with this name already exists": "A form with this name already exists",
-  "Create a new form": "Create a new form",
-  "Create a new form or edit an existing form": "Create a new form or edit an existing form",
-  "Edit page": "Edit page",
-  "Enter form name": "Enter form name",
-  "Enter the name for your form, for example Applying for visitors pass": "Enter the name for your form, for example Applying for visitors pass",
-  "Preview page": "Preview page",
-  "Select an existing form to edit": "Select an existing form to edit",
-  "Start": "Start",
   "Test": "For testing purpose, do not delete it",
-  "There is a problem": "There is a problem",
   "add": "Add",
   "addLink": {
     "header": {
@@ -52,7 +42,6 @@
       "option": "Select a section"
     }
   },
-  "cancel": "Cancel",
   "close": "Close",
   "common": {
     "autocomplete": {
@@ -134,7 +123,6 @@
     "conditionValue": "Value",
     "conditionValueOption": "Select a value"
   },
-  "create": "create {{noun}}",
   "dateFieldEditComponent": {
     "maxDaysInFutureField": {
       "helpText": "Determines the latest date users can enter",
@@ -146,7 +134,6 @@
     }
   },
   "delete": "Delete",
-  "edit": "edit {{noun}}",
   "error": "Error",
   "errors": {
     "required": "Enter {{field, lowerFirst}}",
@@ -154,7 +141,6 @@
     "spaces": "{{field, upperFirst}} must not include spaces",
     "duplicate": "{{field, upperFirst}} already exists"
   },
-  "field": "field",
   "fieldEdit": {
     "conditions": {
       "hint": "Select a condition that determines whether to show the contents of this component. You can create and edit conditions from the Conditions screen.",
@@ -205,7 +191,6 @@
     "FileUploadField": "File upload",
     "FileUploadField_info": "Allows a user to upload files"
   },
-  "leaveDesigner": "Are you sure you want to leave the Designer? If you have unsaved changes they will be lost.",
   "link": {
     "edit": "Edit link"
   },
@@ -226,13 +211,10 @@
       "add": "Add a new list item",
       "conditions": "Conditions (optional)",
       "conditionsHint": "Select a condition that determines whether to show this list item. You can create and edit conditions on the Conditions screen.",
-      "createSubcomponent": "Create sub component",
       "conditionsOption": "Select a condition",
       "editTitle": "Edit list item {{title, lowerFirst}}",
       "help": "Help text (optional)",
       "helpHint": "Enter the description to show for this list item",
-      "subComponent": "Sub component (optional)",
-      "subComponentHint": "You need a sub component if the list item answer needs more information, for example an email address. This will only be shown when the user selects this list item.",
       "title": "Item text",
       "titleHint": "Enter the text you want to show",
       "value": "Value",
@@ -275,7 +257,6 @@
   "name": {
     "hint": "This is generated automatically and does not show on the page. Only change it if you are using an integration that requires you to, for example GOV.UK Notify. It must not contain spaces."
   },
-  "no": "no",
   "numberFieldEditComponent": {
     "maxField": {
       "helpText": "Specifies the highest number users can enter",
@@ -298,7 +279,6 @@
       "title": "Suffix"
     }
   },
-  "optional": "{{noun}} (optional)",
   "page": {
     "add": "Add page",
     "edit": "Edit page",
@@ -311,8 +291,6 @@
       "fileUpload": "File upload",
       "summary": "Summary page"
     },
-    "noun": "page",
-    "noun_plural": "pages",
     "path": "Path",
     "pathHint": "Appears in the browser path. The value you enter in the page title field automatically populates the path name. To override it, enter your own path name, relevant to the page, and use lowercase text and hyphens between words. For example, '/personal-details'.",
     "section": "Section (optional)",
@@ -324,9 +302,6 @@
   "section": {
     "add": "Add a new section",
     "edit": "Edit section",
-    "editingTitle": "Edit {{title, lowerFirst}}",
-    "noun": "section",
-    "noun_plural": "sections",
     "editTitle": "Edit {{title, lowerFirst}}"
   },
   "textFieldEditComponent": {
@@ -372,8 +347,5 @@
   },
   "summary": {
     "edit": "Edit summary"
-  },
-  "warning": "Warning",
-  "wontShow": "This will not show on the page.",
-  "yes": "yes"
+  }
 }

--- a/designer/client/src/list/ListItemEdit.test.tsx
+++ b/designer/client/src/list/ListItemEdit.test.tsx
@@ -128,7 +128,9 @@ describe('ListItemEdit', () => {
     })
 
     expect($select.value).toBe('')
-    expect($select.options[$select.selectedIndex].textContent).toBe('')
+    expect($select.options[$select.selectedIndex].textContent).toBe(
+      'Select a condition'
+    )
 
     await act(() => userEvent.selectOptions($select, 'MYWwRN'))
 

--- a/designer/client/src/list/ListItemEdit.tsx
+++ b/designer/client/src/list/ListItemEdit.tsx
@@ -108,7 +108,7 @@ export function ListItemEdit() {
           value={condition}
           onChange={handleConditionChange}
         >
-          <option value="" />
+          <option value="">{i18n('list.item.conditionsOption')}</option>
           {conditions.map((condition) => (
             <option key={condition.name} value={condition.name}>
               {condition.displayName}


### PR DESCRIPTION
This PR adds some small UI tweaks for consistency

1. Prefer "Add a new" or "Edit" text for conditions/sections
2. Align page create/edit views by moving "Link from" to the bottom
3. Add default "Select an XXX" empty option to all select menus