### PR TITLE
Add form validation to page type options

### DIFF
--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -1,10 +1,10 @@
 import {
-  controllerNameFromPath,
   ControllerType,
   getPageDefaults,
   hasComponents,
   hasNext,
   isQuestionPage,
+  PageTypes,
   slugify,
   type Page,
   type Section
@@ -32,6 +32,7 @@ import { addLink } from '~/src/data/page/addLink.js'
 import { addPage } from '~/src/data/page/addPage.js'
 import { findPage } from '~/src/data/page/findPage.js'
 import { findSection } from '~/src/data/section/findSection.js'
+import { isControllerAllowed } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import {
@@ -276,16 +277,12 @@ export class PageCreate extends Component<Props, State> {
 
     const { sections } = data
     const hasErrors = hasValidationErrors(errors)
-
-    // Check if we already have a start page
-    const hasStartPage = pages.some((page) => {
-      return controllerNameFromPath(page.controller) === ControllerType.Start
-    })
-
-    // Check if we already have a summary page
-    const hasSummaryPage = pages.some((page) => {
-      return controllerNameFromPath(page.controller) === ControllerType.Summary
-    })
+    const pageTypes = PageTypes.filter(
+      isControllerAllowed(data, {
+        controller,
+        path
+      })
+    )
 
     return (
       <>
@@ -329,22 +326,11 @@ export class PageCreate extends Component<Props, State> {
               <option value="">
                 {i18n('addPage.controllerOption.option')}
               </option>
-              <option value={ControllerType.Page}>
-                {i18n('page.controllers.question')}
-              </option>
-              {!hasStartPage && (
-                <option value={ControllerType.Start}>
-                  {i18n('page.controllers.start')}
+              {pageTypes.map((pageType) => (
+                <option key={pageType.title} value={pageType.controller}>
+                  {pageType.title}
                 </option>
-              )}
-              <option value={ControllerType.FileUpload}>
-                {i18n('page.controllers.fileUpload')}
-              </option>
-              {!hasSummaryPage && (
-                <option value={ControllerType.Summary}>
-                  {i18n('page.controllers.summary')}
-                </option>
-              )}
+              ))}
             </select>
           </div>
 

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -150,7 +150,7 @@ export class PageCreate extends Component<Props, State> {
     const errors: State['errors'] = {}
 
     errors.title = validateRequired('page-title', title, {
-      label: i18n('page.title')
+      label: i18n('addPage.pageTitleField.title')
     })
 
     errors.path = validateCustom(

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -269,14 +269,14 @@ export class PageCreate extends Component<Props, State> {
     const hasErrors = hasValidationErrors(errors)
 
     // Check if we already have a start page
-    const hasStartPage = pages.some(
-      (page) => page.controller === ControllerType.Start
-    )
+    const hasStartPage = pages.some((page) => {
+      return controllerNameFromPath(page.controller) === ControllerType.Start
+    })
 
     // Check if we already have a summary page
-    const hasSummaryPage = pages.some(
-      (page) => page.controller === ControllerType.Summary
-    )
+    const hasSummaryPage = pages.some((page) => {
+      return controllerNameFromPath(page.controller) === ControllerType.Summary
+    })
 
     return (
       <>

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -312,14 +312,14 @@ export class PageEdit extends Component<Props, State> {
     const hasErrors = hasValidationErrors(errors)
 
     // Check if we already have a start page
-    const hasStartPage = pages.some(
-      (page) => page.controller === ControllerType.Start
-    )
+    const hasStartPage = pages.some((page) => {
+      return controllerNameFromPath(page.controller) === ControllerType.Start
+    })
 
     // Check if we already have a summary page
-    const hasSummaryPage = pages.some(
-      (page) => page.controller === ControllerType.Summary
-    )
+    const hasSummaryPage = pages.some((page) => {
+      return controllerNameFromPath(page.controller) === ControllerType.Summary
+    })
 
     // Check if we have a link from another page
     const hasLinkFrom = findPathsTo(data, page.path).length > 1
@@ -350,7 +350,7 @@ export class PageEdit extends Component<Props, State> {
                 {i18n('page.controllers.question')}
               </option>
               {((!hasStartPage && !hasLinkFrom) ||
-                page.controller === ControllerType.Start) && (
+                controller === ControllerType.Start) && (
                 <option value={ControllerType.Start}>
                   {i18n('page.controllers.start')}
                 </option>
@@ -358,8 +358,7 @@ export class PageEdit extends Component<Props, State> {
               <option value={ControllerType.FileUpload}>
                 {i18n('page.controllers.fileUpload')}
               </option>
-              {(!hasSummaryPage ||
-                page.controller === ControllerType.Summary) && (
+              {(!hasSummaryPage || controller === ControllerType.Summary) && (
                 <option value={ControllerType.Summary}>
                   {i18n('page.controllers.summary')}
                 </option>

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -1,6 +1,7 @@
 import {
   ControllerPath,
   ControllerType,
+  PageTypes,
   controllerNameFromPath,
   getPageDefaults,
   hasComponents,
@@ -31,9 +32,9 @@ import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.j
 import { DataContext } from '~/src/context/DataContext.js'
 import { deleteLink } from '~/src/data/page/deleteLink.js'
 import { findPage } from '~/src/data/page/findPage.js'
-import { findPathsTo } from '~/src/data/page/findPathsTo.js'
 import { updateLinksTo } from '~/src/data/page/updateLinksTo.js'
 import { findSection } from '~/src/data/section/findSection.js'
+import { isControllerAllowed } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import {
@@ -316,21 +317,9 @@ export class PageEdit extends Component<Props, State> {
       errors
     } = this.state
 
-    const { pages, sections } = data
+    const { sections } = data
     const hasErrors = hasValidationErrors(errors)
-
-    // Check if we already have a start page
-    const hasStartPage = pages.some((page) => {
-      return controllerNameFromPath(page.controller) === ControllerType.Start
-    })
-
-    // Check if we already have a summary page
-    const hasSummaryPage = pages.some((page) => {
-      return controllerNameFromPath(page.controller) === ControllerType.Summary
-    })
-
-    // Check if we have a link from another page
-    const hasLinkFrom = findPathsTo(data, page.path).length > 1
+    const pageTypes = PageTypes.filter(isControllerAllowed(data, page))
 
     return (
       <>
@@ -374,23 +363,11 @@ export class PageEdit extends Component<Props, State> {
               <option value="">
                 {i18n('addPage.controllerOption.option')}
               </option>
-              <option value={ControllerType.Page}>
-                {i18n('page.controllers.question')}
-              </option>
-              {((!hasStartPage && !hasLinkFrom) ||
-                controller === ControllerType.Start) && (
-                <option value={ControllerType.Start}>
-                  {i18n('page.controllers.start')}
+              {pageTypes.map((pageType) => (
+                <option key={pageType.title} value={pageType.controller}>
+                  {pageType.title}
                 </option>
-              )}
-              <option value={ControllerType.FileUpload}>
-                {i18n('page.controllers.fileUpload')}
-              </option>
-              {(!hasSummaryPage || controller === ControllerType.Summary) && (
-                <option value={ControllerType.Summary}>
-                  {i18n('page.controllers.summary')}
-                </option>
-              )}
+              ))}
             </select>
           </div>
 

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -159,7 +159,7 @@ export class PageEdit extends Component<Props, State> {
     const errors: State['errors'] = {}
 
     errors.title = validateRequired('page-title', title, {
-      label: i18n('page.title')
+      label: i18n('addPage.pageTitleField.title')
     })
 
     // Path '/status' not allowed
@@ -333,10 +333,10 @@ export class PageEdit extends Component<Props, State> {
         <form onSubmit={this.onSubmit} autoComplete="off" noValidate>
           <div className="govuk-form-group">
             <label className="govuk-label govuk-label--s" htmlFor="controller">
-              {i18n('page.controller')}
+              {i18n('addPage.controllerOption.title')}
             </label>
             <div className="govuk-hint" id="controller-hint">
-              {i18n('page.controllerHint')}
+              {i18n('addPage.controllerOption.helpText')}
             </div>
             <select
               className="govuk-select"
@@ -372,7 +372,7 @@ export class PageEdit extends Component<Props, State> {
             name="title"
             label={{
               className: 'govuk-label--s',
-              children: [i18n('page.title')]
+              children: [i18n('addPage.pageTitleField.title')]
             }}
             value={title ?? ''}
             onChange={this.onChangeTitle}
@@ -385,10 +385,10 @@ export class PageEdit extends Component<Props, State> {
               name="path"
               label={{
                 className: 'govuk-label--s',
-                children: [i18n('page.path')]
+                children: [i18n('addPage.pathField.title')]
               }}
               hint={{
-                children: [i18n('page.pathHint')]
+                children: [i18n('addPage.pathField.helpText')]
               }}
               value={path ?? ''}
               onChange={this.onChangePath}
@@ -401,10 +401,10 @@ export class PageEdit extends Component<Props, State> {
               {!sections.length && (
                 <>
                   <h3 className="govuk-heading-s govuk-!-margin-bottom-1">
-                    {i18n('page.section')}
+                    {i18n('addPage.sectionOption.title')}
                   </h3>
                   <p className="govuk-hint govuk-!-margin-top-0">
-                    {i18n('page.sectionHint')}
+                    {i18n('addPage.sectionOption.helpText')}
                   </p>
                 </>
               )}
@@ -416,10 +416,10 @@ export class PageEdit extends Component<Props, State> {
                       className="govuk-label govuk-label--s"
                       htmlFor="page-section"
                     >
-                      {i18n('page.section')}
+                      {i18n('addPage.sectionOption.title')}
                     </label>
                     <div className="govuk-hint" id="page-section-hint">
-                      {i18n('page.sectionHint')}
+                      {i18n('addPage.sectionOption.helpText')}
                     </div>
                     <select
                       className="govuk-select"
@@ -429,7 +429,9 @@ export class PageEdit extends Component<Props, State> {
                       value={section?.name ?? ''}
                       onChange={this.onChangeSection}
                     >
-                      <option value="">{i18n('page.sectionOption')}</option>
+                      <option value="">
+                        {i18n('addPage.sectionOption.option')}
+                      </option>
                       {sections.map((section) => (
                         <option key={section.name} value={section.name}>
                           {section.title}

--- a/designer/client/src/data/page/findPathsTo.test.ts
+++ b/designer/client/src/data/page/findPathsTo.test.ts
@@ -100,3 +100,15 @@ test('findPathsTo should work with multiple parents', () => {
   expect(findPathsTo(data, '/3')).toEqual(['/1', '/3'])
   expect(findPathsTo(data, '/1')).toEqual(['/1'])
 })
+
+test('findPathsTo should work with empty path', () => {
+  const data = {
+    pages: [],
+    lists: [],
+    sections: [],
+    conditions: []
+  } satisfies FormDefinition
+
+  expect(findPathsTo(data)).toEqual([])
+  expect(findPathsTo(data, '')).toEqual([])
+})

--- a/designer/client/src/data/page/findPathsTo.ts
+++ b/designer/client/src/data/page/findPathsTo.ts
@@ -7,7 +7,11 @@ import {
 } from '@defra/forms-model'
 import dfs, { type Edge } from 'depth-first'
 
-export function findPathsTo({ pages }: FormDefinition, pathTo: string) {
+export function findPathsTo({ pages }: FormDefinition, pathTo?: string) {
+  if (!pathTo) {
+    return []
+  }
+
   const edges = pages.filter(hasNext).flatMap(pageToEdges)
   return dfs(edges, pathTo, { reverse: true }).reverse()
 }

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -30,7 +30,8 @@
     },
     "controllerOption": {
       "helpText": "Select a Start Page to start a form, a Question Page to request information, and a Summary Page at the end of a section or form. For example, use a Summary to let users check their answers to questions before they submit the form.",
-      "title": "Page type"
+      "title": "Page type",
+      "option": "Select a page type"
     },
     "pathField": {
       "helpText": "Appears in the browser path. The value you enter in the page title field automatically populates the path name. To override it, enter your own path name, relevant to the page, and use lowercase text and hyphens between words. For example, '/personal-details'.",

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -292,20 +292,12 @@
     "add": "Add page",
     "edit": "Edit page",
     "preview": "Preview page",
-    "controller": "Page type",
-    "controllerHint": "Select a Start Page to start a form, a Question Page to request information, and a Summary Page at the end of a section or form. For example, use a Summary to let users check their answers to questions before they submit the form.",
     "controllers": {
       "question": "Question page",
       "start": "Start page",
       "fileUpload": "File upload",
       "summary": "Summary page"
-    },
-    "path": "Path",
-    "pathHint": "Appears in the browser path. The value you enter in the page title field automatically populates the path name. To override it, enter your own path name, relevant to the page, and use lowercase text and hyphens between words. For example, '/personal-details'.",
-    "section": "Section (optional)",
-    "sectionHint": "Use sections to split a form. For example, to add a section per applicant. The section title appears above the page title. However, if these titles are the same, the form will only show the page title.",
-    "sectionOption": "Select a section",
-    "title": "Page title"
+    }
   },
   "save": "Save",
   "section": {

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -15,6 +15,7 @@ export interface PageBase {
 }
 
 export interface PageStart extends PageBase {
+  path: ControllerPath.Start | string
   controller: ControllerType.Start | ControllerType.Home
   section?: string | undefined
   next: Link[]
@@ -29,13 +30,13 @@ export interface PageQuestion extends PageBase {
 }
 
 export interface PageSummary extends PageBase {
-  path: ControllerPath.Summary
+  path: ControllerPath.Summary | string
   controller: ControllerType.Summary
   section?: undefined
 }
 
 export interface PageStatus extends PageBase {
-  path: ControllerPath.Status
+  path: ControllerPath.Status | string
   controller: ControllerType.Status
   section?: undefined
 }

--- a/model/src/pages/page-types.ts
+++ b/model/src/pages/page-types.ts
@@ -30,14 +30,6 @@ export const PageTypes: readonly Page[] = Object.freeze([
     components: []
   },
   {
-    title: 'File upload page',
-    path: '/file-upload-page',
-    controller: ControllerType.FileUpload,
-    section: undefined,
-    next: [],
-    components: []
-  },
-  {
     title: 'Summary page',
     path: ControllerPath.Summary,
     controller: ControllerType.Summary,

--- a/model/src/pages/page-types.ts
+++ b/model/src/pages/page-types.ts
@@ -38,13 +38,13 @@ export const PageTypes: readonly Page[] = Object.freeze([
     components: []
   },
   {
-    title: 'Check your answers',
+    title: 'Summary page',
     path: ControllerPath.Summary,
     controller: ControllerType.Summary,
     section: undefined
   },
   {
-    title: 'Form submitted',
+    title: 'Status page',
     path: ControllerPath.Status,
     controller: ControllerType.Status,
     section: undefined

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,9 +7,29 @@ sonar.links.ci=https://github.com/DEFRA/forms-designer/actions
 sonar.links.scm=https://github.com/DEFRA/forms-designer
 sonar.links.issue=https://github.com/DEFRA/forms-designer/issues
 
-sonar.sources=./designer/client/src,./designer/server/src,./model/src
-sonar.exclusions=./**/*.test.*
-sonar.tests=.
-sonar.test.inclusions=**/*.test.js
-
+sonar.modules=client,server,model
 sonar.sourceEncoding=UTF-8
+
+# @defra/forms-designer (client)
+client.sonar.projectName=forms-designer (client)
+client.sonar.projectBaseDir=designer/client
+client.sonar.sources=src
+client.sonar.exclusions=src/**/*.test.*
+client.sonar.tests=src
+client.sonar.test.inclusions=src/**/*.test.*
+
+# @defra/forms-designer (server)
+server.sonar.projectName=forms-designer (server)
+server.sonar.projectBaseDir=designer/server
+server.sonar.sources=src
+server.sonar.exclusions=src/**/*.test.*
+server.sonar.tests=src
+server.sonar.test.inclusions=src/**/*.test.*
+
+# @defra/forms-model
+model.sonar.projectName=forms-model
+model.sonar.projectBaseDir=model
+model.sonar.sources=src
+model.sonar.exclusions=src/**/*.test.*
+model.sonar.tests=src
+model.sonar.test.inclusions=src/**/*.test.*


### PR DESCRIPTION
This PR adds form validation to **Page type** and replaces hard coded options with `PageTypes`

It makes up [story **#294192**](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/294192) as part of three PRs:

* https://github.com/DEFRA/forms-designer/pull/444 (this PR)
* https://github.com/DEFRA/forms-designer/pull/443
* https://github.com/DEFRA/forms-designer/pull/445