### PR TITLE
Remove Enzyme testing utility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,8 +50,6 @@ updates:
           - '@testing-library/*'
           - 'cheerio'
           - 'concurrently'
-          - 'enzyme'
-          - 'enzyme-*'
           - 'jest'
           - 'jest-*'
           - 'nodemon'

--- a/designer/client/jest.setup.cjs
+++ b/designer/client/jest.setup.cjs
@@ -1,6 +1,1 @@
-const { configure } = require('enzyme')
-const Adapter = require('enzyme-adapter-react-16')
-
 process.env.REACT_LOG_LEVEL = 'silent'
-
-configure({ adapter: new Adapter() })

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -10,7 +10,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen, waitFor } from '@testing-library/dom'
-import { act, cleanup, render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
 import React from 'react'
@@ -69,8 +69,6 @@ describe('ComponentTypeEdit', () => {
       ]
     }
   })
-
-  afterEach(cleanup)
 
   describe.each([
     [

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -295,7 +295,7 @@ describe('ComponentTypeEdit', () => {
       }
     ]
   ])('Component type edit: %s', (type, options) => {
-    let selectedComponent: ComponentDef | undefined
+    let selectedComponent: ComponentDef
 
     beforeEach(() => {
       selectedComponent = getComponentDefaults({ type })
@@ -315,7 +315,7 @@ describe('ComponentTypeEdit', () => {
         })
 
         expect($input).toBeInTheDocument()
-        expect($input?.value).toBe(selectedComponent?.title)
+        expect($input).toHaveValue(selectedComponent.title)
       })
     } else {
       it("should not render 'Title' input", () => {
@@ -335,7 +335,7 @@ describe('ComponentTypeEdit', () => {
         })
 
         expect($textarea).toBeInTheDocument()
-        expect($textarea?.value).toBe(
+        expect($textarea).toHaveValue(
           hasHint(selectedComponent) ? (selectedComponent.hint ?? '') : ''
         )
       })
@@ -397,7 +397,7 @@ describe('ComponentTypeEdit', () => {
         })
 
         expect($input).toBeInTheDocument()
-        expect($input?.value).toBe(selectedComponent?.name)
+        expect($input).toHaveValue(selectedComponent.name)
       })
     } else {
       it("should not render 'Component name' input", () => {
@@ -412,7 +412,7 @@ describe('ComponentTypeEdit', () => {
     if (options.optional) {
       it("should render 'Make {{component}} optional' checkbox", () => {
         const $checkbox = screen.queryByRole<HTMLInputElement>('checkbox', {
-          name: `Make ${lowerFirst(selectedComponent?.title)} optional`,
+          name: `Make ${lowerFirst(selectedComponent.title)} optional`,
           description:
             'Tick this box if users do not need to complete this field to progress through the form'
         })
@@ -423,7 +423,7 @@ describe('ComponentTypeEdit', () => {
 
       it('should render "Hide \'(optional)\' text" checkbox when optional', async () => {
         const $checkbox1 = screen.getByRole<HTMLInputElement>('checkbox', {
-          name: `Make ${lowerFirst(selectedComponent?.title)} optional`
+          name: `Make ${lowerFirst(selectedComponent.title)} optional`
         })
 
         expect($checkbox1).toBeInTheDocument()
@@ -447,7 +447,7 @@ describe('ComponentTypeEdit', () => {
 
       it('should not render "Hide \'(optional)\' text" checkbox when required', () => {
         const $checkbox1 = screen.getByRole<HTMLInputElement>('checkbox', {
-          name: `Make ${lowerFirst(selectedComponent?.title)} optional`
+          name: `Make ${lowerFirst(selectedComponent.title)} optional`
         })
 
         expect($checkbox1).toBeInTheDocument()
@@ -462,7 +462,7 @@ describe('ComponentTypeEdit', () => {
     } else {
       it("should not render 'Make {{component}} optional' checkbox", () => {
         const $checkbox = screen.queryByRole('checkbox', {
-          name: `Make ${lowerFirst(selectedComponent?.title)} optional`
+          name: `Make ${lowerFirst(selectedComponent.title)} optional`
         })
 
         expect($checkbox).not.toBeInTheDocument()
@@ -486,7 +486,7 @@ describe('ComponentTypeEdit', () => {
         })
 
         expect($select).toBeInTheDocument()
-        expect($select?.value).toBe(
+        expect($select).toHaveValue(
           hasListField(selectedComponent) ? selectedComponent.list : ''
         )
       })
@@ -509,7 +509,7 @@ describe('ComponentTypeEdit', () => {
         })
 
         expect($select).toBeInTheDocument()
-        expect($select?.value).toBe(
+        expect($select).toHaveValue(
           hasConditionSupport(selectedComponent)
             ? (selectedComponent.options.condition ?? '')
             : ''

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -309,7 +309,7 @@ describe('ComponentTypeEdit', () => {
 
     if (options.title) {
       it("should render 'Title' input", () => {
-        const $input = screen.queryByRole<HTMLInputElement>('textbox', {
+        const $input = screen.getByRole<HTMLInputElement>('textbox', {
           name: 'Title',
           description: 'Enter the name to show for this field'
         })
@@ -329,7 +329,7 @@ describe('ComponentTypeEdit', () => {
 
     if (options.hint) {
       it("should render 'Help text (optional)' textarea", () => {
-        const $textarea = screen.queryByRole<HTMLTextAreaElement>('textbox', {
+        const $textarea = screen.getByRole<HTMLTextAreaElement>('textbox', {
           name: 'Help text (optional)',
           description: 'Enter the description to show for this field'
         })
@@ -351,14 +351,14 @@ describe('ComponentTypeEdit', () => {
 
     if (options.hideTitle) {
       it("should render 'Hide title' checkbox", () => {
-        const $checkbox = screen.queryByRole<HTMLInputElement>('checkbox', {
+        const $checkbox = screen.getByRole<HTMLInputElement>('checkbox', {
           name: 'Hide title',
           description:
             'Tick this box if you do not want the title to show on the page'
         })
 
         expect($checkbox).toBeInTheDocument()
-        expect($checkbox?.checked).toBe(false)
+        expect($checkbox.checked).toBe(false)
       })
     } else {
       it("should not render 'Hide title' checkbox", () => {
@@ -372,7 +372,7 @@ describe('ComponentTypeEdit', () => {
 
     if (options.content) {
       it("should render 'Content' textarea", () => {
-        const $textarea = screen.queryByRole<HTMLTextAreaElement>('textbox', {
+        const $textarea = screen.getByRole<HTMLTextAreaElement>('textbox', {
           name: 'Content'
         })
 
@@ -390,7 +390,7 @@ describe('ComponentTypeEdit', () => {
 
     if (options.name) {
       it("should render 'Component name' input", () => {
-        const $input = screen.queryByRole<HTMLInputElement>('textbox', {
+        const $input = screen.getByRole<HTMLInputElement>('textbox', {
           name: 'Component name',
           description:
             'This is generated automatically and does not show on the page. Only change it if you are using an integration that requires you to, for example GOV.UK Notify. It must not contain spaces.'
@@ -411,14 +411,14 @@ describe('ComponentTypeEdit', () => {
 
     if (options.optional) {
       it("should render 'Make {{component}} optional' checkbox", () => {
-        const $checkbox = screen.queryByRole<HTMLInputElement>('checkbox', {
+        const $checkbox = screen.getByRole<HTMLInputElement>('checkbox', {
           name: `Make ${lowerFirst(selectedComponent.title)} optional`,
           description:
             'Tick this box if users do not need to complete this field to progress through the form'
         })
 
         expect($checkbox).toBeInTheDocument()
-        expect($checkbox?.checked).toBe(false)
+        expect($checkbox.checked).toBe(false)
       })
 
       it('should render "Hide \'(optional)\' text" checkbox when optional', async () => {
@@ -479,7 +479,7 @@ describe('ComponentTypeEdit', () => {
 
     if (options.selectList) {
       it("should render 'Select list' options", () => {
-        const $select = screen.queryByRole<HTMLSelectElement>('combobox', {
+        const $select = screen.getByRole<HTMLSelectElement>('combobox', {
           name: 'Select list',
           description:
             'Select an existing list to show in this field or add a new list'
@@ -502,7 +502,7 @@ describe('ComponentTypeEdit', () => {
 
     if (options.selectCondition) {
       it("should render 'Condition (optional)' options", () => {
-        const $select = screen.queryByRole<HTMLSelectElement>('combobox', {
+        const $select = screen.getByRole<HTMLSelectElement>('combobox', {
           name: 'Condition (optional)',
           description:
             'Select a condition that determines whether to show the contents of this component. You can create and edit conditions from the Conditions screen.'

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -4,7 +4,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import React from 'react'
 
 import { FieldEdit } from '~/src/FieldEdit.jsx'
@@ -38,8 +38,6 @@ describe('Field Edit', () => {
       conditions: []
     }
   })
-
-  afterEach(cleanup)
 
   it('should render options for non-list components', () => {
     render(

--- a/designer/client/src/LinkEdit.test.tsx
+++ b/designer/client/src/LinkEdit.test.tsx
@@ -7,7 +7,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen, within } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -47,8 +47,6 @@ const data = {
   sections: [],
   conditions: []
 } satisfies FormDefinition
-
-afterEach(cleanup)
 
 describe('LinkEdit', () => {
   test('hint text is rendered correctly', () => {

--- a/designer/client/src/PageCreate.test.tsx
+++ b/designer/client/src/PageCreate.test.tsx
@@ -1,6 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import React from 'react'
 
 import { PageCreate } from '~/src/PageCreate.jsx'
@@ -13,8 +13,6 @@ describe('page create fields text', () => {
     sections: [],
     conditions: []
   } satisfies FormDefinition
-
-  afterEach(cleanup)
 
   test('displays field titles and help texts', () => {
     render(

--- a/designer/client/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/designer/client/src/components/Autocomplete/Autocomplete.test.tsx
@@ -1,6 +1,6 @@
 import { ComponentType } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import React from 'react'
 
 import { Autocomplete } from '~/src/components/Autocomplete/Autocomplete.jsx'
@@ -29,8 +29,6 @@ describe('Autocomplete attribute', () => {
       </RenderWithContext>
     )
   })
-
-  afterEach(cleanup)
 
   test('should display display correct title', () => {
     const text = 'Autocomplete'

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -37,8 +37,13 @@ describe('ComponentCreate:', () => {
       name: 'Details'
     })
 
-    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument()
-    expect(screen.queryByLabelText('Content')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('textbox', { name: 'Title' })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.queryByRole('textbox', { name: 'Content' })
+    ).not.toBeInTheDocument()
 
     await act(() => userEvent.click($componentLink))
     await waitFor(() => screen.getAllByRole('textbox'))

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -23,8 +23,6 @@ describe('ComponentCreate:', () => {
   } satisfies FormDefinition
 
   const page = data.pages[0]
-
-  afterEach(cleanup)
 
   test('Selecting a component type should display the component edit form', async () => {
     render(

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
@@ -4,7 +4,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -48,8 +48,6 @@ describe('ComponentListSelect', () => {
     sections: [],
     conditions: []
   } satisfies FormDefinition
-
-  afterEach(cleanup)
 
   test('Lists all available lists', () => {
     const { container } = render(

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
@@ -4,7 +4,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, cleanup, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -80,7 +80,10 @@ describe('ComponentListSelect', () => {
       </RenderListEditorWithContext>
     )
 
-    const $select = await waitFor(() => screen.getByLabelText('Select list'))
+    const $select = screen.getByRole('combobox', {
+      name: 'Select list'
+    })
+
     await act(() => userEvent.selectOptions($select, 'myList'))
 
     expect(screen.getByText('Edit list')).toBeInTheDocument()
@@ -93,14 +96,18 @@ describe('ComponentListSelect', () => {
       </RenderListEditorWithContext>
     )
 
-    const title = 'Select list'
-    const help =
-      'Select an existing list to show in this field or add a new list'
-    const addNew = 'Add a new list'
+    const $select = screen.getByRole('combobox', {
+      name: 'Select list',
+      description:
+        'Select an existing list to show in this field or add a new list'
+    })
 
-    expect(screen.getByText(title)).toBeInTheDocument()
-    expect(screen.getByText(help)).toBeInTheDocument()
-    expect(screen.getByText(addNew)).toBeInTheDocument()
+    const $link = screen.getByRole('link', {
+      name: 'Add a new list'
+    })
+
+    expect($select).toBeInTheDocument()
+    expect($link).toBeInTheDocument()
   })
 
   test('should display list error when state has errors', async () => {
@@ -120,7 +127,7 @@ describe('ComponentListSelect', () => {
       </RenderListEditorWithContext>
     )
 
-    const $select = await waitFor(() => screen.getByLabelText('Select list'))
+    const $select = screen.getByRole('combobox', { name: 'Select list' })
     await act(() => userEvent.selectOptions($select, 'Select a list'))
 
     expect(

--- a/designer/client/src/components/ErrorMessage/ErrorMessage.test.tsx
+++ b/designer/client/src/components/ErrorMessage/ErrorMessage.test.tsx
@@ -1,12 +1,10 @@
 import { screen } from '@testing-library/dom'
-import { render, cleanup } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import React from 'react'
 
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 
 describe('ErrorMessage component', () => {
-  afterEach(cleanup)
-
   it('renders children text', () => {
     render(<ErrorMessage className="123">Error 123</ErrorMessage>)
     expect(screen.getByText('Error 123')).toBeDefined()

--- a/designer/client/src/components/FieldEditors/ConditionEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ConditionEdit.test.tsx
@@ -8,7 +8,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import React from 'react'
 
 import { ConditionEdit } from '~/src/components/FieldEditors/ConditionEdit.jsx'
@@ -60,8 +60,6 @@ describe('Condition edit', () => {
       }
     ]
   } satisfies FormDefinition
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/FieldEditors/DateFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/DateFieldEdit.test.tsx
@@ -5,7 +5,7 @@ import {
   type ComponentDef
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import React from 'react'
 
 import { DateFieldEdit } from '~/src/components/FieldEditors/DateFieldEdit.jsx'
@@ -13,8 +13,6 @@ import { RenderComponent } from '~/test/helpers/renderers.jsx'
 
 describe('Date field edit', () => {
   const supported = [ComponentType.DatePartsField]
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/FieldEditors/FileUploadFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/FileUploadFieldEdit.test.tsx
@@ -5,7 +5,7 @@ import {
   type ComponentDef
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import React from 'react'
 
 import { FileUploadFieldEdit } from '~/src/components/FieldEditors/FileUploadFieldEdit.jsx'
@@ -13,8 +13,6 @@ import { RenderComponent } from '~/test/helpers/renderers.jsx'
 
 describe('File upload field edit', () => {
   const supported = [ComponentType.FileUploadField]
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/FieldEditors/ListContentEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.test.tsx
@@ -6,7 +6,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import React from 'react'
 
 import { ListContentEdit } from '~/src/components/FieldEditors/ListContentEdit.jsx'
@@ -31,8 +31,6 @@ describe('List content edit', () => {
     sections: [],
     conditions: []
   } satisfies FormDefinition
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/FieldEditors/ListFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ListFieldEdit.test.tsx
@@ -6,7 +6,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, type RenderResult } from '@testing-library/react'
+import { act, render, type RenderResult } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -38,8 +38,6 @@ describe('List field edit', () => {
     sections: [],
     conditions: []
   } satisfies FormDefinition
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/FieldEditors/MultilineTextFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/MultilineTextFieldEdit.test.tsx
@@ -5,7 +5,7 @@ import {
   type ComponentDef
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import React from 'react'
 
 import { MultilineTextFieldEdit } from '~/src/components/FieldEditors/MultilineTextFieldEdit.jsx'
@@ -13,8 +13,6 @@ import { RenderComponent } from '~/test/helpers/renderers.jsx'
 
 describe('Multiline text field edit', () => {
   const supported = [ComponentType.MultilineTextField]
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/FieldEditors/NumberFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/NumberFieldEdit.test.tsx
@@ -5,7 +5,7 @@ import {
   type ComponentDef
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import React from 'react'
 
 import { NumberFieldEdit } from '~/src/components/FieldEditors/NumberFieldEdit.jsx'
@@ -13,8 +13,6 @@ import { RenderComponent } from '~/test/helpers/renderers.jsx'
 
 describe('Number field edit', () => {
   const supported = [ComponentType.NumberField]
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/FieldEditors/SelectFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/SelectFieldEdit.test.tsx
@@ -5,7 +5,7 @@ import {
   type ComponentDef
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import React from 'react'
 
 import { SelectFieldEdit } from '~/src/components/FieldEditors/SelectFieldEdit.jsx'
@@ -13,8 +13,6 @@ import { RenderComponent } from '~/test/helpers/renderers.jsx'
 
 describe('Select field edit', () => {
   const supported = [ComponentType.SelectField]
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.test.tsx
@@ -5,7 +5,7 @@ import {
   type ComponentDef
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import React from 'react'
 
 import { TextFieldEdit } from '~/src/components/FieldEditors/TextFieldEdit.jsx'
@@ -18,8 +18,6 @@ describe('Text field edit', () => {
     ComponentType.EmailAddressField,
     ComponentType.TelephoneNumberField
   ]
-
-  afterEach(cleanup)
 
   describe('Supported components', () => {
     it.each(ComponentTypes.filter(({ type }) => supported.includes(type)))(

--- a/designer/client/src/components/Flyout/Flyout.test.tsx
+++ b/designer/client/src/components/Flyout/Flyout.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -7,8 +7,6 @@ import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
 describe('Flyout', () => {
-  afterEach(cleanup)
-
   it('renders with accessible heading and close button', () => {
     render(
       <RenderWithContext>
@@ -48,13 +46,13 @@ describe('Flyout', () => {
     const increment = jest.fn()
     const decrement = jest.fn()
 
-    render(
+    const { unmount } = render(
       <RenderWithContext context={{ flyout: { increment, decrement } }}>
         <Flyout title="Example 1" onHide={jest.fn()} />
       </RenderWithContext>
     )
 
-    cleanup()
+    unmount()
 
     expect(increment).toHaveBeenCalledTimes(1)
     expect(decrement).toHaveBeenCalledTimes(1)

--- a/designer/client/src/components/Flyout/Flyout.test.tsx
+++ b/designer/client/src/components/Flyout/Flyout.test.tsx
@@ -16,9 +16,9 @@ describe('Flyout', () => {
       </RenderWithContext>
     )
 
-    const $dialog = screen.queryByRole('dialog', { name: 'Example' })
-    const $heading = screen.queryByRole('heading', { name: 'Example' })
-    const $button = screen.queryByRole('button', { name: 'Close' })
+    const $dialog = screen.getByRole('dialog', { name: 'Example' })
+    const $heading = screen.getByRole('heading', { name: 'Example' })
+    const $button = screen.getByRole('button', { name: 'Close' })
 
     expect($dialog).toBeInTheDocument()
     expect($dialog).toContainElement($heading)

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -47,7 +47,7 @@ describe('Menu', () => {
 
     await act(() => userEvent.click($buttonSummary))
 
-    const $dialog = screen.queryByRole('dialog', {
+    const $dialog = screen.getByRole('dialog', {
       name: 'Edit summary'
     })
 
@@ -74,14 +74,14 @@ describe('Menu', () => {
 
     await act(() => userEvent.click($buttonFormOverview))
 
-    const $dialog = screen.queryByRole('dialog', {
+    const $dialog = screen.getByRole('dialog', {
       name: 'Form overview'
     })
 
     expect($dialog).toBeInTheDocument()
 
-    const $tabs = screen.queryAllByRole('tab')
-    const $panels = screen.queryAllByRole('tabpanel')
+    const $tabs = screen.getAllByRole('tab')
+    const $panels = screen.getAllByRole('tabpanel')
 
     // All tabs links are visible
     expect($tabs[0]).toBeVisible()
@@ -120,7 +120,7 @@ describe('Menu', () => {
 
     await act(() => userEvent.click($buttonSummary))
 
-    const $dialog = screen.queryByRole('dialog', {
+    const $dialog = screen.getByRole('dialog', {
       name: 'Edit summary'
     })
 

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -1,6 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -14,8 +14,6 @@ describe('Menu', () => {
     sections: [],
     conditions: []
   } satisfies FormDefinition
-
-  afterEach(cleanup)
 
   it('Renders button strings correctly', () => {
     render(

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -146,25 +146,25 @@ describe('Page', () => {
       </RenderWithContext>
     )
 
-    const $heading = screen.queryByRole('heading', {
+    const $heading = screen.getByRole('heading', {
       name: 'my first page'
     })
 
     expect($heading).toBeInTheDocument()
 
-    const $buttonEdit = screen.queryByRole('button', {
+    const $buttonEdit = screen.getByRole('button', {
       name: 'Edit page',
-      description: $heading?.innerText
+      description: $heading.innerText
     })
 
-    const $linkPreview = screen.queryByRole('link', {
+    const $linkPreview = screen.getByRole('link', {
       name: 'Preview page',
-      description: $heading?.innerText
+      description: $heading.innerText
     })
 
-    const $buttonAdd = screen.queryByRole('button', {
+    const $buttonAdd = screen.getByRole('button', {
       name: 'Add component',
-      description: $heading?.innerText
+      description: $heading.innerText
     })
 
     expect($buttonEdit).toBeInTheDocument()
@@ -179,7 +179,7 @@ describe('Page', () => {
       </RenderWithContext>
     )
 
-    const $heading = screen.queryByRole('heading', {
+    const $heading = screen.getByRole('heading', {
       name: 'my first page'
     })
 
@@ -189,20 +189,20 @@ describe('Page', () => {
       {
         title: 'First name',
         label: 'Text input',
-        description: $heading?.innerText
+        description: $heading.innerText
       },
       {
         title: 'Middle name',
         label: 'Text input',
-        description: $heading?.innerText
+        description: $heading.innerText
       },
       {
         title: 'Surname',
         label: 'Text input',
-        description: $heading?.innerText
+        description: $heading.innerText
       }
     ]) {
-      const $component = screen.queryByRole('button', {
+      const $component = screen.getByRole('button', {
         name: `Edit ${lowerFirst(label)} component: ${title}`,
         description
       })
@@ -230,7 +230,7 @@ describe('Page', () => {
       </RenderWithContext>
     )
 
-    const $heading = screen.queryByRole('heading', {
+    const $heading = screen.getByRole('heading', {
       name: 'my second page'
     })
 
@@ -240,10 +240,10 @@ describe('Page', () => {
       {
         title: 'Mobile phone number',
         label: 'Telephone number',
-        description: $heading?.innerText
+        description: $heading.innerText
       }
     ]) {
-      const $component = screen.queryByRole('button', {
+      const $component = screen.getByRole('button', {
         name: `Edit ${lowerFirst(label)} component: ${title}`,
         description
       })

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
 import React from 'react'
@@ -68,8 +68,6 @@ const data = {
 } satisfies FormDefinition
 
 describe('Page', () => {
-  afterEach(cleanup)
-
   test('Page edit can be shown/hidden successfully', async () => {
     render(
       <RenderWithContext data={data}>

--- a/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
+++ b/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from 'enzyme'
+import { render } from '@testing-library/react'
 import React from 'react'
 
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
@@ -13,7 +13,7 @@ describe('RenderInPortal component', () => {
   test('renders paragraph inside portal', () => {
     expect(portalRoot?.innerHTML).toBe('')
 
-    const wrapper = mount(
+    const wrapper = render(
       <RenderInPortal>
         <p id="test-paragraph">Test</p>
       </RenderInPortal>
@@ -29,13 +29,13 @@ describe('RenderInPortal component', () => {
   })
 
   test('renders multiple portals in parallel', () => {
-    const wrapper1 = mount(
+    const wrapper1 = render(
       <RenderInPortal>
         <p id="test-paragraph1">Test 1</p>
       </RenderInPortal>
     )
 
-    const wrapper2 = mount(
+    const wrapper2 = render(
       <RenderInPortal>
         <p id="test-paragraph2">Test 2</p>
       </RenderInPortal>

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -104,7 +104,7 @@ describe('Visualisation', () => {
     })
 
     expect(
-      screen.queryByRole('dialog', {
+      screen.getByRole('dialog', {
         name: 'Edit link'
       })
     ).toBeInTheDocument()

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -1,6 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -8,8 +8,6 @@ import { Visualisation } from '~/src/components/Visualisation/Visualisation.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
 describe('Visualisation', () => {
-  afterEach(cleanup)
-
   test('Graph is rendered with correct number of pages and updates', () => {
     const data = {
       pages: [

--- a/designer/client/src/conditions/AbsoluteDateValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.test.tsx
@@ -8,7 +8,7 @@ import { AbsoluteDateValues } from '~/src/conditions/AbsoluteDateValues.jsx'
 describe('AbsoluteDateValues', () => {
   afterEach(cleanup)
 
-  it("renders out a date that's passed to it", async () => {
+  it("renders out a date that's passed to it", () => {
     render(
       <AbsoluteDateValues
         updateValue={jest.fn()}
@@ -16,9 +16,9 @@ describe('AbsoluteDateValues', () => {
       />
     )
 
-    const $year = await waitFor(() => screen.findByLabelText('Year'))
-    const $month = await waitFor(() => screen.findByLabelText('Month'))
-    const $day = await waitFor(() => screen.findByLabelText('Day'))
+    const $day = screen.getByRole('spinbutton', { name: 'Day' })
+    const $month = screen.getByRole('spinbutton', { name: 'Month' })
+    const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
     expect($year).toHaveValue(1999)
     expect($month).toHaveValue(12)
@@ -29,9 +29,9 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $year = await waitFor(() => screen.findByLabelText('Year'))
-    const $month = await waitFor(() => screen.findByLabelText('Month'))
-    const $day = await waitFor(() => screen.findByLabelText('Day'))
+    const $day = screen.getByRole('spinbutton', { name: 'Day' })
+    const $month = screen.getByRole('spinbutton', { name: 'Month' })
+    const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
     await act(() => userEvent.type($year, '2020'))
     await act(() => userEvent.type($month, '4'))
@@ -55,9 +55,9 @@ describe('AbsoluteDateValues', () => {
       />
     )
 
-    const $year = await waitFor(() => screen.findByLabelText('Year'))
-    const $month = await waitFor(() => screen.findByLabelText('Month'))
-    const $day = await waitFor(() => screen.findByLabelText('Day'))
+    const $day = screen.getByRole('spinbutton', { name: 'Day' })
+    const $month = screen.getByRole('spinbutton', { name: 'Month' })
+    const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
     // Clear existing values
     await Promise.all([$year, $month, $day].map(userEvent.clear))
@@ -79,9 +79,9 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $year = await waitFor(() => screen.findByLabelText('Year'))
-    const $month = await waitFor(() => screen.findByLabelText('Month'))
-    const $day = await waitFor(() => screen.findByLabelText('Day'))
+    const $day = screen.getByRole('spinbutton', { name: 'Day' })
+    const $month = screen.getByRole('spinbutton', { name: 'Month' })
+    const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
     await act(() => userEvent.type($year, '2020'))
     await act(() => userEvent.type($month, '4'))
@@ -94,8 +94,8 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $year = await waitFor(() => screen.findByLabelText('Year'))
-    const $month = await waitFor(() => screen.findByLabelText('Month'))
+    const $year = screen.getByRole('spinbutton', { name: 'Year' })
+    const $month = screen.getByRole('spinbutton', { name: 'Month' })
 
     await act(() => userEvent.type($year, '2020'))
     await act(() => userEvent.type($month, '4'))
@@ -107,8 +107,8 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $year = await waitFor(() => screen.findByLabelText('Year'))
-    const $day = await waitFor(() => screen.findByLabelText('Day'))
+    const $day = screen.getByRole('spinbutton', { name: 'Day' })
+    const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
     await act(() => userEvent.type($year, '2020'))
     await act(() => userEvent.type($day, '7'))
@@ -120,8 +120,8 @@ describe('AbsoluteDateValues', () => {
     const updateValue = jest.fn()
     render(<AbsoluteDateValues updateValue={updateValue} value={{}} />)
 
-    const $month = await waitFor(() => screen.findByLabelText('Month'))
-    const $day = await waitFor(() => screen.findByLabelText('Day'))
+    const $month = screen.getByRole('spinbutton', { name: 'Month' })
+    const $day = screen.getByRole('spinbutton', { name: 'Day' })
 
     await act(() => userEvent.type($month, '4'))
     await act(() => userEvent.type($day, '23'))

--- a/designer/client/src/conditions/AbsoluteDateValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.test.tsx
@@ -1,13 +1,11 @@
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
 import { AbsoluteDateValues } from '~/src/conditions/AbsoluteDateValues.jsx'
 
 describe('AbsoluteDateValues', () => {
-  afterEach(cleanup)
-
   it("renders out a date that's passed to it", () => {
     render(
       <AbsoluteDateValues

--- a/designer/client/src/conditions/AbsoluteDateValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.test.tsx
@@ -20,9 +20,9 @@ describe('AbsoluteDateValues', () => {
     const $month = await waitFor(() => screen.findByLabelText('Month'))
     const $day = await waitFor(() => screen.findByLabelText('Day'))
 
-    expect($year.getAttribute('value')).toBe('1999')
-    expect($month.getAttribute('value')).toBe('12')
-    expect($day.getAttribute('value')).toBe('31')
+    expect($year).toHaveValue(1999)
+    expect($month).toHaveValue(12)
+    expect($day).toHaveValue(31)
   })
 
   it('calls the updateValue prop if a valid date is entered', async () => {

--- a/designer/client/src/conditions/ConditionsEdit.test.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.test.tsx
@@ -157,11 +157,11 @@ describe('ConditionsEdit', () => {
         </RenderWithContext>
       )
 
-      const $link = screen.queryByRole('link', {
+      const $link = screen.getByRole('link', {
         name: condition.displayName
       })
 
-      const $link2 = screen.queryByRole('link', {
+      const $link2 = screen.getByRole('link', {
         name: condition2.displayName
       })
 
@@ -221,7 +221,7 @@ describe('ConditionsEdit', () => {
         </RenderWithContext>
       )
 
-      const $button = screen.queryByRole('button', {
+      const $button = screen.getByRole('button', {
         name: 'Add a new condition'
       })
 

--- a/designer/client/src/conditions/ConditionsEdit.test.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.test.tsx
@@ -6,7 +6,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -62,8 +62,6 @@ describe('ConditionsEdit', () => {
     sections: [],
     conditions: []
   } satisfies FormDefinition
-
-  afterEach(cleanup)
 
   describe('hint texts', () => {
     test('main hint text is correct', () => {

--- a/designer/client/src/conditions/InlineConditions.test.tsx
+++ b/designer/client/src/conditions/InlineConditions.test.tsx
@@ -1,14 +1,12 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import React from 'react'
 
 import { InlineConditions } from '~/src/conditions/InlineConditions.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
 describe('InlineConditions', () => {
-  afterEach(cleanup)
-
   test('Strings are rendered correctly', () => {
     const props = {
       path: '/some-path',

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -9,7 +9,7 @@ import {
   type Item
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import upperFirst from 'lodash/upperFirst.js'
 import React from 'react'
@@ -18,8 +18,6 @@ import { InlineConditionsDefinitionValue } from '~/src/conditions/InlineConditio
 import { type FieldDef } from '~/src/data/component/fields.js'
 
 describe('InlineConditionsDefinitionValue', () => {
-  afterEach(cleanup)
-
   it('should display a text input for fields without custom mappings or options', () => {
     const fieldDef: FieldDef = {
       label: 'Something',

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -128,7 +128,7 @@ describe('InlineConditionsDefinitionValue', () => {
     )
 
     expect($select).toBeInTheDocument()
-    expect($select.options[0].value).toBe('')
+    expect($select).toHaveValue('')
     expect($select.options[1]).toMatchObject(values[0])
     expect($select.options[2]).toMatchObject(values[1])
   })

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -9,7 +9,7 @@ import {
   type Item
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { act, cleanup, render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import upperFirst from 'lodash/upperFirst.js'
 import React from 'react'
@@ -20,7 +20,7 @@ import { type FieldDef } from '~/src/data/component/fields.js'
 describe('InlineConditionsDefinitionValue', () => {
   afterEach(cleanup)
 
-  it('should display a text input for fields without custom mappings or options', async () => {
+  it('should display a text input for fields without custom mappings or options', () => {
     const fieldDef: FieldDef = {
       label: 'Something',
       name: 'field1',
@@ -36,7 +36,10 @@ describe('InlineConditionsDefinitionValue', () => {
       />
     )
 
-    const $input = await waitFor(() => screen.findByDisplayValue('my-value'))
+    const $input = screen.getByRole('textbox', {
+      name: 'Value'
+    })
+
     expect($input).toBeInTheDocument()
     expect($input).toHaveAttribute('type', 'text')
   })
@@ -59,7 +62,7 @@ describe('InlineConditionsDefinitionValue', () => {
       />
     )
 
-    const $input = await waitFor(() => screen.getByLabelText('Value'))
+    const $input = screen.getByRole('textbox', { name: 'Value' })
 
     await act(() => userEvent.clear($input))
     await act(() => userEvent.type($input, 'new-value'))
@@ -89,7 +92,10 @@ describe('InlineConditionsDefinitionValue', () => {
       />
     )
 
-    const $input = await waitFor(() => screen.findByDisplayValue('my-value'))
+    const $input = screen.getByRole('textbox', {
+      name: 'Value'
+    })
+
     await act(() => userEvent.clear($input))
 
     expect(updateValueCallback).toHaveBeenLastCalledWith({
@@ -99,7 +105,7 @@ describe('InlineConditionsDefinitionValue', () => {
     })
   })
 
-  it('should display a select input for fields without custom mappings and with options', async () => {
+  it('should display a select input for fields without custom mappings and with options', () => {
     const values: Item[] = [
       { value: 'value1', text: 'Value 1' },
       { value: 'value2', text: 'Value 2' }
@@ -121,11 +127,9 @@ describe('InlineConditionsDefinitionValue', () => {
       />
     )
 
-    const $select = await waitFor(() =>
-      screen.findByRole<HTMLSelectElement>('combobox', {
-        name: 'Value'
-      })
-    )
+    const $select = screen.getByRole<HTMLSelectElement>('combobox', {
+      name: 'Value'
+    })
 
     expect($select).toBeInTheDocument()
     expect($select).toHaveValue('')
@@ -271,7 +275,7 @@ describe('InlineConditionsDefinitionValue', () => {
 
   it.each(relativeDateOperatorNames)(
     `should display relative date component fields for '%s' operator`,
-    async (operator) => {
+    (operator) => {
       const fieldDef: FieldDef = {
         label: 'Something',
         name: 'field1',
@@ -288,34 +292,18 @@ describe('InlineConditionsDefinitionValue', () => {
         />
       )
 
-      const $period = await waitFor(() =>
-        screen.findByRole('textbox', {
-          name: 'Period'
-        })
-      )
-
-      const $units = await waitFor(() =>
-        screen.findByRole('group', {
-          name: 'Units'
-        })
-      )
-
-      const $direction = await waitFor(() =>
-        screen.findByRole('group', {
-          name: 'Direction'
-        })
-      )
+      const $period = screen.getByRole('textbox', { name: 'Period' })
+      const $units = screen.getByRole('group', { name: 'Units' })
+      const $direction = screen.getByRole('group', { name: 'Direction' })
 
       expect($period).toBeInTheDocument()
       expect($units).toBeInTheDocument()
       expect($direction).toBeInTheDocument()
 
       for (const unit of Object.values(DateUnits)) {
-        const $unit = await waitFor(() =>
-          screen.findByRole('radio', {
-            name: upperFirst(unit)
-          })
-        )
+        const $unit = screen.getByRole('radio', {
+          name: upperFirst(unit)
+        })
 
         expect($unit).toBeInTheDocument()
       }
@@ -324,7 +312,7 @@ describe('InlineConditionsDefinitionValue', () => {
 
   it.each(absoluteDateOperatorNames)(
     `should display absolute date component fields for '%s' operator`,
-    async (operator) => {
+    (operator) => {
       const fieldDef: FieldDef = {
         label: 'Something',
         name: 'field1',
@@ -341,23 +329,9 @@ describe('InlineConditionsDefinitionValue', () => {
         />
       )
 
-      const $day = await waitFor(() =>
-        screen.findByRole('spinbutton', {
-          name: 'Day'
-        })
-      )
-
-      const $month = await waitFor(() =>
-        screen.findByRole('spinbutton', {
-          name: 'Month'
-        })
-      )
-
-      const $year = await waitFor(() =>
-        screen.findByRole('spinbutton', {
-          name: 'Year'
-        })
-      )
+      const $day = screen.getByRole('spinbutton', { name: 'Day' })
+      const $month = screen.getByRole('spinbutton', { name: 'Month' })
+      const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
       expect($day).toBeInTheDocument()
       expect($month).toBeInTheDocument()

--- a/designer/client/src/conditions/SelectConditions.test.tsx
+++ b/designer/client/src/conditions/SelectConditions.test.tsx
@@ -5,15 +5,13 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { cleanup, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import React from 'react'
 
 import { SelectConditions } from '~/src/conditions/SelectConditions.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
 describe('SelectConditions', () => {
-  afterEach(cleanup)
-
   const data = {
     pages: [],
     lists: [],

--- a/designer/client/src/conditions/SelectConditions.test.tsx
+++ b/designer/client/src/conditions/SelectConditions.test.tsx
@@ -38,7 +38,7 @@ describe('SelectConditions', () => {
       </RenderWithContext>
     )
 
-    const $paragraphs = screen.queryAllByRole('paragraph')
+    const $paragraphs = screen.getAllByRole('paragraph')
     const $conditions = screen.queryByRole('link', {
       name: 'Add a new condition'
     })
@@ -262,8 +262,8 @@ describe('SelectConditions', () => {
       (condition) => condition.displayName
     )
 
-    const $paragraphs = screen.queryAllByRole('paragraph')
-    const $conditions = screen.queryByRole('link', {
+    const $paragraphs = screen.getAllByRole('paragraph')
+    const $conditions = screen.getByRole('link', {
       name: 'Add a new condition'
     })
 

--- a/designer/client/src/list/ListItemEdit.test.tsx
+++ b/designer/client/src/list/ListItemEdit.test.tsx
@@ -137,14 +137,14 @@ describe('ListItemEdit', () => {
         'Select a condition that determines whether to show this list item. You can create and edit conditions on the Conditions screen.'
     })
 
-    expect($select.value).toBe('')
+    expect($select).toHaveValue('')
     expect($select.options[$select.selectedIndex].textContent).toBe(
       'Select a condition'
     )
 
     await act(() => userEvent.selectOptions($select, 'MYWwRN'))
 
-    expect($select.value).toBe('MYWwRN')
+    expect($select).toHaveValue('MYWwRN')
     expect($select.options[$select.selectedIndex].textContent).toBe(
       'my condition'
     )

--- a/designer/client/src/list/ListSelect.test.tsx
+++ b/designer/client/src/list/ListSelect.test.tsx
@@ -34,9 +34,9 @@ describe('ListSelect', () => {
       </RenderListEditorWithContext>
     )
 
-    const $link1 = screen.queryByRole('link', { name: data.lists[0].title })
-    const $link2 = screen.queryByRole('link', { name: data.lists[1].title })
-    const $button = screen.queryByRole('button', { name: 'Add a new list' })
+    const $link1 = screen.getByRole('link', { name: data.lists[0].title })
+    const $link2 = screen.getByRole('link', { name: data.lists[1].title })
+    const $button = screen.getByRole('button', { name: 'Add a new list' })
 
     expect($link1).toBeInTheDocument()
     expect($link2).toBeInTheDocument()

--- a/designer/client/src/section/SectionEdit.test.tsx
+++ b/designer/client/src/section/SectionEdit.test.tsx
@@ -1,13 +1,11 @@
 import { screen } from '@testing-library/dom'
-import { cleanup, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import React from 'react'
 
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
 describe('Section edit fields', () => {
-  afterEach(cleanup)
-
   test('should display titles and help texts', () => {
     render(
       <RenderWithContext>

--- a/designer/package.json
+++ b/designer/package.json
@@ -84,8 +84,6 @@
     "concurrently": "^8.2.2",
     "copy-webpack-plugin": "^12.0.2",
     "core-js": "^3.38.1",
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.8",
     "file-loader": "^6.2.0",
     "jsdom": "^25.0.0",
     "outdent": "^0.8.0",

--- a/designer/server/src/routes/forms/contact/email.test.js
+++ b/designer/server/src/routes/forms/contact/email.test.js
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/createServer.js'
@@ -77,11 +78,21 @@ describe('Forms contact email', () => {
 
     const { document } = await renderResponse(server, options)
 
-    const address = document.querySelector('#address')
-    expect(address).toHaveValue(emailAddress)
+    const $address = within(document.body).getByRole('textbox', {
+      name: 'Email address',
+      description:
+        'Enter a dedicated support team email address. Do not enter a named individual. For example, ‘support@defra.gov.uk’'
+    })
 
-    const responseTime = document.querySelector('#responseTime')
-    expect(responseTime).toHaveValue(responseTimeText)
+    expect($address).toHaveValue(emailAddress)
+
+    const $responseTime = within(document.body).getByRole('textbox', {
+      name: 'Response time',
+      description:
+        'Enter how long it takes to receive a response, for example, ‘We aim to respond within 2 working days’'
+    })
+
+    expect($responseTime).toHaveValue(responseTimeText)
   })
 
   test('POST - should redirect to overviewpage after updating email details', async () => {

--- a/designer/server/src/routes/forms/contact/online.test.js
+++ b/designer/server/src/routes/forms/contact/online.test.js
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/createServer.js'
@@ -75,11 +76,19 @@ describe('Forms contact online', () => {
 
     const { document } = await renderResponse(server, options)
 
-    const url = document.querySelector('#url')
-    expect(url).toHaveValue('https://www.gov.uk/guidance/contact-defra')
+    const $url = within(document.body).getByRole('textbox', {
+      name: 'Contact link',
+      description: 'For example, ‘https://www.gov.uk/guidance/contact-defra’'
+    })
 
-    const text = document.querySelector('#text')
-    expect(text).toHaveValue('Online contact form')
+    expect($url).toHaveValue('https://www.gov.uk/guidance/contact-defra')
+
+    const $text = within(document.body).getByRole('textbox', {
+      name: 'Text to describe the contact link',
+      description: 'For example, ‘Online contact form’'
+    })
+
+    expect($text).toHaveValue('Online contact form')
   })
 
   test('POST - should redirect to overviewpage after updating online details', async () => {

--- a/designer/server/src/routes/forms/contact/phone.test.js
+++ b/designer/server/src/routes/forms/contact/phone.test.js
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/createServer.js'
@@ -72,8 +73,11 @@ describe('Forms contact phone', () => {
 
     const { document } = await renderResponse(server, options)
 
-    const phone = document.querySelector('#phone')
-    expect(phone).toHaveValue('123')
+    const $phone = within(document.body).getByRole('textbox', {
+      name: 'What’s the phone number and opening times for users to get help?'
+    })
+
+    expect($phone).toHaveValue('123')
   })
 
   test('POST - should redirect to overviewpage after updating phone details', async () => {

--- a/designer/server/src/routes/forms/edit.test.js
+++ b/designer/server/src/routes/forms/edit.test.js
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/createServer.js'
@@ -69,11 +70,20 @@ describe('Forms library routes', () => {
 
     const { document } = await renderResponse(server, options)
 
-    const teamName = document.querySelector('#teamName')
-    const teamEmail = document.querySelector('#teamEmail')
+    const $teamName = within(document.body).getByRole('textbox', {
+      name: 'Name of team',
+      description:
+        'Enter the name of the policy team or business area responsible for this form'
+    })
 
-    expect(teamName).toHaveValue('Defra Forms')
-    expect(teamEmail).toHaveValue('defraforms@defra.gov.uk')
+    const $teamEmail = within(document.body).getByRole('textbox', {
+      name: 'Shared team email address',
+      description:
+        'Used to contact the form subject matter expert (SME) or key stakeholder. Must be a UK email address, like name@example.gov.uk'
+    })
+
+    expect($teamName).toHaveValue('Defra Forms')
+    expect($teamEmail).toHaveValue('defraforms@defra.gov.uk')
   })
 
   test('POST - should redirect to overviewpage after updating team details', async () => {
@@ -111,8 +121,11 @@ describe('Forms library routes', () => {
 
     const { document } = await renderResponse(server, options)
 
-    const title = document.querySelector('#title')
-    expect(title).toHaveValue('Test form')
+    const $title = within(document.body).getByRole('textbox', {
+      name: 'Enter a name for your form'
+    })
+
+    expect($title).toHaveValue('Test form')
   })
 
   test('POST - should redirect to overviewpage after updating title', async () => {

--- a/designer/server/src/routes/forms/privacy-notice.test.js
+++ b/designer/server/src/routes/forms/privacy-notice.test.js
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/createServer.js'
@@ -70,8 +71,12 @@ describe('Forms privacy notice', () => {
 
     const { document } = await renderResponse(server, options)
 
-    const privacyNoticeUrl = document.querySelector('#privacyNoticeUrl')
-    expect(privacyNoticeUrl).toHaveValue(
+    const $privacyNoticeUrl = within(document.body).getByRole('textbox', {
+      name: 'Link to privacy notice for this form',
+      description: 'For example, https://www.gov.uk/help/privacy-notice'
+    })
+
+    expect($privacyNoticeUrl).toHaveValue(
       'https://www.gov.uk/help/privacy-notice'
     )
   })

--- a/designer/server/src/routes/health.test.js
+++ b/designer/server/src/routes/health.test.js
@@ -1,24 +1,20 @@
+import { createServer } from '~/src/createServer.js'
 import { auth } from '~/test/fixtures/auth.js'
 
 describe('Health check route', () => {
-  const startServer = async () => {
-    const { createServer } = await import('~/src/createServer.js')
-
-    const server = await createServer()
-    await server.initialize()
-    return server
-  }
-
   /** @type {Server} */
   let server
 
-  afterEach(async () => {
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
     await server.stop()
   })
 
   test('/health route response is correct', async () => {
-    server = await startServer()
-
     const options = {
       method: 'GET',
       url: '/health',

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,6 @@
       },
       "optionalDependencies": {
         "@types/dagre": "^0.7.52",
-        "@types/enzyme": "^3.10.18",
-        "@types/enzyme-adapter-react-16": "^1.0.9",
         "@types/eslint": "^8.56.12",
         "@types/govuk-frontend": "^5.4.0",
         "@types/hapi__catbox-memory": "^4.1.8",
@@ -137,8 +135,6 @@
         "concurrently": "^8.2.2",
         "copy-webpack-plugin": "^12.0.2",
         "core-js": "^3.38.1",
-        "enzyme": "^3.11.0",
-        "enzyme-adapter-react-16": "^1.15.8",
         "file-loader": "^6.2.0",
         "jsdom": "^25.0.0",
         "outdent": "^0.8.0",
@@ -4769,50 +4765,11 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/cheerio": {
-      "version": "0.22.35",
-      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
-      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/dagre": {
       "version": "0.7.52",
       "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.52.tgz",
       "integrity": "sha512-XKJdy+OClLk3hketHi9Qg6gTfe1F3y+UFnHxKA2rn9Dw+oXa4Gb378Ztz9HlMgZKSxpPmn4BNVh9wgkpvrK1uw==",
       "optional": true
-    },
-    "node_modules/@types/enzyme": {
-      "version": "3.10.18",
-      "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.18.tgz",
-      "integrity": "sha512-RaO/TyyHZvXkpzinbMTZmd/S5biU4zxkvDsn22ujC29t9FMSzq8tnn8f2MxQ2P8GVhFRG5jTAL05DXKyTtpEQQ==",
-      "optional": true,
-      "dependencies": {
-        "@types/cheerio": "*",
-        "@types/react": "^16"
-      }
-    },
-    "node_modules/@types/enzyme-adapter-react-16": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.9.tgz",
-      "integrity": "sha512-z24MMxGtUL8HhXdye3tWzjp+19QTsABqLaX2oOZpxMPHRJgLfahQmOeTTrEBQd9ogW20+UmPBXD9j+XOasFHvw==",
-      "optional": true,
-      "dependencies": {
-        "@types/enzyme": "*"
-      }
-    },
-    "node_modules/@types/enzyme/node_modules/@types/react": {
-      "version": "16.14.60",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.60.tgz",
-      "integrity": "sha512-wIFmnczGsTcgwCBeIYOuy2mdXEiKZ5znU/jNOnMZPQyCcIxauMGWlX0TNG4lZ7NxRKj7YUIZRneJQSSdB2jKgg==",
-      "optional": true,
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
@@ -5625,35 +5582,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "dev": true,
-      "dependencies": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
-      }
-    },
-    "node_modules/airbnb-prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -5863,40 +5791,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array.prototype.filter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz",
-      "integrity": "sha512-VizNcj/RGJiUyQBgzwxzE5oHdeuXY5hSbbmKMlphj1cy1Vl7Pn2asCGbSrru6hSQjmCzqTBPVWAF/whmEOVHbw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.find": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.2.2.tgz",
-      "integrity": "sha512-DRumkfW97iZGOfn+lIXbkVrXL04sfYKX+EfOodo8XboR5sxPDVvOjZTF/rysusa9lmhmSOeD6Vp6RKQP+eP4Tg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -6658,44 +6552,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-      "dev": true,
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/cheerio-select": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-      "dev": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-select": "^5.1.0",
-        "css-what": "^6.1.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chokidar": {
@@ -7990,12 +7846,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -8201,122 +8051,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/enzyme": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-      "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-      "dev": true,
-      "dependencies": {
-        "array.prototype.flat": "^1.2.3",
-        "cheerio": "^1.0.0-rc.3",
-        "enzyme-shallow-equal": "^1.0.1",
-        "function.prototype.name": "^1.1.2",
-        "has": "^1.0.3",
-        "html-element-map": "^1.2.0",
-        "is-boolean-object": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-number-object": "^1.0.4",
-        "is-regex": "^1.0.5",
-        "is-string": "^1.0.5",
-        "is-subset": "^0.1.1",
-        "lodash.escape": "^4.0.1",
-        "lodash.isequal": "^4.5.0",
-        "object-inspect": "^1.7.0",
-        "object-is": "^1.0.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1",
-        "object.values": "^1.1.1",
-        "raf": "^3.4.1",
-        "rst-selector-parser": "^2.2.3",
-        "string.prototype.trim": "^1.2.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16": {
-      "version": "1.15.8",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.8.tgz",
-      "integrity": "sha512-uYGC31eGZBp5nGsr4nKhZKvxGQjyHGjS06BJsUlWgE29/hvnpgCsT1BJvnnyny7N3GIIVyxZ4O9GChr6hy2WQA==",
-      "dev": true,
-      "dependencies": {
-        "enzyme-adapter-utils": "^1.14.2",
-        "enzyme-shallow-equal": "^1.0.7",
-        "hasown": "^2.0.0",
-        "object.assign": "^4.1.5",
-        "object.values": "^1.1.7",
-        "prop-types": "^15.8.1",
-        "react-is": "^16.13.1",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "enzyme": "^3.0.0",
-        "react": "^16.0.0-0",
-        "react-dom": "^16.0.0-0"
-      }
-    },
-    "node_modules/enzyme-adapter-react-16/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
-    "node_modules/enzyme-adapter-react-16/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/enzyme-adapter-utils": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.2.tgz",
-      "integrity": "sha512-1ZC++RlsYRaiOWE5NRaF5OgsMt7F5rn/VuaJIgc7eW/fmgg8eS1/Ut7EugSPPi7VMdWMLcymRnMF+mJUJ4B8KA==",
-      "dev": true,
-      "dependencies": {
-        "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.6",
-        "hasown": "^2.0.0",
-        "object.assign": "^4.1.5",
-        "object.fromentries": "^2.0.7",
-        "prop-types": "^15.8.1",
-        "semver": "^6.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "0.13.x || 0.14.x || ^15.0.0-0 || ^16.0.0-0"
-      }
-    },
-    "node_modules/enzyme-adapter-utils/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/enzyme-shallow-equal": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.7.tgz",
-      "integrity": "sha512-/um0GFqUXnpM9SvKtje+9Tjoz3f1fpBC3eXRFrNs8kpYn69JljciYP7KZTqM/YQbUY9KUjvKB4jo/q+L6WGGvg==",
-      "dev": true,
-      "dependencies": {
-        "hasown": "^2.0.0",
-        "object-is": "^1.1.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -8385,12 +8119,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-      "dev": true
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
@@ -10309,15 +10037,6 @@
         "real-require": "^0.2.0"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -10404,19 +10123,6 @@
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "dev": true
     },
-    "node_modules/html-element-map": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-      "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-      "dev": true,
-      "dependencies": {
-        "array.prototype.filter": "^1.0.0",
-        "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -10434,25 +10140,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
-      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -11184,12 +10871,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-subset": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-      "dev": true
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
@@ -13955,18 +13636,6 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
-    "node_modules/lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-      "dev": true
-    },
-    "node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-      "dev": true
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -13983,12 +13652,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -14314,12 +13977,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/moo": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "dev": true
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -14359,34 +14016,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
-    },
-    "node_modules/nearley": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "bin": {
-        "nearley-railroad": "bin/nearley-railroad.js",
-        "nearley-test": "bin/nearley-test.js",
-        "nearley-unparse": "bin/nearley-unparse.js",
-        "nearleyc": "bin/nearleyc.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://nearley.js.org/#give-to-nearley"
-      }
-    },
-    "node_modules/nearley/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
     "node_modules/neo-async": {
@@ -14981,19 +14610,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-      "dev": true,
-      "dependencies": {
-        "domhandler": "^5.0.2",
-        "parse5": "^7.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -15074,12 +14690,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.0.1",
@@ -16184,17 +15794,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "node_modules/prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -16353,34 +15952,6 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
-    "node_modules/railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true
-    },
-    "node_modules/randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
-      "dependencies": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -16493,27 +16064,6 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -16598,12 +16148,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha512-qOLsBKHCpSOFKK1NUOCGC5VyeufB6lEsFe92AL2bhIJsacZS1qdoOZSbPk3MYKuT2cFlRDnulKXuuElIrMjGUg==",
-      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -16830,15 +16374,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -16876,16 +16411,6 @@
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true
-    },
-    "node_modules/rst-selector-parser": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-      "integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-      "dev": true,
-      "dependencies": {
-        "lodash.flattendeep": "^4.4.0",
-        "nearley": "^2.7.10"
-      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,6 @@
   },
   "optionalDependencies": {
     "@types/dagre": "^0.7.52",
-    "@types/enzyme": "^3.10.18",
-    "@types/enzyme-adapter-react-16": "^1.0.9",
     "@types/eslint": "^8.56.12",
     "@types/govuk-frontend": "^5.4.0",
     "@types/hapi__catbox-memory": "^4.1.8",


### PR DESCRIPTION
This PR follows up with https://github.com/DEFRA/forms-designer/pull/458 and removes the [**Enzyme** testing utility](https://www.npmjs.com/package/enzyme)

All tests now use [Testing Library](https://testing-library.com) instead

**Note:** I've swapped test `queryByX` → `getByX` for more useful failure output, including generated HTML