### PR TITLE
Fix up/down buttons showing for single component

### DIFF
--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -288,7 +288,7 @@ export const Component: FunctionComponent<Readonly<Props>> = (props) => {
     await save(definition)
   }
 
-  const showMoveActions = hasComponents(page) && !!page.components.length
+  const showMoveActions = hasComponents(page) && page.components.length > 1
 
   return (
     <>

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -130,7 +130,40 @@ describe('Page', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  test('Visualisation page actions contain expected call to actions', () => {
+  test('Page actions are available', () => {
+    render(
+      <RenderWithContext data={data}>
+        <Page page={data.pages[0]} />
+      </RenderWithContext>
+    )
+
+    const $heading = screen.queryByRole('heading', {
+      name: 'my first page'
+    })
+
+    expect($heading).toBeInTheDocument()
+
+    const $buttonEdit = screen.queryByRole('button', {
+      name: 'Edit page',
+      description: $heading?.innerText
+    })
+
+    const $linkPreview = screen.queryByRole('link', {
+      name: 'Preview page',
+      description: $heading?.innerText
+    })
+
+    const $buttonAdd = screen.queryByRole('button', {
+      name: 'Add component',
+      description: $heading?.innerText
+    })
+
+    expect($buttonEdit).toBeInTheDocument()
+    expect($linkPreview).toBeInTheDocument()
+    expect($buttonAdd).toBeInTheDocument()
+  })
+
+  test('Component actions are available', () => {
     render(
       <RenderWithContext data={data}>
         <Page page={data.pages[0]} />
@@ -179,24 +212,5 @@ describe('Page', () => {
       expect($buttonMoveUp).toBeInTheDocument()
       expect($buttonMoveDown).toBeInTheDocument()
     }
-
-    const $buttonEdit = screen.queryByRole('button', {
-      name: 'Edit page',
-      description: $heading?.innerText
-    })
-
-    const $linkPreview = screen.queryByRole('link', {
-      name: 'Preview page',
-      description: $heading?.innerText
-    })
-
-    const $buttonAdd = screen.queryByRole('button', {
-      name: 'Add component',
-      description: $heading?.innerText
-    })
-
-    expect($buttonEdit).toBeInTheDocument()
-    expect($linkPreview).toBeInTheDocument()
-    expect($buttonAdd).toBeInTheDocument()
   })
 })

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -50,7 +50,16 @@ const data = {
       title: 'my second page',
       path: '/2',
       next: [],
-      components: []
+      components: [
+        {
+          name: 'phone',
+          title: 'Mobile phone number',
+          type: ComponentType.TelephoneNumberField,
+          options: {
+            required: true
+          }
+        }
+      ]
     }
   ],
   lists: [],
@@ -211,6 +220,47 @@ describe('Page', () => {
       expect($component).toBeInTheDocument()
       expect($buttonMoveUp).toBeInTheDocument()
       expect($buttonMoveDown).toBeInTheDocument()
+    }
+  })
+
+  test('Component up/down not available for single component', () => {
+    render(
+      <RenderWithContext data={data}>
+        <Page page={data.pages[1]} />
+      </RenderWithContext>
+    )
+
+    const $heading = screen.queryByRole('heading', {
+      name: 'my second page'
+    })
+
+    expect($heading).toBeInTheDocument()
+
+    for (const { title, label, description } of [
+      {
+        title: 'Mobile phone number',
+        label: 'Telephone number',
+        description: $heading?.innerText
+      }
+    ]) {
+      const $component = screen.queryByRole('button', {
+        name: `Edit ${lowerFirst(label)} component: ${title}`,
+        description
+      })
+
+      const $buttonMoveUp = screen.queryByRole('button', {
+        name: `Move ${lowerFirst(label)} component up: ${title}`,
+        description
+      })
+
+      const $buttonMoveDown = screen.queryByRole('button', {
+        name: `Move ${lowerFirst(label)} component down: ${title}`,
+        description
+      })
+
+      expect($component).toBeInTheDocument()
+      expect($buttonMoveUp).not.toBeInTheDocument()
+      expect($buttonMoveDown).not.toBeInTheDocument()
     }
   })
 })


### PR DESCRIPTION
This PR fixes a regression where up/down sorting arrows appeared on single component pages

Added tests to make sure it won't happen again

Closes [story #440769](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/440769)