### PR TITLE
Fix browser pino logger `undefined` issue

### DIFF
--- a/designer/server/src/routes/forms/api.js
+++ b/designer/server/src/routes/forms/api.js
@@ -94,10 +94,11 @@ export default [
     path: '/api/log',
     options: {
       handler(request, h) {
-        const { level, messages, error } = request.payload
+        const { logger, payload } = request
+        const { level, messages, error } = payload
 
         try {
-          const logFn = request.logger[level]
+          const logFn = logger[level].bind(logger)
 
           // Include error if present
           if (error) {
@@ -108,7 +109,7 @@ export default [
 
           return h.response({ ok: true }).code(StatusCodes.NO_CONTENT)
         } catch (error) {
-          request.logger.error(error)
+          logger.error(error)
           return h
             .response({ ok: false })
             .code(StatusCodes.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
This PR resolves an issue where browser error logging gets stuck in a loop

1. Error is caught
2. Error is logged
3. Logger throws
4. Repeat

Probably caused by a recent Pino update, a new webpack optimisation, or when the **forms-designer** `/api` endpoint responds with an empty `err: {}` object when Joi validation fails 😬 

```console
TypeError: Cannot read properties of undefined (reading 'Symbol(pino.msgPrefix)')
    at LOG (/path/to/forms-designer/node_modules/hapi-pino/node_modules/pino/lib/tools.js:59:22)
    at handler (file:///path/to/forms-designer/designer/server/src/routes/forms/api.js:104:13)
```