### PR TITLE
Enable file upload component

### DIFF
--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -177,7 +177,7 @@ export function FieldEdit() {
                 htmlFor="field-options-required"
               >
                 {i18n('common.componentOptionalOption.title', {
-                  component: defaults?.title ?? ''
+                  component: defaults.title
                 })}
               </label>
               <div

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -102,7 +102,9 @@ export class PageCreate extends Component<Props, State> {
     } = this.state
 
     // Page defaults
-    const defaults = getPageDefaults({ controller })
+    const defaults = getPageDefaults({
+      controller: controller ?? ControllerType.Page
+    })
 
     // Remove trailing spaces and hyphens
     const payload = {

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -78,7 +78,9 @@ export class PageEdit extends Component<Props, State> {
     const { data } = this.context
 
     const { path, title } = page
-    const controller = controllerNameFromPath(page.controller)
+    const controller = controllerNameFromPath(
+      page.controller ?? ControllerType.Page
+    )
 
     this.setState({
       path,
@@ -98,7 +100,9 @@ export class PageEdit extends Component<Props, State> {
     const { page, onSave } = this.props
 
     // Page defaults
-    const defaults = getPageDefaults({ controller })
+    const defaults = getPageDefaults({
+      controller: controller ?? ControllerType.Page
+    })
 
     // Remove trailing spaces and hyphens
     const payload = {

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -34,7 +34,7 @@ import { deleteLink } from '~/src/data/page/deleteLink.js'
 import { findPage } from '~/src/data/page/findPage.js'
 import { updateLinksTo } from '~/src/data/page/updateLinksTo.js'
 import { findSection } from '~/src/data/section/findSection.js'
-import { isControllerAllowed } from '~/src/helpers.js'
+import { isComponentAllowed, isControllerAllowed } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import {
@@ -135,9 +135,13 @@ export class PageEdit extends Component<Props, State> {
       }
     }
 
-    // Copy over components
+    // Copy over allowed components only
     if (hasComponents(pageEdit) && hasComponents(pageUpdate)) {
-      pageUpdate.components = pageEdit.components
+      pageUpdate.components.unshift(
+        ...pageEdit.components.filter(
+          isComponentAllowed({ controller: payload.controller })
+        )
+      )
     }
 
     // Copy over links

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -47,13 +47,15 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
 
   return (
     <div className="govuk-form-group">
-      <div className="govuk-hint">{i18n('component.create_info')}</div>
+      <div className="govuk-hint">{i18n('componentCreate.hint')}</div>
       <ol className="govuk-list">
         <li>
-          <h3 className="govuk-heading-s">{i18n('Content')}</h3>
-          <div className="govuk-hint">
-            {i18n('component.contentfields_info')}
-          </div>
+          <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
+            {i18n('componentCreate.contentFields.title')}
+          </h3>
+          <p className="govuk-body">
+            {i18n('componentCreate.contentFields.info')}
+          </p>
           <ol className="govuk-list">
             {contentFields.map((component) => (
               <li key={component.name}>
@@ -82,10 +84,12 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
         {isComponentPage && (
           <>
             <li>
-              <h3 className="govuk-heading-s">{i18n('Input fields')}</h3>
-              <div className="govuk-hint">
-                {i18n('component.inputfields_info')}
-              </div>
+              <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
+                {i18n('componentCreate.inputFields.title')}
+              </h3>
+              <p className="govuk-body">
+                {i18n('componentCreate.inputFields.info')}
+              </p>
               <ol className="govuk-list">
                 {inputFields.map((component) => (
                   <li key={component.type}>
@@ -110,10 +114,12 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
               <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
             </li>
             <li>
-              <h3 className="govuk-heading-s">{i18n('Selection fields')}</h3>
-              <div className="govuk-hint">
-                {i18n('component.selectfields_info')}
-              </div>
+              <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
+                {i18n('componentCreate.selectionFields.title')}
+              </h3>
+              <p className="govuk-body">
+                {i18n('componentCreate.selectionFields.info')}
+              </p>
               <ol className="govuk-list">
                 {selectionFields.map((component) => (
                   <li key={component.type}>

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -3,33 +3,14 @@ import {
   controllerNameFromPath,
   ControllerType,
   hasContent,
+  hasInputField,
   hasSelectionFields,
   type ComponentDef,
-  type ContentComponentsDef,
-  type Page,
-  type SelectionComponentsDef
+  type Page
 } from '@defra/forms-model'
-import React, { type MouseEvent, useCallback } from 'react'
+import React, { type MouseEvent, useCallback, useMemo } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
-
-const contentFields: ContentComponentsDef[] = []
-const selectionFields: SelectionComponentsDef[] = []
-const inputFields: ComponentDef[] = []
-
-const ComponentTypesSorted = [...structuredClone(ComponentTypes)].sort(
-  ({ type: typeA }, { type: typeB }) => typeA.localeCompare(typeB)
-)
-
-for (const component of ComponentTypesSorted) {
-  if (hasContent(component)) {
-    contentFields.push(component)
-  } else if (hasSelectionFields(component)) {
-    selectionFields.push(component)
-  } else {
-    inputFields.push(component)
-  }
-}
 
 interface Props {
   page: Page
@@ -52,6 +33,20 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
     },
     [onSelectComponent]
   )
+
+  const componentList = useMemo(() => {
+    return [...structuredClone(ComponentTypes)].sort(
+      ({ type: typeA }, { type: typeB }) => typeA.localeCompare(typeB)
+    )
+  }, [])
+
+  const { contentFields, selectionFields, inputFields } = useMemo(() => {
+    return {
+      contentFields: componentList.filter(hasContent),
+      selectionFields: componentList.filter(hasSelectionFields),
+      inputFields: componentList.filter(hasInputField)
+    }
+  }, [componentList])
 
   return (
     <div className="govuk-form-group">

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -21,7 +21,10 @@ interface Props {
 
 export const ComponentCreateList = (props: Readonly<Props>) => {
   const { page, onSelectComponent } = props
-  const controller = controllerNameFromPath(page.controller)
+
+  const controller = controllerNameFromPath(
+    page.controller ?? ControllerType.Page
+  )
 
   // Allow component pages to add input + selection fields
   const isComponentPage =

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -8,7 +8,7 @@ import {
   type ComponentDef,
   type Page
 } from '@defra/forms-model'
-import React, { type MouseEvent, useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 
@@ -25,14 +25,6 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
   const isComponentPage =
     controller === ControllerType.Page ||
     controller === ControllerType.FileUpload
-
-  const selectComponent = useCallback(
-    (event: MouseEvent<HTMLAnchorElement>, component: ComponentDef) => {
-      event.preventDefault()
-      onSelectComponent(component)
-    },
-    [onSelectComponent]
-  )
 
   const componentList = useMemo(() => {
     return [...structuredClone(ComponentTypes)].sort(
@@ -64,7 +56,10 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
                   <a
                     className="govuk-link"
                     href="#0"
-                    onClick={(e) => selectComponent(e, component)}
+                    onClick={(e) => {
+                      e.preventDefault()
+                      onSelectComponent(component)
+                    }}
                   >
                     {i18n(`fieldTypeToName.${component.type}`)}
                   </a>
@@ -93,7 +88,10 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
                       <a
                         href="#0"
                         className="govuk-link"
-                        onClick={(e) => selectComponent(e, component)}
+                        onClick={(e) => {
+                          e.preventDefault()
+                          onSelectComponent(component)
+                        }}
                       >
                         {i18n(`fieldTypeToName.${component.type}`)}
                       </a>
@@ -118,7 +116,10 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
                       <a
                         href="#0"
                         className="govuk-link"
-                        onClick={(e) => selectComponent(e, component)}
+                        onClick={(e) => {
+                          e.preventDefault()
+                          onSelectComponent(component)
+                        }}
                       >
                         {i18n(`fieldTypeToName.${component.type}`)}
                       </a>

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -11,6 +11,7 @@ import {
 } from '@defra/forms-model'
 import React, { useMemo } from 'react'
 
+import { isComponentAllowed } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 
 interface Props {
@@ -28,10 +29,10 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
     controller === ControllerType.FileUpload
 
   const componentList = useMemo(() => {
-    return [...structuredClone(ComponentTypes)].sort(
-      ({ type: typeA }, { type: typeB }) => typeA.localeCompare(typeB)
-    )
-  }, [])
+    return [...structuredClone(ComponentTypes)]
+      .filter(isComponentAllowed(page))
+      .sort(({ type: typeA }, { type: typeB }) => typeA.localeCompare(typeB))
+  }, [page])
 
   const { contentFields, selectionFields, inputFields } = useMemo(() => {
     return {
@@ -56,27 +57,34 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
           <p className="govuk-body">
             {i18n('componentCreate.contentFields.info')}
           </p>
-          <ol className="govuk-list">
-            {contentFields.map((component) => (
-              <li key={component.name}>
-                <p className="govuk-body govuk-!-margin-bottom-2">
-                  <a
-                    className="govuk-link"
-                    href="#0"
-                    onClick={(e) => {
-                      e.preventDefault()
-                      onSelectComponent(component)
-                    }}
-                  >
-                    {i18n(`fieldTypeToName.${component.type}`)}
-                  </a>
-                </p>
-                <div className="govuk-hint govuk-!-margin-top-2">
-                  {i18n(`fieldTypeToName.${component.type}_info`)}
-                </div>
-              </li>
-            ))}
-          </ol>
+          {!contentFields.length && (
+            <p className="govuk-hint">
+              {i18n('componentCreate.contentFields.unavailable')}
+            </p>
+          )}
+          {!!contentFields.length && (
+            <ol className="govuk-list">
+              {contentFields.map((component) => (
+                <li key={component.name}>
+                  <p className="govuk-body govuk-!-margin-bottom-2">
+                    <a
+                      className="govuk-link"
+                      href="#0"
+                      onClick={(e) => {
+                        e.preventDefault()
+                        onSelectComponent(component)
+                      }}
+                    >
+                      {i18n(`fieldTypeToName.${component.type}`)}
+                    </a>
+                  </p>
+                  <div className="govuk-hint govuk-!-margin-top-2">
+                    {i18n(`fieldTypeToName.${component.type}_info`)}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
           {isComponentPage && (
             <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
           )}
@@ -90,27 +98,34 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
               <p className="govuk-body">
                 {i18n('componentCreate.inputFields.info')}
               </p>
-              <ol className="govuk-list">
-                {inputFields.map((component) => (
-                  <li key={component.type}>
-                    <p className="govuk-body govuk-!-margin-bottom-2">
-                      <a
-                        href="#0"
-                        className="govuk-link"
-                        onClick={(e) => {
-                          e.preventDefault()
-                          onSelectComponent(component)
-                        }}
-                      >
-                        {i18n(`fieldTypeToName.${component.type}`)}
-                      </a>
-                    </p>
-                    <div className="govuk-hint govuk-!-margin-top-2">
-                      {i18n(`fieldTypeToName.${component.type}_info`)}
-                    </div>
-                  </li>
-                ))}
-              </ol>
+              {!inputFields.length && (
+                <p className="govuk-hint">
+                  {i18n('componentCreate.inputFields.unavailable')}
+                </p>
+              )}
+              {!!inputFields.length && (
+                <ol className="govuk-list">
+                  {inputFields.map((component) => (
+                    <li key={component.type}>
+                      <p className="govuk-body govuk-!-margin-bottom-2">
+                        <a
+                          href="#0"
+                          className="govuk-link"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            onSelectComponent(component)
+                          }}
+                        >
+                          {i18n(`fieldTypeToName.${component.type}`)}
+                        </a>
+                      </p>
+                      <div className="govuk-hint govuk-!-margin-top-2">
+                        {i18n(`fieldTypeToName.${component.type}_info`)}
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
               <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
             </li>
             <li>
@@ -120,27 +135,34 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
               <p className="govuk-body">
                 {i18n('componentCreate.selectionFields.info')}
               </p>
-              <ol className="govuk-list">
-                {selectionFields.map((component) => (
-                  <li key={component.type}>
-                    <p className="govuk-body govuk-!-margin-bottom-2">
-                      <a
-                        href="#0"
-                        className="govuk-link"
-                        onClick={(e) => {
-                          e.preventDefault()
-                          onSelectComponent(component)
-                        }}
-                      >
-                        {i18n(`fieldTypeToName.${component.type}`)}
-                      </a>
-                    </p>
-                    <div className="govuk-hint govuk-!-margin-top-2">
-                      {i18n(`fieldTypeToName.${component.type}_info`)}
-                    </div>
-                  </li>
-                ))}
-              </ol>
+              {!selectionFields.length && (
+                <p className="govuk-hint">
+                  {i18n('componentCreate.selectionFields.unavailable')}
+                </p>
+              )}
+              {!!selectionFields.length && (
+                <ol className="govuk-list">
+                  {selectionFields.map((component) => (
+                    <li key={component.type}>
+                      <p className="govuk-body govuk-!-margin-bottom-2">
+                        <a
+                          href="#0"
+                          className="govuk-link"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            onSelectComponent(component)
+                          }}
+                        >
+                          {i18n(`fieldTypeToName.${component.type}`)}
+                        </a>
+                      </p>
+                      <div className="govuk-hint govuk-!-margin-top-2">
+                        {i18n(`fieldTypeToName.${component.type}_info`)}
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
             </li>
           </>
         )}

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -2,6 +2,7 @@ import {
   ComponentTypes,
   controllerNameFromPath,
   ControllerType,
+  hasComponents,
   hasContent,
   hasInputField,
   hasSelectionFields,
@@ -39,6 +40,10 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
       inputFields: componentList.filter(hasInputField)
     }
   }, [componentList])
+
+  if (!hasComponents(page)) {
+    return null
+  }
 
   return (
     <div className="govuk-form-group">

--- a/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
+++ b/designer/client/src/components/ComponentCreate/__snapshots__/ComponentCreateList.test.tsx.snap
@@ -15,15 +15,15 @@ exports[`ComponentCreateList should match snapshot 1`] = `
     >
       <li>
         <h3
-          class="govuk-heading-s"
+          class="govuk-heading-s govuk-!-margin-bottom-1"
         >
           Content
         </h3>
-        <div
-          class="govuk-hint"
+        <p
+          class="govuk-body"
         >
-          Content components allow you to add information to your page
-        </div>
+          Content components allow you to add information to your page.
+        </p>
         <ol
           class="govuk-list"
         >
@@ -102,15 +102,15 @@ exports[`ComponentCreateList should match snapshot 1`] = `
       </li>
       <li>
         <h3
-          class="govuk-heading-s"
+          class="govuk-heading-s govuk-!-margin-bottom-1"
         >
-          Input fields
+          Input
         </h3>
-        <div
-          class="govuk-hint"
+        <p
+          class="govuk-body"
         >
-          Input fields allow you to ask users to enter information
-        </div>
+          Input fields allow you to ask users to enter information.
+        </p>
         <ol
           class="govuk-list"
         >
@@ -257,15 +257,15 @@ exports[`ComponentCreateList should match snapshot 1`] = `
       </li>
       <li>
         <h3
-          class="govuk-heading-s"
+          class="govuk-heading-s govuk-!-margin-bottom-1"
         >
-          Selection fields
+          Selection
         </h3>
-        <div
-          class="govuk-hint"
+        <p
+          class="govuk-body"
         >
-          Selection fields allow you to provide lists of answers for users to choose from
-        </div>
+          Selection fields allow you to provide lists of answers for users to choose from.
+        </p>
         <ol
           class="govuk-list"
         >

--- a/designer/client/src/data/component/fields.ts
+++ b/designer/client/src/data/component/fields.ts
@@ -9,8 +9,8 @@ import {
   type ConditionalComponentType,
   type FormDefinition,
   type Item,
-  type PageQuestion,
-  type PageStart,
+  type Link,
+  type Page,
   type Section
 } from '@defra/forms-model'
 
@@ -46,7 +46,7 @@ export function getFieldsTo(data: FormDefinition, pathTo?: string) {
  */
 export function pageToFields(
   this: FormDefinition,
-  page: PageStart | PageQuestion
+  page: Extract<Page, { next: Link[] }>
 ) {
   const section = hasSection(page) ? findSection(this, page.section) : undefined
 

--- a/designer/client/src/data/page/findPathsTo.ts
+++ b/designer/client/src/data/page/findPathsTo.ts
@@ -2,8 +2,7 @@ import {
   hasNext,
   type FormDefinition,
   type Link,
-  type PageQuestion,
-  type PageStart
+  type Page
 } from '@defra/forms-model'
 import dfs, { type Edge } from 'depth-first'
 
@@ -16,10 +15,10 @@ export function findPathsTo({ pages }: FormDefinition, pathTo?: string) {
   return dfs(edges, pathTo, { reverse: true }).reverse()
 }
 
-export function pageToEdges(page: PageStart | PageQuestion) {
+export function pageToEdges(page: Extract<Page, { next: Link[] }>) {
   return page.next.map(linkToEdge.bind(page))
 }
 
-export function linkToEdge(this: PageStart | PageQuestion, link: Link) {
+export function linkToEdge(this: Extract<Page, { next: Link[] }>, link: Link) {
   return [this.path, link.path] satisfies Edge<string>
 }

--- a/designer/client/src/helpers.js
+++ b/designer/client/src/helpers.js
@@ -1,6 +1,8 @@
 import {
+  ComponentType,
   controllerNameFromPath,
   ControllerType,
+  hasContent,
   hasNext
 } from '@defra/forms-model'
 
@@ -16,6 +18,35 @@ export function arrayMove(arr, from, to) {
   const elm = arr.splice(from, 1)[0]
   arr.splice(to, 0, elm)
   return arr
+}
+
+/**
+ * Create filter for allowed components
+ * @param {Partial<Page>} page
+ */
+export function isComponentAllowed(page) {
+  const controller = controllerNameFromPath(page.controller)
+
+  /**
+   * Filter allowed components for current page
+   * @param {ComponentDef} component
+   */
+  return (component) => {
+    const isContent = hasContent(component)
+
+    // File upload components not allowed on question pages
+    const isQuestion =
+      component.type !== ComponentType.FileUploadField &&
+      (!controller || controller === ControllerType.Page)
+
+    // File upload pages can have a single file upload form component
+    const isFileUpload =
+      component.type === ComponentType.FileUploadField &&
+      controller === ControllerType.FileUpload
+
+    // Content components are always allowed
+    return isContent || isQuestion || isFileUpload
+  }
 }
 
 /**
@@ -83,5 +114,5 @@ export function isControllerAllowed(data, page) {
 }
 
 /**
- * @import { FormDefinition, Page } from '@defra/forms-model'
+ * @import { ComponentDef, FormDefinition, Page } from '@defra/forms-model'
  */

--- a/designer/client/src/helpers.js
+++ b/designer/client/src/helpers.js
@@ -107,9 +107,7 @@ export function isControllerAllowed(data, page) {
     /**
      * Page types currently unavailable
      */
-    const isInactivePage =
-      pageType.controller === ControllerType.FileUpload ||
-      pageType.controller === ControllerType.Status
+    const isInactivePage = pageType.controller === ControllerType.Status
 
     /**
      * Ignore rules when already selected

--- a/designer/client/src/helpers.js
+++ b/designer/client/src/helpers.js
@@ -2,6 +2,7 @@ import {
   ComponentType,
   controllerNameFromPath,
   ControllerType,
+  hasComponents,
   hasContent,
   hasNext
 } from '@defra/forms-model'
@@ -25,7 +26,13 @@ export function arrayMove(arr, from, to) {
  * @param {Partial<Page>} page
  */
 export function isComponentAllowed(page) {
+  const components = hasComponents(page) ? page.components : []
   const controller = controllerNameFromPath(page.controller)
+
+  // Check for existing file upload components
+  const hasFileUpload = components.some(
+    (c) => c.type === ComponentType.FileUploadField
+  )
 
   /**
    * Filter allowed components for current page
@@ -42,7 +49,8 @@ export function isComponentAllowed(page) {
     // File upload pages can have a single file upload form component
     const isFileUpload =
       component.type === ComponentType.FileUploadField &&
-      controller === ControllerType.FileUpload
+      controller === ControllerType.FileUpload &&
+      !hasFileUpload
 
     // Content components are always allowed
     return isContent || isQuestion || isFileUpload

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -87,16 +87,27 @@
   },
   "component": {
     "component": "component",
-    "contentfields_info": "Content components allow you to add information to your page",
     "create": "Add component",
-    "create_info": "Select a component to add to your page. If your page has only one component, the component title does not show on the page. To name or describe the component, use the page title instead.",
     "edit": "Edit {{name, lowerFirst}} component",
-    "inputfields_info": "Input fields allow you to ask users to enter information",
-    "selectfields_info": "Selection fields allow you to provide lists of answers for users to choose from",
     "moveUp": "Move component up",
     "moveUp_label": "Move {{name, lowerFirst}} component up",
     "moveDown": "Move component down",
     "moveDown_label": "Move {{name, lowerFirst}} component down"
+  },
+  "componentCreate": {
+    "hint": "Select a component to add to your page. If your page has only one component, the component title does not show on the page. To name or describe the component, use the page title instead.",
+    "contentFields": {
+      "title": "Content",
+      "info": "Content components allow you to add information to your page."
+    },
+    "inputFields": {
+      "title": "Input",
+      "info": "Input fields allow you to ask users to enter information."
+    },
+    "selectionFields": {
+      "title": "Selection",
+      "info": "Selection fields allow you to provide lists of answers for users to choose from."
+    }
   },
   "conditions": {
     "add": "Add a new condition",

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -98,15 +98,18 @@
     "hint": "Select a component to add to your page. If your page has only one component, the component title does not show on the page. To name or describe the component, use the page title instead.",
     "contentFields": {
       "title": "Content",
-      "info": "Content components allow you to add information to your page."
+      "info": "Content components allow you to add information to your page.",
+      "unavailable": "No content components available"
     },
     "inputFields": {
       "title": "Input",
-      "info": "Input fields allow you to ask users to enter information."
+      "info": "Input fields allow you to ask users to enter information.",
+      "unavailable": "No input components available"
     },
     "selectionFields": {
       "title": "Selection",
-      "info": "Selection fields allow you to provide lists of answers for users to choose from."
+      "info": "Selection fields allow you to provide lists of answers for users to choose from.",
+      "unavailable": "No selection components available"
     }
   },
   "conditions": {

--- a/model/src/components/component-types.ts
+++ b/model/src/components/component-types.ts
@@ -104,6 +104,13 @@ export const ComponentTypes: readonly ComponentDef[] = Object.freeze([
     options: {}
   },
   {
+    name: 'FileUploadField',
+    title: 'File upload field',
+    type: ComponentType.FileUploadField,
+    options: {},
+    schema: {}
+  },
+  {
     name: 'Html',
     title: 'Html',
     type: ComponentType.Html,

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -17,14 +17,18 @@ import {
 /**
  * Return component defaults by type
  */
-export function getComponentDefaults(component?: Partial<ComponentDef>) {
-  if (!component?.type) {
-    return
+export function getComponentDefaults<FieldType extends ComponentDef>(
+  component?: Pick<FieldType, 'type'>
+) {
+  const defaults = ComponentTypes.find(({ type }) => type === component?.type)
+
+  if (!defaults) {
+    throw new Error(
+      `Defaults not found for component type '${component?.type}'`
+    )
   }
 
-  return structuredClone(
-    ComponentTypes.find(({ type }) => type === component.type)
-  )
+  return structuredClone(defaults) as FieldType
 }
 
 /**

--- a/model/src/components/helpers.ts
+++ b/model/src/components/helpers.ts
@@ -7,6 +7,7 @@ import {
   type ContentComponentsDef,
   type FormComponentsDef,
   type HtmlComponent,
+  type InputFieldsComponentsDef,
   type InsetTextComponent,
   type ListComponent,
   type ListComponentsDef,
@@ -91,6 +92,7 @@ export function isContentType(
 
 /**
  * Filter known components with form fields
+ * (includes input fields and selection fields)
  */
 export function hasFormField(
   component?: Partial<ComponentDef>
@@ -128,7 +130,18 @@ export function isListType(
 }
 
 /**
- * Filter known components with selection fields
+ * Filter known form components with input fields
+ * (excludes content and selection fields)
+ */
+export function hasInputField(
+  component?: Partial<ComponentDef>
+): component is InputFieldsComponentsDef {
+  return hasFormField(component) && !hasSelectionFields(component)
+}
+
+/**
+ * Filter known form components with selection fields
+ * (excludes content and input fields)
  */
 export function hasSelectionFields(
   component?: Partial<ComponentDef>

--- a/model/src/components/index.ts
+++ b/model/src/components/index.ts
@@ -7,6 +7,7 @@ export {
   hasFormField,
   hasHint,
   hasListField,
+  hasInputField,
   hasSelectionFields,
   hasTitle,
   isConditionalType,

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -23,7 +23,14 @@ export interface PageStart extends PageBase {
 }
 
 export interface PageQuestion extends PageBase {
-  controller?: ControllerType.Page | ControllerType.FileUpload
+  controller?: ControllerType.Page
+  section?: string | undefined
+  next: Link[]
+  components: ComponentDef[]
+}
+
+export interface PageFileUpload extends PageBase {
+  controller?: ControllerType.FileUpload
   section?: string | undefined
   next: Link[]
   components: ComponentDef[]
@@ -41,7 +48,12 @@ export interface PageStatus extends PageBase {
   section?: undefined
 }
 
-export type Page = PageStart | PageQuestion | PageSummary | PageStatus
+export type Page =
+  | PageStart
+  | PageQuestion
+  | PageFileUpload
+  | PageSummary
+  | PageStatus
 
 export type RequiredField<
   Type extends Partial<object>,

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -2,6 +2,7 @@ import { type ComponentDef } from '~/src/components/types.js'
 import {
   type Link,
   type Page,
+  type PageFileUpload,
   type PageQuestion,
   type PageStart,
   type RequiredField
@@ -56,8 +57,11 @@ export function hasFormComponents(
  * Check page has sections
  */
 export function hasSection(
-  page?: Partial<Page>
-): page is RequiredField<PageStart | PageQuestion, 'section'> {
+  page: Partial<Page>
+): page is
+  | RequiredField<PageStart, 'section'>
+  | RequiredField<PageQuestion, 'section'>
+  | RequiredField<PageFileUpload, 'section'> {
   return isLinkablePage(page) && typeof page.section === 'string'
 }
 

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -16,18 +16,22 @@ import { PageTypes } from '~/src/pages/page-types.js'
 /**
  * Return component defaults by type
  */
-export function getPageDefaults(page: Pick<Page, 'controller'>) {
-  const controller = controllerNameFromPath(page.controller)
+export function getPageDefaults<PageType extends Page>(
+  page: Pick<PageType, 'controller'>
+) {
+  const controller = controllerNameFromPath(
+    page.controller ?? ControllerType.Page
+  )
 
   const defaults = PageTypes.find(
     (pageType) => pageType.controller === controller
   )
 
   if (!defaults) {
-    throw new Error(`Defaults not found for ${page.controller}`)
+    throw new Error(`Defaults not found for page type '${page.controller}'`)
   }
 
-  return structuredClone(defaults)
+  return structuredClone(defaults) as PageType
 }
 
 /**

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -40,6 +40,15 @@ export function hasComponents(
 }
 
 /**
+ * Check page has form components
+ */
+export function hasFormComponents(
+  page?: Partial<Page>
+): page is Extract<Page, { components: ComponentDef[] }> {
+  return isLinkablePage(page) && Array.isArray(page.components)
+}
+
+/**
  * Check page has sections
  */
 export function hasSection(

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -86,6 +86,7 @@ export function isLinkablePage(
   const controller = controllerNameFromPath(page.controller)
 
   return (
+    !controller ||
     controller === ControllerType.Start ||
     controller === ControllerType.Page ||
     controller === ControllerType.FileUpload
@@ -99,6 +100,7 @@ export function isQuestionPage(page?: Partial<Page>): page is PageQuestion {
   const controller = controllerNameFromPath(page?.controller)
 
   return (
+    !controller ||
     controller === ControllerType.Page ||
     controller === ControllerType.FileUpload
   )
@@ -114,5 +116,5 @@ export function controllerNameFromPath(nameOrPath?: ControllerType | string) {
   }
 
   const options = ControllerTypes.find(({ path }) => path === nameOrPath)
-  return options?.name ?? ControllerType.Page
+  return options?.name
 }

--- a/model/src/pages/index.ts
+++ b/model/src/pages/index.ts
@@ -9,6 +9,7 @@ export {
   controllerNameFromPath,
   getPageDefaults,
   hasComponents,
+  hasFormComponents,
   hasSection,
   hasNext,
   isControllerName,


### PR DESCRIPTION
This PR enables the file upload component

It makes up [story **#294192**](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/294192) as part of three PRs:

* https://github.com/DEFRA/forms-designer/pull/444
* https://github.com/DEFRA/forms-designer/pull/443 (this PR)
* https://github.com/DEFRA/forms-designer/pull/445

Jump to [PR #445](https://github.com/DEFRA/forms-designer/pull/445) to see the file upload component complete with settings

## Component restrictions

The **File upload** component can't be listed on the "Add component" page because it requires its own page type

This means we need to:

1. Prevent file upload component being added to other pages
2. Prevent file upload component being added more than once 
3. Filter "Add component" list to allow content components on file upload pages
4. Filter "Add component" list to allow file upload component on file upload pages
5. Remove unsupported components when switching page type

E.g. For 5) we must remove the file upload component when switching to "Question page" type