### PR TITLE
Fix page type not set by default

### DIFF
--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -67,6 +67,7 @@ export class PageCreate extends Component<Props, State> {
   static readonly contextType = DataContext
 
   state: State = {
+    controller: ControllerType.Page,
     isEditingSection: false,
     isNewSection: false,
     isQuestionPage: true,
@@ -322,7 +323,7 @@ export class PageCreate extends Component<Props, State> {
                 (errors.controller ? 'page-controller-error' : '')
               }
               name="controller"
-              value={controller ?? ControllerType.Page}
+              value={controller ?? ''}
               onChange={this.onChangeController}
             >
               <option value="">


### PR DESCRIPTION
When adding a new page we default the page type to "Question page"

This PR fixes a bug where the state wasn't updated until the page type `onChange` event fired