### PR TITLE
Fix title overflow affecting `<Flyout>` component

### DIFF
--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -352,9 +352,9 @@ export class PageCreate extends Component<Props, State> {
             <>
               {!sections.length && (
                 <>
-                  <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
+                  <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
                     {i18n('addPage.sectionOption.title')}
-                  </h4>
+                  </h3>
                   <p className="govuk-hint govuk-!-margin-top-0">
                     {i18n('addPage.sectionOption.helpText')}
                   </p>

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -400,9 +400,9 @@ export class PageEdit extends Component<Props, State> {
             <>
               {!sections.length && (
                 <>
-                  <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
+                  <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
                     {i18n('page.section')}
-                  </h4>
+                  </h3>
                   <p className="govuk-hint govuk-!-margin-top-0">
                     {i18n('page.sectionHint')}
                   </p>

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -139,16 +139,16 @@ export function ComponentCreate(props: Readonly<Props>) {
 
   return (
     <>
-      {!type && <h4 className="govuk-heading-m">{i18n('component.create')}</h4>}
+      {!type && <h2 className="govuk-heading-m">{i18n('component.create')}</h2>}
       {type && (
         <>
           <BackLink onClick={handleReset} href="#">
             {i18n('Back to create component list')}
           </BackLink>
-          <h4 className="govuk-heading-m">
+          <h2 className="govuk-heading-m">
             {i18n(`fieldTypeToName.${selectedComponent.type}`)}{' '}
             {i18n('component.component')}
-          </h4>
+          </h2>
         </>
       )}
       {hasErrors && (

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -55,10 +55,10 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
 
   return (
     <div className="govuk-form-group">
-      <h1 className="govuk-hint">{i18n('component.create_info')}</h1>
+      <div className="govuk-hint">{i18n('component.create_info')}</div>
       <ol className="govuk-list">
         <li>
-          <h2 className="govuk-heading-s">{i18n('Content')}</h2>
+          <h3 className="govuk-heading-s">{i18n('Content')}</h3>
           <div className="govuk-hint">
             {i18n('component.contentfields_info')}
           </div>
@@ -87,7 +87,7 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
         {isComponentPage && (
           <>
             <li>
-              <h2 className="govuk-heading-s">{i18n('Input fields')}</h2>
+              <h3 className="govuk-heading-s">{i18n('Input fields')}</h3>
               <div className="govuk-hint">
                 {i18n('component.inputfields_info')}
               </div>
@@ -112,7 +112,7 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
               <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
             </li>
             <li>
-              <h2 className="govuk-heading-s">{i18n('Selection fields')}</h2>
+              <h3 className="govuk-heading-s">{i18n('Selection fields')}</h3>
               <div className="govuk-hint">
                 {i18n('component.selectfields_info')}
               </div>

--- a/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
+++ b/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
@@ -5,20 +5,20 @@ exports[`ComponentCreateList should match snapshot 1`] = `
   <div
     class="govuk-form-group"
   >
-    <h1
+    <div
       class="govuk-hint"
     >
       Select a component to add to your page. If your page has only one component, the component title does not show on the page. To name or describe the component, use the page title instead.
-    </h1>
+    </div>
     <ol
       class="govuk-list"
     >
       <li>
-        <h2
+        <h3
           class="govuk-heading-s"
         >
           Content
-        </h2>
+        </h3>
         <div
           class="govuk-hint"
         >
@@ -101,11 +101,11 @@ exports[`ComponentCreateList should match snapshot 1`] = `
         />
       </li>
       <li>
-        <h2
+        <h3
           class="govuk-heading-s"
         >
           Input fields
-        </h2>
+        </h3>
         <div
           class="govuk-hint"
         >
@@ -256,11 +256,11 @@ exports[`ComponentCreateList should match snapshot 1`] = `
         />
       </li>
       <li>
-        <h2
+        <h3
           class="govuk-heading-s"
         >
           Selection fields
-        </h2>
+        </h3>
         <div
           class="govuk-hint"
         >

--- a/designer/client/src/components/Flyout/Flyout.scss
+++ b/designer/client/src/components/Flyout/Flyout.scss
@@ -43,16 +43,6 @@
     textarea {
       resize: vertical;
     }
-
-    .panel {
-      display: flex;
-      max-height: 100%;
-      flex-direction: column;
-    }
-
-    .panel-body {
-      flex: 1;
-    }
   }
 
   &.hide {
@@ -78,5 +68,26 @@
 
   & h2 a:hover {
     text-decoration: underline;
+  }
+}
+
+.panel {
+  position: relative;
+  display: flex;
+  max-height: 100%;
+  flex-direction: column;
+
+  &__header,
+  &__body {
+    padding: govuk-spacing(4);
+  }
+
+  &__header {
+    padding-right: govuk-em(75px, $context-font-size: 16);
+    padding-bottom: 0;
+  }
+
+  &__body {
+    padding-top: 0;
   }
 }

--- a/designer/client/src/components/Flyout/Flyout.tsx
+++ b/designer/client/src/components/Flyout/Flyout.tsx
@@ -48,13 +48,11 @@ export function useFlyoutEffect(props?: Readonly<Pick<Props, 'onHide'>>) {
    * Update styling for offset flyouts
    */
   useEffect(() => {
-    if (offset > 0) {
-      setStyle({
-        paddingLeft: `${offset * 50}px`,
-        transform: `translateX(${offset * -50}px)`,
-        position: 'relative'
-      })
-    }
+    setStyle({
+      paddingLeft: `${offset * 50}px`,
+      transform: `translateX(${offset * -50}px)`,
+      position: 'relative'
+    })
   }, [offset])
 
   function closeOnClick(
@@ -84,8 +82,11 @@ export function Flyout(props: Readonly<Props>) {
     onHide
   })
 
+  const count = offset + 1
+  const flyoutId = `flyout-${count}`
+
   return (
-    <div className="flyout show" data-testid={`flyout-${offset}`}>
+    <div className="flyout show" data-testid={flyoutId}>
       <FocusTrap
         focusTrapOptions={{
           preventScroll: true,

--- a/designer/client/src/components/Flyout/Flyout.tsx
+++ b/designer/client/src/components/Flyout/Flyout.tsx
@@ -102,7 +102,7 @@ export function Flyout(props: Readonly<Props>) {
           </button>
           <div className="panel">
             <div className="panel__header">
-              {title && <h4 className="govuk-heading-m">{title}</h4>}
+              {title && <h2 className="govuk-heading-m">{title}</h2>}
             </div>
             <div className="panel__body">{children}</div>
           </div>

--- a/designer/client/src/components/Flyout/Flyout.tsx
+++ b/designer/client/src/components/Flyout/Flyout.tsx
@@ -100,15 +100,11 @@ export function Flyout(props: Readonly<Props>) {
           >
             {i18n('close')}
           </button>
-          <div className="panel panel--flyout">
-            <div className="panel-header govuk-!-padding-top-4 govuk-!-padding-left-4">
+          <div className="panel">
+            <div className="panel__header">
               {title && <h4 className="govuk-heading-m">{title}</h4>}
             </div>
-            <div className="panel-body">
-              <div className="govuk-!-padding-left-4 govuk-!-padding-right-4 govuk-!-padding-bottom-4">
-                {children}
-              </div>
-            </div>
+            <div className="panel__body">{children}</div>
           </div>
         </div>
       </FocusTrap>

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -37,9 +37,9 @@ export function Menu() {
       panel: {
         children: (
           <>
-            <h4 className="govuk-heading-m govuk-!-margin-bottom-2">
+            <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
               Definition
-            </h4>
+            </h3>
             <p className="govuk-body">Form definition JSON</p>
 
             <DataPrettyPrint className="language-json">{data}</DataPrettyPrint>
@@ -53,9 +53,9 @@ export function Menu() {
       panel: {
         children: (
           <>
-            <h4 className="govuk-heading-m govuk-!-margin-bottom-2">
+            <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
               Metadata
-            </h4>
+            </h3>
             <p className="govuk-body">Form metadata JSON</p>
 
             <DataPrettyPrint className="language-json">{meta}</DataPrettyPrint>
@@ -69,7 +69,7 @@ export function Menu() {
       panel: {
         children: (
           <>
-            <h4 className="govuk-heading-m govuk-!-margin-bottom-2">Pages</h4>
+            <h3 className="govuk-heading-s govuk-!-margin-bottom-1">Pages</h3>
             <p className="govuk-body">
               Form definition JSON <code>pages</code> showing paths and titles
             </p>
@@ -90,9 +90,9 @@ export function Menu() {
       panel: {
         children: (
           <>
-            <h4 className="govuk-heading-m govuk-!-margin-bottom-2">
+            <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
               Components
-            </h4>
+            </h3>
             <p className="govuk-body">
               Form definition JSON <code>components</code> showing name, type
               and (optional) list
@@ -197,7 +197,11 @@ export function Menu() {
 
       {overview.isVisible && (
         <RenderInPortal>
-          <Flyout width="xlarge" onHide={overview.hide}>
+          <Flyout
+            title={i18n('menu.overview')}
+            width="xlarge"
+            onHide={overview.hide}
+          >
             <Tabs
               title={i18n('menu.overview')}
               items={overviewTabs}

--- a/designer/client/src/conditions/InlineConditions.tsx
+++ b/designer/client/src/conditions/InlineConditions.tsx
@@ -250,9 +250,9 @@ export class InlineConditions extends Component<Props, State> {
             onChange={this.onChangeDisplayName}
           />
         </div>
-        <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
+        <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
           {i18n('conditions.condition')}
-        </h4>
+        </h3>
         <p className="govuk-hint govuk-!-margin-top-0">
           {i18n('conditions.conditionHint')}
         </p>

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -232,9 +232,9 @@ export class SelectConditions extends Component<Props, State> {
 
     return (
       <>
-        <h4 className="govuk-heading-s govuk-!-margin-bottom-1">
+        <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
           {i18n('conditions.optional')}
-        </h4>
+        </h3>
         {hasFields || hasConditionsForPath ? (
           <>
             {hasConditionsForPath && (

--- a/designer/client/src/context/FlyoutContext.ts
+++ b/designer/client/src/context/FlyoutContext.ts
@@ -7,7 +7,7 @@ export interface FlyoutContextType {
 }
 
 export const FlyoutContext = createContext<FlyoutContextType>({
-  count: 1,
+  count: 0,
   increment: () => undefined,
   decrement: () => undefined
 })

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -307,7 +307,3 @@ p code {
     }
   }
 }
-
-.panel--flyout {
-  position: relative;
-}

--- a/designer/client/test/helpers/renderers.tsx
+++ b/designer/client/test/helpers/renderers.tsx
@@ -45,7 +45,7 @@ export function RenderWithContext(props: Readonly<RenderWithContextProps>) {
       <FlyoutContext.Provider
         value={useMemo(
           () => ({
-            count: 1,
+            count: 0,
             increment: jest.fn(),
             decrement: jest.fn()
           }),


### PR DESCRIPTION
This PR fixes an issue affecting long flyout titles (e.g. when editing lists)

I've also adjusted the heading order for accessibility and removed the -50px offset from the first flyout

# Before

No safe space around close button

<img width="619" alt="Flyout title, before" src="https://github.com/user-attachments/assets/2977da86-3928-473a-8934-d2e2e6f22fc1">

# After

Safe space added around close button

<img width="620" alt="Flyout title, after" src="https://github.com/user-attachments/assets/3b99dddd-0383-4836-a3ae-6f757f484d07">
