### PR TITLE
Add environment identification tag in the header (409424)

### DIFF
--- a/designer/client/src/stylesheets/application.scss
+++ b/designer/client/src/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @use "components/breadcrumbs";
 @use "components/form-card";
 @use "components/service-header";
+@use "components/tag-env";
 @use "components/button";
 @use "components/header";
 

--- a/designer/client/src/stylesheets/components/_tag-env.scss
+++ b/designer/client/src/stylesheets/components/_tag-env.scss
@@ -1,0 +1,1 @@
+@forward "@defra/forms-designer/server/src/common/components/tag-env/tag-env";

--- a/designer/server/src/common/components/service-header/_service-header.scss
+++ b/designer/server/src/common/components/service-header/_service-header.scss
@@ -74,7 +74,7 @@ $defra-link-colour-hover: govuk-shade($defra-link-colour, 50%);
   min-width: max-content;
   border: 0;
   margin: 0;
-  padding: govuk-spacing(2) 0 govuk-spacing(1) govuk-spacing(4);
+  padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(4);
   background: none;
 
   &::before {
@@ -86,14 +86,14 @@ $defra-link-colour-hover: govuk-shade($defra-link-colour, 50%);
     display: inline-block;
     width: 0.6rem;
     height: 0.6rem;
-    transform: translateY(-65%) rotate(135deg);
+    transform: translateY(-75%) rotate(135deg);
     border-top: 0.15rem solid;
     border-right: 0.15rem solid;
   }
 
   &.cross-service-header__button--open {
     &::before {
-      transform: translateY(-15%) rotate(-45deg);
+      transform: translateY(-25%) rotate(-45deg);
     }
   }
 
@@ -161,18 +161,25 @@ $defra-link-colour-hover: govuk-shade($defra-link-colour, 50%);
   display: flex;
   position: relative;
   justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
   flex-wrap: wrap;
+
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row;
+    align-items: center;
+  }
 }
 
 .one-login-header__logo {
-  min-width: max-content;
   padding-top: govuk-spacing(2);
-  padding-bottom: govuk-spacing(2);
-  max-width: 33.33%;
+  padding-bottom: govuk-spacing(1);
+
   @include govuk-media-query($from: desktop) {
+    min-width: max-content;
+    max-width: 33.33%;
     width: 33.33%;
     padding-right: govuk-spacing(3);
+    padding-bottom: govuk-spacing(2);
   }
 }
 
@@ -309,16 +316,23 @@ $defra-link-colour-hover: govuk-shade($defra-link-colour, 50%);
   display: inline-block;
   padding: govuk-spacing(2) 0;
 
+  @include govuk-media-query($until: tablet) {
+    &:first-of-type {
+      padding-top: govuk-spacing(1);
+    }
+  }
+
   @include govuk-media-query($from: tablet) {
-    padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(6);
+    padding: govuk-spacing(2) 0;
     align-self: stretch;
 
-    &:not(:only-child) {
+    & + & {
+      padding-left: govuk-spacing(5);
       border-left: 1px solid $govuk-border-colour;
     }
 
     &:not(:last-child) {
-      margin-right: govuk-spacing(4);
+      margin-right: govuk-spacing(5);
     }
   }
 

--- a/designer/server/src/common/components/service-header/template.njk
+++ b/designer/server/src/common/components/service-header/template.njk
@@ -1,5 +1,3 @@
-{% from "govuk/components/tag/macro.njk" import govukTag %}
-
 {#
 Component options:
   - organisationName (string): The name of the organisation
@@ -74,8 +72,6 @@ Component options:
             {% endif %}
           </span>
         </a>
-        {# Environment identification tag #}
-        {{ govukTag(params.envTag) }}
       </div>
       <button type="button"
         aria-controls="one-login-header__nav"

--- a/designer/server/src/common/components/service-header/template.njk
+++ b/designer/server/src/common/components/service-header/template.njk
@@ -1,3 +1,5 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
 {#
 Component options:
   - organisationName (string): The name of the organisation
@@ -72,6 +74,8 @@ Component options:
             {% endif %}
           </span>
         </a>
+        {# Environment identification tag #}
+        {{ govukTag(params.envTag) }}
       </div>
       <button type="button"
         aria-controls="one-login-header__nav"

--- a/designer/server/src/common/components/tag-env/_tag-env.scss
+++ b/designer/server/src/common/components/tag-env/_tag-env.scss
@@ -1,0 +1,24 @@
+@use "govuk-frontend" as *;
+
+.app-tag--env {
+  margin: -6px 0 0;
+  vertical-align: top;
+
+  // Override product name font size
+  @include govuk-font-size($size: 16);
+
+  // Align with product name
+  @include govuk-media-query($from: tablet) {
+    margin: -3px 0 0;
+  }
+
+  // Override service header alignment
+  .cross-service-header & {
+    margin: -2px 0 0 govuk-spacing(1);
+
+    // Align with product name
+    @include govuk-media-query($from: tablet) {
+      margin: 0 0 0 govuk-spacing(2);
+    }
+  }
+}

--- a/designer/server/src/common/components/tag-env/macro.njk
+++ b/designer/server/src/common/components/tag-env/macro.njk
@@ -1,0 +1,3 @@
+{% macro appTagEnv(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/designer/server/src/common/components/tag-env/template.njk
+++ b/designer/server/src/common/components/tag-env/template.njk
@@ -1,0 +1,30 @@
+{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+
+{%- switch params.env %}
+  {% case "local" %}
+    {% set text = "Local" %}
+    {% set classes = "govuk-tag--green" %}
+  {% case "dev" %}
+    {% set text = "Development" %}
+    {% set classes = "govuk-tag--grey" %}
+  {% case "test" %}
+    {% set text = "Test" %}
+    {% set classes = "govuk-tag--yellow" %}
+  {% case "ext-test" %}
+    {% set text = "External test" %}
+    {% set classes = "govuk-tag--yellow" %}
+  {% case "perf-test" %}
+    {% set text = "Performance test" %}
+    {% set classes = "govuk-tag--yellow" %}
+  {% case "prod" %}
+    {% set text = "Production" %}
+    {% set classes = "govuk-tag--red" %}
+  {% default %}
+    {% set text = env | replace("-", " ") | capitalize %}
+    {% set classes = "govuk-tag--grey" %}
+{% endswitch -%}
+
+{{ govukTag({
+  text: text,
+  classes: classes + " app-tag--env"
+}) }}

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -8,7 +8,7 @@ import { buildNavigation } from '~/src/common/nunjucks/context/build-navigation.
 import config from '~/src/config.js'
 
 const logger = createLogger()
-const { cdpEnvironment, phase, serviceName } = config
+const { cdpEnvironment, phase, serviceName, serviceVersion } = config
 
 /** @type {Record<string, string> | undefined} */
 let webpackManifest
@@ -35,7 +35,8 @@ export async function context(request) {
     config: {
       cdpEnvironment,
       phase,
-      serviceName
+      serviceName,
+      serviceVersion
     },
     navigation: buildNavigation(request),
     getAssetPath: (asset = '') => `/${webpackManifest?.[asset] ?? asset}`,

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -1,8 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
 
-import upperFirst from 'lodash/upperFirst.js'
-
 import { SCOPE_READ } from '~/src/common/constants/scopes.js'
 import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
 import { createLogger } from '~/src/common/helpers/logging/logger.js'
@@ -10,7 +8,7 @@ import { buildNavigation } from '~/src/common/nunjucks/context/build-navigation.
 import config from '~/src/config.js'
 
 const logger = createLogger()
-const { phase, serviceName, env, isTest, isProduction } = config
+const { cdpEnvironment, phase, serviceName } = config
 
 /** @type {Record<string, string> | undefined} */
 let webpackManifest
@@ -32,25 +30,10 @@ export async function context(request) {
 
   const credentials = request ? await getUserSession(request) : undefined
 
-  let tagColour
-
-  if (isTest) {
-    tagColour = 'yellow'
-  } else if (isProduction) {
-    tagColour = 'red'
-  } else {
-    tagColour = 'grey'
-  }
-
-  const envTag = {
-    text: upperFirst(env),
-    classes: `govuk-tag--${tagColour}`
-  }
-
   return {
-    envTag,
     breadcrumbs: [],
     config: {
+      cdpEnvironment,
       phase,
       serviceName
     },

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
 
+import upperFirst from 'lodash/upperFirst.js'
+
 import { SCOPE_READ } from '~/src/common/constants/scopes.js'
 import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
 import { createLogger } from '~/src/common/helpers/logging/logger.js'
@@ -8,7 +10,7 @@ import { buildNavigation } from '~/src/common/nunjucks/context/build-navigation.
 import config from '~/src/config.js'
 
 const logger = createLogger()
-const { phase, serviceName } = config
+const { phase, serviceName, env, isTest, isProduction } = config
 
 /** @type {Record<string, string> | undefined} */
 let webpackManifest
@@ -30,7 +32,21 @@ export async function context(request) {
 
   const credentials = request ? await getUserSession(request) : undefined
 
+  let tagColour = 'grey'
+
+  if (isTest) {
+    tagColour = 'yellow'
+  } else if (isProduction) {
+    tagColour = 'red'
+  }
+
+  const envTag = {
+    text: upperFirst(env),
+    classes: `govuk-tag--${tagColour}`
+  }
+
   return {
+    envTag,
     breadcrumbs: [],
     config: {
       phase,

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -32,12 +32,14 @@ export async function context(request) {
 
   const credentials = request ? await getUserSession(request) : undefined
 
-  let tagColour = 'grey'
+  let tagColour
 
   if (isTest) {
     tagColour = 'yellow'
   } else if (isProduction) {
     tagColour = 'red'
+  } else {
+    tagColour = 'grey'
   }
 
   const envTag = {

--- a/designer/server/src/common/nunjucks/context/index.test.js
+++ b/designer/server/src/common/nunjucks/context/index.test.js
@@ -79,6 +79,7 @@ describe('Nunjucks context', () => {
       const ctx = await context(null)
 
       expect(ctx.config).toEqual({
+        cdpEnvironment: config.cdpEnvironment,
         phase: config.phase,
         serviceName: config.serviceName
       })

--- a/designer/server/src/common/nunjucks/context/index.test.js
+++ b/designer/server/src/common/nunjucks/context/index.test.js
@@ -81,7 +81,8 @@ describe('Nunjucks context', () => {
       expect(ctx.config).toEqual({
         cdpEnvironment: config.cdpEnvironment,
         phase: config.phase,
-        serviceName: config.serviceName
+        serviceName: config.serviceName,
+        serviceVersion: config.serviceVersion
       })
     })
   })

--- a/designer/server/src/common/templates/layouts/page.njk
+++ b/designer/server/src/common/templates/layouts/page.njk
@@ -5,6 +5,17 @@
 {% from "heading/macro.njk" import appHeading %}
 
 {% block head %}
+  <meta name="application-name" content="@defra/forms-designer" {{- govukAttributes({
+    "data-environment": {
+      value: config.cdpEnvironment,
+      optional: true
+    },
+    "data-version": {
+      value: config.serviceVersion,
+      optional: true
+    }
+  }) }}>
+
   <link href="{{ getAssetPath("stylesheets/application.scss") }}" rel="stylesheet">
 {% endblock %}
 

--- a/designer/server/src/common/templates/partials/navigation.njk
+++ b/designer/server/src/common/templates/partials/navigation.njk
@@ -1,10 +1,14 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "service-header/macro.njk" import appServiceHeader %}
+{% from "tag-env/macro.njk" import appTagEnv %}
+
+{%- set productName %}
+  Forms Designer {{ appTagEnv({ env: config.cdpEnvironment }) }}
+{% endset -%}
 
 {{ appServiceHeader({
   organisationName: "Defra",
-  productName: "Forms Designer",
-  envTag: envTag,
+  productName: productName | safe | trim,
   navigationItems: navigation if isAuthenticated and isAuthorized and isFormsUser,
   accountName: authedUser.displayName if isAuthenticated,
   accountLink: "/library",

--- a/designer/server/src/common/templates/partials/navigation.njk
+++ b/designer/server/src/common/templates/partials/navigation.njk
@@ -4,6 +4,7 @@
 {{ appServiceHeader({
   organisationName: "Defra",
   productName: "Forms Designer",
+  envTag: envTag,
   navigationItems: navigation if isAuthenticated and isAuthorized and isFormsUser,
   accountName: authedUser.displayName if isAuthenticated,
   accountLink: "/library",

--- a/designer/server/src/config.ts
+++ b/designer/server/src/config.ts
@@ -6,8 +6,17 @@ import joi from 'joi'
 const configPath = fileURLToPath(import.meta.url)
 
 export interface Config {
-  env: 'development' | 'test' | 'production'
   port: number
+  cdpEnvironment:
+    | 'local'
+    | 'infra-dev'
+    | 'management'
+    | 'dev'
+    | 'test'
+    | 'perf-test'
+    | 'ext-test'
+    | 'prod'
+  env: 'development' | 'test' | 'production'
   appDir: string
   clientDir: string
   previewUrl: string
@@ -37,6 +46,19 @@ export interface Config {
 // Define config schema
 const schema = joi.object<Config>({
   port: joi.number().default(3000),
+  cdpEnvironment: joi
+    .string()
+    .valid(
+      'local',
+      'infra-dev',
+      'management',
+      'dev',
+      'test',
+      'perf-test',
+      'ext-test',
+      'prod'
+    )
+    .default('local'),
   env: joi
     .string()
     .valid('development', 'test', 'production')
@@ -90,6 +112,7 @@ const schema = joi.object<Config>({
 const result = schema.validate(
   {
     port: process.env.PORT,
+    cdpEnvironment: process.env.ENVIRONMENT,
     env: process.env.NODE_ENV,
     managerUrl: process.env.MANAGER_URL,
     submissionUrl: process.env.SUBMISSION_URL,

--- a/designer/server/src/config.ts
+++ b/designer/server/src/config.ts
@@ -23,6 +23,7 @@ export interface Config {
   managerUrl: string
   submissionUrl: string
   serviceName: string
+  serviceVersion?: string
   logLevel: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent'
   phase?: 'alpha' | 'beta' | 'live'
   isProduction: boolean
@@ -77,6 +78,7 @@ const schema = joi.object<Config>({
   submissionUrl: joi.string().required(),
   previewUrl: joi.string().required(),
   serviceName: joi.string().required(),
+  serviceVersion: joi.string().optional(),
   logLevel: joi
     .string()
     .default('info')
@@ -118,6 +120,7 @@ const result = schema.validate(
     submissionUrl: process.env.SUBMISSION_URL,
     previewUrl: process.env.PREVIEW_URL,
     serviceName: 'Submit a form to Defra',
+    serviceVersion: process.env.SERVICE_VERSION,
     logLevel: process.env.LOG_LEVEL,
     phase: process.env.PHASE,
     isProduction: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
Adds an environment tag to the header

<br>

<img width="1022" alt="Header tag development" src="https://github.com/user-attachments/assets/7f1264bc-b39f-4f6a-84bf-8c1c3e7e115e">

<br>
<br>

<img width="1022" alt="Header tag performance test" src="https://github.com/user-attachments/assets/78797267-586e-4698-ab57-ae39be4121b4">

<br>
<br>

<img width="1022" alt="Header tag production" src="https://github.com/user-attachments/assets/29557d39-a921-41a5-a2ec-0b612186b671">
