### PR TITLE
Fix error on unknown component types etc

### DIFF
--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -3,7 +3,6 @@ import {
   hasTitle,
   slugify,
   type ComponentDef,
-  type FormDefinition,
   type Page
 } from '@defra/forms-model'
 import React, { useContext, useState, type FunctionComponent } from 'react'
@@ -232,7 +231,6 @@ export const componentTypes = {
 }
 
 export interface Props {
-  data: FormDefinition
   page: Page
   selectedComponent: ComponentDef
   index: number

--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -244,6 +244,12 @@ export const Component: FunctionComponent<Props> = (props) => {
   const onSave = () => setShowEditor(!showEditor)
 
   const { title, type } = selectedComponent
+
+  // Check if component type is supported
+  if (!(type in componentTypes)) {
+    return null
+  }
+
   const ComponentIcon = componentTypes[type]
 
   const pageId = slugify(page.path)

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -1,8 +1,7 @@
 import {
   slugify,
   type ComponentDef,
-  type Page as PageType,
-  type FormDefinition
+  type Page as PageType
 } from '@defra/forms-model'
 import React, { useContext, useState, type CSSProperties } from 'react'
 
@@ -21,9 +20,8 @@ const ComponentItem = (props: {
   index: number
   page: PageType
   selectedComponent: ComponentDef
-  data: FormDefinition
 }) => {
-  const { index, page, selectedComponent, data } = props
+  const { index, page, selectedComponent } = props
 
   return (
     <div className="component-item">
@@ -31,16 +29,13 @@ const ComponentItem = (props: {
         key={index}
         index={index}
         page={page}
-        data={data}
         selectedComponent={selectedComponent}
       />
     </div>
   )
 }
 
-const ComponentList = (props: { page: PageType; data: FormDefinition }) => {
-  const { page, data } = props
-
+const ComponentList = ({ page }: { page: PageType }) => {
   if (!hasComponents(page) || !page.components.length) {
     return null
   }
@@ -54,7 +49,6 @@ const ComponentList = (props: { page: PageType; data: FormDefinition }) => {
           key={index}
           index={index}
           page={page}
-          data={data}
           selectedComponent={component}
         />
       ))}
@@ -91,7 +85,7 @@ export const Page = (props: {
         </h3>
       </div>
 
-      <ComponentList page={page} data={data} />
+      <ComponentList page={page} />
 
       <div className="page__actions">
         <button

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -10,7 +10,7 @@ import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 describe('Visualisation', () => {
   afterEach(cleanup)
 
-  test('Graph is rendered with correct number of pages and updates', async () => {
+  test('Graph is rendered with correct number of pages and updates', () => {
     const data = {
       pages: [
         {

--- a/designer/client/src/components/Visualisation/getLayout.ts
+++ b/designer/client/src/components/Visualisation/getLayout.ts
@@ -1,7 +1,9 @@
 import { graphlib, layout, type GraphEdge, type Node } from '@dagrejs/dagre'
 import { type FormDefinition } from '@defra/forms-model'
 
+import { logger } from '~/src/common/helpers/logging/logger.js'
 import { findPage } from '~/src/data/page/findPage.js'
+import { hasNext } from '~/src/data/page/hasNext.js'
 
 export interface Point {
   node: Node
@@ -58,18 +60,22 @@ export const getLayout = (data: FormDefinition, el: HTMLDivElement) => {
 
   // Add edges to the graph.
   pages.forEach((page) => {
-    if (!Array.isArray(page.next)) {
+    if (!hasNext(page)) {
       return
     }
 
     page.next.forEach((next) => {
-      const pageNext = findPage(data, next.path)
-      const condition = conditions.find(({ name }) => name === next.condition)
+      try {
+        const pageNext = findPage(data, next.path)
+        const condition = conditions.find(({ name }) => name === next.condition)
 
-      g.setEdge(page.path, pageNext.path, {
-        label: condition?.displayName,
-        width: condition?.displayName ? 270 : undefined
-      })
+        g.setEdge(page.path, pageNext.path, {
+          label: condition?.displayName,
+          width: condition?.displayName ? 270 : undefined
+        })
+      } catch (error) {
+        logger.error(error, 'Visualisation')
+      }
     })
   })
 

--- a/designer/client/test/helpers/renderers-lists.tsx
+++ b/designer/client/test/helpers/renderers-lists.tsx
@@ -13,25 +13,29 @@ export interface RenderListEditorWithContextProps {
   children: ReactElement
   selectedListName?: string
   data: DataContextType['data']
+  meta?: DataContextType['meta']
   save?: DataContextType['save']
   state?: Parameters<typeof initComponentState>[0]
 }
 
-export function RenderListEditorWithContext({
-  children,
-  selectedListName,
-  state: componentState,
-  data,
-  save = jest.fn()
-}: RenderListEditorWithContextProps) {
+export function RenderListEditorWithContext(
+  props: RenderListEditorWithContextProps
+) {
   const [state, dispatch] = useReducer(
     componentReducer,
-    initComponentState(componentState),
-    initComponentState
+    initComponentState(props.state)
   )
 
+  const {
+    children,
+    selectedListName,
+    data = {} as DataContextType['data'],
+    meta,
+    save = jest.fn()
+  } = props
+
   return (
-    <DataContext.Provider value={{ data, save }}>
+    <DataContext.Provider value={{ data, meta, save }}>
       <ListsEditorContextProvider>
         <ComponentContext.Provider value={{ state, dispatch }}>
           <ListContextProvider selectedListName={selectedListName}>

--- a/designer/server/src/common/components/service-header/service-header.js
+++ b/designer/server/src/common/components/service-header/service-header.js
@@ -13,9 +13,14 @@ export class ServiceHeader {
    * @param {Element | null} $module - HTML element to use for header
    */
   constructor($module) {
+    const $navigation = $module?.querySelectorAll('[data-one-login-header-nav]')
+
+    if (!($module instanceof HTMLElement) || !$navigation?.length) {
+      return
+    }
+
     this.$module = $module
-    this.$navigation =
-      $module?.querySelectorAll('[data-one-login-header-nav]') ?? []
+    this.$navigation = $navigation
 
     /**
      * The header can render with one or two navigation elements which collapse
@@ -25,7 +30,7 @@ export class ServiceHeader {
      * 2. an aria-controls attribute which can be mapped to the ID of the element
      * that should be hidden on mobile
      */
-    for (const $nav of this.$navigation) {
+    for (const $nav of Array.from(this.$navigation)) {
       const $menuButton = $nav.querySelector('.js-x-header-toggle')
       const $menuId = $menuButton?.getAttribute('aria-controls')
 

--- a/designer/server/src/routes/forms/edit.test.js
+++ b/designer/server/src/routes/forms/edit.test.js
@@ -124,9 +124,11 @@ describe('Forms library routes', () => {
 
   test('POST - should redirect to overviewpage after updating title', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
-    jest
-      .mocked(forms.updateMetadata)
-      .mockResolvedValueOnce({ slug: 'new-title' })
+    jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
+      id: formMetadata.id,
+      slug: 'new-title',
+      status: 'updated'
+    })
 
     const options = {
       method: 'post',

--- a/model/src/utils/helpers.ts
+++ b/model/src/utils/helpers.ts
@@ -1,39 +1,5 @@
 import slug from 'slug'
 
-export const serialiseAndDeserialise = <T>(obj: T): T => {
-  if (typeof obj === 'object' && obj !== null) {
-    return JSON.parse(JSON.stringify(obj))
-  }
-
-  return obj
-}
-
-export const clone = <T>(obj: T & { clone?: () => T }): T => {
-  if (obj) {
-    if (typeof obj.clone === 'function') {
-      return obj.clone()
-    }
-
-    return serialiseAndDeserialise<T>(obj)
-  }
-  return obj
-}
-
-export function filter<T extends Record<string, unknown>>(
-  obj: T,
-  predicate: (value: any) => boolean
-): Partial<T> {
-  const result = {}
-
-  for (const [key, value] of Object.entries(obj)) {
-    if (value && predicate(value)) {
-      result[key] = value
-    }
-  }
-
-  return result
-}
-
 /**
  * Replace whitespace, en-dashes and em-dashes with spaces
  * before running through the slug package


### PR DESCRIPTION
This PR fixes a JavaScript error when importing JSON with unknown component types

We attempted to render `<ComponentIcon>` when it was `undefined` and the editor crashes

I've also included some minor type fixes and removed unused model helpers