### PR TITLE
Fix Sonar warning to use buttons (not links) for actions

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -224,13 +224,18 @@ module.exports = {
       env: {
         browser: true
       },
-      extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+      extends: [
+        'plugin:jsx-a11y/recommended',
+        'plugin:react/jsx-runtime',
+        'plugin:react/recommended',
+        'plugin:react-hooks/recommended'
+      ],
       files: ['**/*.{jsx,tsx}'],
       parserOptions: {
         ecmaFeatures: { jsx: true },
         sourceType: 'module'
       },
-      plugins: ['react', 'react-hooks'],
+      plugins: ['jsx-a11y', 'react', 'react-hooks'],
       rules: {
         'react/prop-types': 0,
         'react-hooks/rules-of-hooks': 'warn'

--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -324,7 +324,11 @@ export function Component(props: Readonly<ComponentProps>) {
       )}
       {showEditor && (
         <RenderInPortal>
-          <Flyout title={componentFlyoutTitle} onHide={onSave}>
+          <Flyout
+            id="component-edit"
+            title={componentFlyoutTitle}
+            onHide={onSave}
+          >
             <ComponentContextProvider selectedComponent={selectedComponent}>
               <ComponentEdit page={page} onSave={onSave} />
             </ComponentContextProvider>

--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -291,19 +291,19 @@ export function Component(props: Readonly<ComponentProps>) {
   const showMoveActions = hasComponents(page) && page.components.length > 1
 
   return (
-    <>
+    <div className="app-component">
       <button
-        className="component govuk-link"
+        className="app-component__button govuk-button govuk-button--component"
         onClick={onSave}
-        aria-label={componentButtonLabel}
         aria-describedby={headingId}
       >
+        <span className="govuk-visually-hidden">{componentButtonLabel}</span>
         <ComponentIcon />
       </button>
       {showMoveActions && (
-        <div className="govuk-button-group">
+        <div className="app-component__actions">
           <button
-            className="component-move govuk-button govuk-button--secondary govuk-!-margin-right-0"
+            className="app-component__action govuk-button govuk-button--secondary"
             onClick={() => move(index, index - 1)}
             title={componentMoveUpTitle}
             aria-label={componentMoveUpLabel}
@@ -312,7 +312,7 @@ export function Component(props: Readonly<ComponentProps>) {
             ▲
           </button>
           <button
-            className="component-move govuk-button govuk-button--secondary"
+            className="app-component__action govuk-button govuk-button--secondary"
             onClick={() => move(index, index + 1)}
             title={componentMoveDownTitle}
             aria-label={componentMoveDownLabel}
@@ -335,6 +335,6 @@ export function Component(props: Readonly<ComponentProps>) {
           </Flyout>
         </RenderInPortal>
       )}
-    </>
+    </div>
   )
 }

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -413,7 +413,7 @@ export class PageCreate extends Component<Props, State> {
                 <p className="govuk-body govuk-!-margin-top-2">
                   {section && (
                     <a
-                      href="#"
+                      href="#section-edit"
                       className="govuk-link govuk-!-display-block"
                       onClick={this.editSection}
                     >
@@ -421,7 +421,7 @@ export class PageCreate extends Component<Props, State> {
                     </a>
                   )}
                   <a
-                    href="#"
+                    href="#section-edit"
                     className="govuk-link govuk-!-display-block"
                     onClick={(e) => this.editSection(e, true)}
                   >
@@ -485,6 +485,7 @@ export class PageCreate extends Component<Props, State> {
         {isEditingSection && (
           <RenderInPortal>
             <Flyout
+              id="section-edit"
               title={
                 !isNewSection && !!section
                   ? i18n('section.editTitle', { title: section.title })

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -455,7 +455,7 @@ export class PageEdit extends Component<Props, State> {
                 <p className="govuk-body govuk-!-margin-top-2">
                   {section && (
                     <a
-                      href="#"
+                      href="#section-edit"
                       className="govuk-link govuk-!-display-block"
                       onClick={this.editSection}
                     >
@@ -463,7 +463,7 @@ export class PageEdit extends Component<Props, State> {
                     </a>
                   )}
                   <a
-                    href="#"
+                    href="#section-edit"
                     className="govuk-link govuk-!-display-block"
                     onClick={(e) => this.editSection(e, true)}
                   >
@@ -491,6 +491,7 @@ export class PageEdit extends Component<Props, State> {
         {isEditingSection && (
           <RenderInPortal>
             <Flyout
+              id="section-edit"
               title={
                 !isNewSection && !!section
                   ? i18n('section.editTitle', { title: section.title })

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -118,7 +118,11 @@ export function ComponentCreate(props: Readonly<Props>) {
   return (
     <>
       <RenderInPortal>
-        <Flyout title={i18n('component.create')} onHide={onSave}>
+        <Flyout
+          id="component-create-list"
+          title={i18n('component.create')}
+          onHide={onSave}
+        >
           <ComponentCreateList
             page={props.page}
             onSelectComponent={handleCreate}
@@ -129,6 +133,7 @@ export function ComponentCreate(props: Readonly<Props>) {
       {type && (
         <RenderInPortal>
           <Flyout
+            id="component-type-edit"
             title={`${componentName} ${i18n('component.component')}`}
             onHide={handleReset}
           >

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -72,7 +72,7 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
                   <p className="govuk-body govuk-!-margin-bottom-2">
                     <a
                       className="govuk-link"
-                      href="#0"
+                      href="#component-create-list"
                       onClick={(e) => {
                         e.preventDefault()
                         onSelectComponent(component)
@@ -112,7 +112,7 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
                     <li key={component.type}>
                       <p className="govuk-body govuk-!-margin-bottom-2">
                         <a
-                          href="#0"
+                          href="#component-type-edit"
                           className="govuk-link"
                           onClick={(e) => {
                             e.preventDefault()
@@ -149,7 +149,7 @@ export const ComponentCreateList = (props: Readonly<Props>) => {
                     <li key={component.type}>
                       <p className="govuk-body govuk-!-margin-bottom-2">
                         <a
-                          href="#0"
+                          href="#component-type-edit"
                           className="govuk-link"
                           onClick={(e) => {
                             e.preventDefault()

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -149,7 +149,7 @@ export function ComponentListSelect() {
           <a
             className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
             onClick={handleEditList}
-            href="#"
+            href="#list-edit"
           >
             {i18n('list.edit')}
           </a>
@@ -157,7 +157,7 @@ export function ComponentListSelect() {
         <a
           className="govuk-link govuk-!-display-block govuk-!-margin-bottom-1"
           onClick={handleAddList}
-          href="#"
+          href="#list-edit"
         >
           {i18n('list.add')}
         </a>

--- a/designer/client/src/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/src/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -6,8 +6,8 @@ interface Props extends Omit<ComponentProps<'pre'>, 'children'> {
 
 export function DataPrettyPrint({ children, ...attributes }: Readonly<Props>) {
   return (
-    <pre tabIndex={-1} {...attributes}>
-      <code tabIndex={0}>{JSON.stringify(children, undefined, 2)}</code>
+    <pre {...attributes}>
+      <code>{JSON.stringify(children, undefined, 2)}</code>
     </pre>
   )
 }

--- a/designer/client/src/components/Flyout/Flyout.test.tsx
+++ b/designer/client/src/components/Flyout/Flyout.test.tsx
@@ -10,17 +10,17 @@ describe('Flyout', () => {
   it('renders with accessible heading and close button', () => {
     render(
       <RenderWithContext>
-        <Flyout title="Example" onHide={jest.fn()} />
+        <Flyout id="example" title="Example" onHide={jest.fn()} />
       </RenderWithContext>
     )
 
     const $dialog = screen.getByRole('dialog', { name: 'Example' })
     const $heading = screen.getByRole('heading', { name: 'Example' })
-    const $button = screen.getByRole('button', { name: 'Close' })
+    const $close = screen.getByRole('button', { name: 'Close' })
 
     expect($dialog).toBeInTheDocument()
     expect($dialog).toContainElement($heading)
-    expect($dialog).toContainElement($button)
+    expect($dialog).toContainElement($close)
 
     const headingId = 'flyout-1-heading'
 
@@ -34,7 +34,7 @@ describe('Flyout', () => {
 
     render(
       <RenderWithContext context={{ flyout: { increment, decrement } }}>
-        <Flyout title="Example 1" onHide={jest.fn()} />
+        <Flyout id="example" title="Example 1" onHide={jest.fn()} />
       </RenderWithContext>
     )
 
@@ -48,7 +48,7 @@ describe('Flyout', () => {
 
     const { unmount } = render(
       <RenderWithContext context={{ flyout: { increment, decrement } }}>
-        <Flyout title="Example 1" onHide={jest.fn()} />
+        <Flyout id="example" title="Example 1" onHide={jest.fn()} />
       </RenderWithContext>
     )
 
@@ -61,14 +61,17 @@ describe('Flyout', () => {
   it('opens and closes as a modal dialog', async () => {
     render(
       <RenderWithContext>
-        <Flyout title="Example" onHide={jest.fn()} />
+        <Flyout id="example" title="Example" onHide={jest.fn()} />
       </RenderWithContext>
     )
 
     expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled()
 
-    const $button = screen.getByRole('button', { name: 'Close' })
-    await act(() => userEvent.click($button))
+    const $close = screen.getByRole('button', {
+      name: 'Close'
+    })
+
+    await act(() => userEvent.click($close))
 
     expect(HTMLDialogElement.prototype.close).toHaveBeenCalled()
   })
@@ -76,7 +79,7 @@ describe('Flyout', () => {
   it('renders first flyout without an offset', () => {
     render(
       <RenderWithContext>
-        <Flyout title="Example 1" onHide={jest.fn()} />
+        <Flyout id="example" title="Example 1" onHide={jest.fn()} />
       </RenderWithContext>
     )
 
@@ -95,7 +98,7 @@ describe('Flyout', () => {
   it('renders subsequent flyouts with an offset', () => {
     render(
       <RenderWithContext context={{ flyout: { count: 1 } }}>
-        <Flyout title="Example 2" onHide={jest.fn()} />
+        <Flyout id="example" title="Example 2" onHide={jest.fn()} />
       </RenderWithContext>
     )
 

--- a/designer/client/src/components/Flyout/Flyout.tsx
+++ b/designer/client/src/components/Flyout/Flyout.tsx
@@ -14,6 +14,7 @@ import { FlyoutContext } from '~/src/context/FlyoutContext.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 
 interface Props {
+  id: string
   title: string
   width?: string
   children?: ReactNode
@@ -95,7 +96,7 @@ export function useFlyoutEffect(
 }
 
 export function Flyout(props: Readonly<Props>) {
-  const { title, width = '', children } = props
+  const { id, title, width = '', children } = props
   const { style, offset, ref, closeOnClick, closeOnEnter } =
     useFlyoutEffect(props)
 
@@ -109,10 +110,11 @@ export function Flyout(props: Readonly<Props>) {
         tabbableOptions: { displayCheck: 'none' }
       }}
     >
-      <dialog className="flyout" aria-labelledby={headingId} ref={ref}>
+      <dialog id={id} className="flyout" aria-labelledby={headingId} ref={ref}>
         <div className={`flyout__container ${width}`.trim()} style={style}>
           <button
             className="flyout__button-close govuk-link"
+            type="button"
             onClick={closeOnClick}
             onKeyDown={closeOnEnter}
           >

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -51,11 +51,11 @@ describe('Menu', () => {
 
     expect($dialog).toBeInTheDocument()
 
-    const $buttonClose = screen.getByRole('button', {
+    const $close = screen.getByRole('button', {
       name: 'Close'
     })
 
-    await act(() => userEvent.click($buttonClose))
+    await act(() => userEvent.click($close))
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -141,7 +141,7 @@ export function Menu() {
 
       {page.isVisible && (
         <RenderInPortal>
-          <Flyout title={i18n('page.add')} onHide={page.hide}>
+          <Flyout id="page-create" title={i18n('page.add')} onHide={page.hide}>
             <PageCreate onSave={page.hide} />
           </Flyout>
         </RenderInPortal>
@@ -149,7 +149,7 @@ export function Menu() {
 
       {link.isVisible && (
         <RenderInPortal>
-          <Flyout title={i18n('menu.links')} onHide={link.hide}>
+          <Flyout id="link-edit" title={i18n('menu.links')} onHide={link.hide}>
             <LinkEdit onSave={link.hide} />
           </Flyout>
         </RenderInPortal>
@@ -157,7 +157,11 @@ export function Menu() {
 
       {sections.isVisible && (
         <RenderInPortal>
-          <Flyout title={i18n('sections.edit')} onHide={sections.hide}>
+          <Flyout
+            id="sections-edit"
+            title={i18n('sections.edit')}
+            onHide={sections.hide}
+          >
             <SectionsEdit />
           </Flyout>
         </RenderInPortal>
@@ -166,6 +170,7 @@ export function Menu() {
       {conditions.isVisible && (
         <RenderInPortal>
           <Flyout
+            id="conditions-edit"
             title={i18n('conditions.addOrEdit')}
             onHide={conditions.hide}
             width="large"
@@ -177,7 +182,11 @@ export function Menu() {
 
       {lists.isVisible && (
         <RenderInPortal>
-          <Flyout title={i18n('list.addOrEdit')} onHide={lists.hide}>
+          <Flyout
+            id="lists-edit"
+            title={i18n('list.addOrEdit')}
+            onHide={lists.hide}
+          >
             <ListsEditorContextProvider>
               <ListContextProvider>
                 <ListsEdit showEditLists={false} />
@@ -189,7 +198,11 @@ export function Menu() {
 
       {summary.isVisible && (
         <RenderInPortal>
-          <Flyout title={i18n('summary.edit')} onHide={summary.hide}>
+          <Flyout
+            id="declaration-edit"
+            title={i18n('summary.edit')}
+            onHide={summary.hide}
+          >
             <DeclarationEdit onSave={summary.hide} />
           </Flyout>
         </RenderInPortal>
@@ -198,6 +211,7 @@ export function Menu() {
       {overview.isVisible && (
         <RenderInPortal>
           <Flyout
+            id="form-overview"
             title={i18n('menu.overview')}
             width="xlarge"
             onHide={overview.hide}

--- a/designer/client/src/components/Menu/SubMenu.tsx
+++ b/designer/client/src/components/Menu/SubMenu.tsx
@@ -87,18 +87,21 @@ export function SubMenu({ overview }: Readonly<Props>) {
     <div className="govuk-button-group">
       <button
         className="govuk-link govuk-!-font-size-16"
+        type="button"
         onClick={onClickUpload}
       >
         {i18n('menu.upload')}
       </button>
       <button
         className="govuk-link govuk-!-font-size-16"
+        type="button"
         onClick={onClickDownload}
       >
         {i18n('menu.download')}
       </button>
       <button
         className="govuk-link govuk-!-font-size-16"
+        type="button"
         onClick={overview.show}
       >
         {i18n('menu.overview')}

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -107,12 +107,12 @@ describe('Page', () => {
       })
     )
 
-    const $buttonClose = screen.getByRole('button', {
+    const $close = screen.getByRole('button', {
       name: 'Close'
     })
 
     // Close edit page
-    await act(() => userEvent.click($buttonClose))
+    await act(() => userEvent.click($close))
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
@@ -129,11 +129,11 @@ describe('Page', () => {
 
     await act(() => userEvent.click($buttonAdd))
 
-    const $buttonClose = screen.getByRole('button', {
+    const $close = screen.getByRole('button', {
       name: 'Close'
     })
 
-    await act(() => userEvent.click($buttonClose))
+    await act(() => userEvent.click($close))
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -124,6 +124,7 @@ export const Page = (
       {isEditingPage && (
         <RenderInPortal>
           <Flyout
+            id="page-edit"
             title={i18n('page.edit')}
             onHide={() => setIsEditingPage(false)}
           >

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -27,14 +27,12 @@ const ComponentItem = (
   const { index, page, selectedComponent } = props
 
   return (
-    <div className="component-item">
-      <Component
-        index={index}
-        page={page}
-        key={selectedComponent.name}
-        selectedComponent={selectedComponent}
-      />
-    </div>
+    <Component
+      index={index}
+      page={page}
+      key={selectedComponent.name}
+      selectedComponent={selectedComponent}
+    />
   )
 }
 
@@ -48,7 +46,7 @@ const ComponentList = (props: Readonly<{ page: PageType }>) => {
   const { components = [] } = page
 
   return (
-    <div className="component-list">
+    <>
       {components.map((component, index) => (
         <ComponentItem
           index={index}
@@ -57,7 +55,7 @@ const ComponentList = (props: Readonly<{ page: PageType }>) => {
           selectedComponent={component}
         />
       ))}
-    </div>
+    </>
   )
 }
 
@@ -96,15 +94,16 @@ export const Page = (
 
       <div className="page__actions">
         <button
-          onClick={() => setIsEditingPage(true)}
-          className="govuk-link"
+          className="govuk-button govuk-button--editor"
+          type="button"
           aria-describedby={headingId}
+          onClick={() => setIsEditingPage(true)}
         >
           {i18n('page.edit')}
         </button>
         <a
           href={href}
-          className="govuk-link"
+          className="govuk-button govuk-button--editor"
           target="_blank"
           rel="noreferrer"
           aria-describedby={headingId}
@@ -113,9 +112,9 @@ export const Page = (
         </a>
         {hasComponents(page) && (
           <button
-            onClick={() => setIsCreatingComponent(true)}
-            className="govuk-link"
+            className="govuk-button govuk-button--editor"
             aria-describedby={headingId}
+            onClick={() => setIsCreatingComponent(true)}
           >
             {i18n('component.create')}
           </button>

--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -106,6 +106,7 @@ export class Lines extends Component<Props, State> {
         {this.state.edge && (
           <RenderInPortal>
             <Flyout
+              id="link-edit"
               title={i18n('link.edit')}
               onHide={() => this.setState({ edge: undefined })}
             >

--- a/designer/client/src/components/Visualisation/visualisation.scss
+++ b/designer/client/src/components/Visualisation/visualisation.scss
@@ -50,28 +50,14 @@ $govuk-breakpoints: (
     &__actions {
       display: flex;
       flex-direction: column;
+      @include govuk-responsive-padding(2, "top");
 
-      button.govuk-link {
-        border: none;
-        box-shadow: none;
-        text-align: left;
-      }
+      .govuk-button {
+        margin-bottom: 1px;
 
-      .govuk-link {
-        @include govuk-responsive-padding(2);
-        text-decoration: none;
-        background-color: govuk-colour("black");
-        color: govuk-colour("white");
-
-        &:hover,
-        &:focus {
-          background-color: govuk-colour("yellow");
-          color: govuk-colour("black");
-          cursor: pointer;
-        }
-
-        &:not(:last-child) {
-          border-bottom: 1px solid #ffffff;
+        &:last-child {
+          margin-bottom: 0;
+          box-shadow: none;
         }
       }
     }

--- a/designer/client/src/conditions/ConditionsEdit.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.tsx
@@ -74,6 +74,7 @@ export function ConditionsEdit({ path }: Readonly<Props>) {
           {showAddCondition && (
             <RenderInPortal>
               <Flyout
+                id="inline-conditions-add"
                 title={i18n('conditions.add')}
                 onHide={cancelInlineCondition}
               >
@@ -94,7 +95,7 @@ export function ConditionsEdit({ path }: Readonly<Props>) {
                 <li key={condition.name}>
                   <a
                     className="govuk-link"
-                    href="#"
+                    href="#inline-conditions-edit"
                     onClick={(e) => onClickCondition(e, condition)}
                   >
                     {condition.displayName}
@@ -124,7 +125,11 @@ export function ConditionsEdit({ path }: Readonly<Props>) {
       )}
       {editingCondition && (
         <RenderInPortal>
-          <Flyout title={i18n('conditions.addOrEdit')} onHide={editFinished}>
+          <Flyout
+            id="inline-conditions-edit"
+            title={i18n('conditions.addOrEdit')}
+            onHide={editFinished}
+          >
             <InlineConditions
               path={path}
               condition={editingCondition}

--- a/designer/client/src/conditions/InlineConditions.tsx
+++ b/designer/client/src/conditions/InlineConditions.tsx
@@ -264,7 +264,7 @@ export class InlineConditions extends Component<Props, State> {
                 <>
                   <br />
                   <a
-                    href="#"
+                    href="#inline-conditions-edit"
                     className="govuk-link"
                     onClick={(e) => {
                       e.preventDefault()

--- a/designer/client/src/conditions/InlineConditionsEdit.tsx
+++ b/designer/client/src/conditions/InlineConditionsEdit.tsx
@@ -66,7 +66,7 @@ export class InlineConditionsEdit extends Component<Props, State> {
     })
   }
 
-  onClickGroup = (e: MouseEvent<HTMLAnchorElement>) => {
+  onClickGroup = (e: MouseEvent<HTMLButtonElement>) => {
     const { conditions, selectedConditions } = this.state
 
     e.preventDefault()
@@ -273,40 +273,40 @@ export class InlineConditionsEdit extends Component<Props, State> {
                       >
                         <div className="govuk-button-group">
                           {condition.isGroup() && (
-                            <a
-                              href="#"
+                            <button
                               className="govuk-link govuk-!-margin-bottom-2"
+                              type="button"
                               onClick={(e) => {
                                 e.preventDefault()
                                 this.onClickSplit(index)
                               }}
                             >
                               Split
-                            </a>
+                            </button>
                           )}
                           {!condition.isGroup() && (
-                            <a
-                              href="#"
+                            <button
                               className="govuk-link govuk-!-margin-bottom-2"
+                              type="button"
                               onClick={(e) => {
                                 e.preventDefault()
                                 this.onClickEdit(index)
                               }}
                             >
                               Edit
-                            </a>
+                            </button>
                           )}
                           {!selectedConditions?.length || (
-                            <a
-                              href="#"
+                            <button
                               className="govuk-link govuk-!-margin-bottom-2"
+                              type="button"
                               onClick={(e) => {
                                 e.preventDefault()
                                 this.onClickRemove(index)
                               }}
                             >
                               Remove
-                            </a>
+                            </button>
                           )}
                         </div>
                       </div>
@@ -315,13 +315,13 @@ export class InlineConditionsEdit extends Component<Props, State> {
                 })}
                 {!!selectedConditions && selectedConditions.length > 1 && (
                   <div className="govuk-button-group">
-                    <a
-                      href="#"
+                    <button
                       className="govuk-link"
+                      type="button"
                       onClick={this.onClickGroup}
                     >
                       Group selected conditions
-                    </a>
+                    </button>
                   </div>
                 )}
               </div>

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -265,7 +265,7 @@ export class SelectConditions extends Component<Props, State> {
             {!inline && (
               <p className="govuk-body">
                 <a
-                  href="#"
+                  href="#inline-conditions-add"
                   className="govuk-link"
                   onClick={this.onClickDefineCondition}
                 >
@@ -276,6 +276,7 @@ export class SelectConditions extends Component<Props, State> {
             {inline && (
               <RenderInPortal>
                 <Flyout
+                  id="inline-conditions-add"
                   title={i18n('conditions.addTitle')}
                   onHide={this.onCancelInlineCondition}
                 >

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -198,7 +198,7 @@ export function ListEdit() {
 
         <p className="govuk-body">
           <a
-            href="#"
+            href="#list-item-edit"
             id="list-items"
             className="govuk-link"
             onClick={handleAddItem}

--- a/designer/client/src/list/ListItems.tsx
+++ b/designer/client/src/list/ListItems.tsx
@@ -30,7 +30,7 @@ const ListItem = ({ item, removeListItem, editListItem }: Readonly<Props>) => {
       </td>
       <td className="govuk-table__cell">
         <a
-          href="#"
+          href="#list-item-edit"
           className="govuk-link"
           onClick={(e) => {
             e.preventDefault()
@@ -41,16 +41,16 @@ const ListItem = ({ item, removeListItem, editListItem }: Readonly<Props>) => {
         </a>
       </td>
       <td className="govuk-table__cell">
-        <a
-          href="#"
+        <button
           className="govuk-link"
+          type="button"
           onClick={(e) => {
             e.preventDefault()
             removeListItem(item)
           }}
         >
           Delete
-        </a>
+        </button>
       </td>
     </tr>
   )

--- a/designer/client/src/list/ListSelect.tsx
+++ b/designer/client/src/list/ListSelect.tsx
@@ -37,7 +37,7 @@ export function ListSelect() {
         {data.lists.map((list) => (
           <li key={list.name}>
             <a
-              href="#"
+              href="#list-edit"
               className="govuk-link"
               onClick={(e) => editList(e, list)}
             >

--- a/designer/client/src/list/ListsEdit.tsx
+++ b/designer/client/src/list/ListsEdit.tsx
@@ -68,6 +68,7 @@ export function ListsEdit({ showEditLists = false }: Readonly<Props>) {
       {isEditingList && (
         <RenderInPortal>
           <Flyout
+            id="list-edit"
             title={listTitle}
             onHide={closeFlyout(ListsEditorStateActions.IS_EDITING_LIST)}
           >
@@ -79,6 +80,7 @@ export function ListsEdit({ showEditLists = false }: Readonly<Props>) {
       {isEditingListItem && (
         <RenderInPortal>
           <Flyout
+            id="list-item-edit"
             title={itemTitle}
             onHide={closeFlyout(ListsEditorStateActions.IS_EDITING_LIST_ITEM)}
           >

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -53,7 +53,7 @@ export class SectionsEdit extends Component<Props, State> {
             <li key={section.name}>
               <a
                 className="govuk-link"
-                href="#"
+                href="#section-edit"
                 onClick={(e) => this.onClickSection(e, section)}
               >
                 {section.title}
@@ -75,6 +75,7 @@ export class SectionsEdit extends Component<Props, State> {
         {isEditingSection && (
           <RenderInPortal>
             <Flyout
+              id="section-edit"
               title={
                 section?.title
                   ? i18n('section.editTitle', { title: section.title })

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -5,6 +5,7 @@ import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
 import { DataContext } from '~/src/context/DataContext.js'
 import { findSection } from '~/src/data/section/findSection.js'
+import { i18n } from '~/src/i18n/i18n.jsx'
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 
 type Props = Record<string, never>
@@ -67,7 +68,7 @@ export class SectionsEdit extends Component<Props, State> {
             type="button"
             onClick={(e) => this.onClickSection(e)}
           >
-            Add section
+            {i18n('section.add')}
           </button>
         </div>
 
@@ -75,7 +76,9 @@ export class SectionsEdit extends Component<Props, State> {
           <RenderInPortal>
             <Flyout
               title={
-                section?.name ? `Editing ${section.name}` : 'Add a new section'
+                section?.title
+                  ? i18n('section.editTitle', { title: section.title })
+                  : i18n('section.add')
               }
               onHide={this.closeFlyout}
             >

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -139,6 +139,7 @@ p code {
 }
 
 .govuk-button--component {
+  min-height: govuk-em(44px, $context-font-size: 16);
   background-color: transparent;
   box-shadow: none;
   border: none;
@@ -313,7 +314,15 @@ p code {
 }
 
 .app-component__action {
+  $app-action-small: govuk-em(39px, $context-font-size: 16);
+  $app-action-large: govuk-em(44px, $context-font-size: 19);
+
+  height: $app-action-small;
   margin-bottom: 0;
+
+  @include govuk-media-query($from: tablet) {
+    height: $app-action-large;
+  }
 }
 
 /* Syntax highlighting */

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -14,6 +14,7 @@ $app-code-font: ui-monospace, menlo, "Cascadia Mono", "Segoe UI Mono", consolas,
 $app-code-color: #d13118;
 $app-light-grey: #f8f8f8;
 $app-box-border: solid 2px #000;
+$app-component-focus-color: govuk-colour("yellow");
 
 %app-button-link {
   @include govuk-link-common;
@@ -21,6 +22,11 @@ $app-box-border: solid 2px #000;
   @include govuk-link-print-friendly;
 
   & {
+    display: inline;
+    align-items: normal;
+    text-align: left;
+    font-size: inherit;
+    appearance: none;
     color: $govuk-link-colour;
     background-color: transparent;
     border: none;
@@ -44,7 +50,6 @@ $app-box-border: solid 2px #000;
 
 button.govuk-link {
   @extend %app-button-link;
-  @include govuk-font-size($size: 16);
 
   & {
     padding: 0;
@@ -108,14 +113,15 @@ p code {
   }
 }
 
-.component.govuk-link {
-  display: block;
-  width: 100%;
-  @include govuk-responsive-padding(2);
+.govuk-button--editor,
+.govuk-button--component {
+  @include govuk-font-size($size: 16);
 
-  color: govuk-colour("black");
-  text-decoration: none;
-  text-align: left;
+  & {
+    display: block;
+    width: 100%;
+    text-align: left;
+  }
 
   &:hover,
   &:focus {
@@ -124,7 +130,37 @@ p code {
     box-shadow: none;
     cursor: pointer;
   }
+}
 
+.govuk-button--editor {
+  background-color: govuk-colour("black");
+  box-shadow: 0 1px 0 govuk-colour("white");
+  color: govuk-colour("white");
+}
+
+.govuk-button--component {
+  background-color: transparent;
+  box-shadow: none;
+  border: none;
+  color: govuk-colour("black");
+  font-weight: bold;
+}
+
+.app-component {
+  position: relative;
+
+  &:hover {
+    background-color: $app-component-focus-color;
+    box-shadow: 0 $govuk-border-width-form-element 0 $app-component-focus-color;
+  }
+}
+
+.app-component__button,
+.app-component__actions {
+  margin: 0;
+}
+
+.app-component__button {
   > div {
     pointer-events: none;
   }
@@ -262,29 +298,22 @@ p code {
   }
 }
 
-.component-item {
-  position: relative;
+.app-component__actions {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: -1;
 
-  &:hover,
-  &:focus-within {
-    background-color: govuk-colour("yellow");
-
-    .component-move {
-      visibility: visible;
+  @at-root {
+    .app-component:hover &,
+    .app-component:focus-within & {
+      z-index: 1;
     }
-  }
-
-  .govuk-button-group {
-    position: absolute;
-    top: 0;
-    right: 0;
   }
 }
 
-.component-move {
-  visibility: hidden;
+.app-component__action {
   margin-bottom: 0;
-  @include govuk-responsive-padding(2);
 }
 
 /* Syntax highlighting */

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-jsdoc": "^50.2.3",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.6.0",
         "eslint-plugin-react": "^7.36.1",
@@ -5970,6 +5971,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6034,6 +6042,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+      "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/babel-jest": {
@@ -7511,6 +7539,13 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
@@ -8740,6 +8775,68 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
+      "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "~5.1.3",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "es-iterator-helpers": "^1.0.19",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-n": {
@@ -13366,6 +13463,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -17485,6 +17602,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.0.tgz",
+      "integrity": "sha512-E34CkBgyeqNDcrbU76cDjL5JLcVrtSdYq0MEh/B10r17pRP4ciHLwTgnuLV8Ay6cgEMLkcBkFCKyFZ43YldYzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "node_modules/string.prototype.matchall": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-jest": "^28.8.3",
     "eslint-plugin-jsdoc": "^50.2.3",
+    "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-react": "^7.36.1",


### PR DESCRIPTION
This PR resolves a Sonar warning that editor uses links `<a href="#">` as buttons

I've installed the ESLint JSX accessibility plugin fixed all that were flagged
