### PR TITLE
Remove unnecessary `act()` and `waitFor()` calls in tests 

### DIFF
--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -9,7 +9,7 @@ import {
   type ComponentDef,
   type FormDefinition
 } from '@defra/forms-model'
-import { screen, waitFor } from '@testing-library/dom'
+import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
@@ -431,13 +431,11 @@ describe('ComponentTypeEdit', () => {
         await userEvent.click($checkbox1)
         expect($checkbox1.checked).toBe(true)
 
-        const $checkbox2 = await waitFor(() =>
-          screen.getByRole<HTMLInputElement>('checkbox', {
-            name: 'Hide ‘(optional)’ text',
-            description:
-              'Tick this box if you do not want the title to indicate that this field is optional'
-          })
-        )
+        const $checkbox2 = screen.getByRole<HTMLInputElement>('checkbox', {
+          name: 'Hide ‘(optional)’ text',
+          description:
+            'Tick this box if you do not want the title to indicate that this field is optional'
+        })
 
         expect($checkbox2).toBeInTheDocument()
         expect($checkbox2.checked).toBe(false)

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -10,7 +10,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen, waitFor } from '@testing-library/dom'
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
 import React from 'react'
@@ -428,7 +428,7 @@ describe('ComponentTypeEdit', () => {
         expect($checkbox1.checked).toBe(false)
 
         // Mark field as optional
-        await act(() => userEvent.click($checkbox1))
+        await userEvent.click($checkbox1)
         expect($checkbox1.checked).toBe(true)
 
         const $checkbox2 = await waitFor(() =>

--- a/designer/client/src/LinkEdit.test.tsx
+++ b/designer/client/src/LinkEdit.test.tsx
@@ -7,7 +7,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen, within } from '@testing-library/dom'
-import { act, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -73,7 +73,7 @@ describe('LinkEdit', () => {
     )
 
     const $source = screen.getByRole('combobox', { name: 'Link from' })
-    await act(() => userEvent.selectOptions($source, data.pages[1].path))
+    await userEvent.selectOptions($source, data.pages[1].path)
 
     expect(screen.getByText(hintText)).toBeInTheDocument()
   })
@@ -108,7 +108,7 @@ describe('LinkEdit', () => {
     expect($conditions).not.toBeInTheDocument()
 
     const $source = screen.getByRole('combobox', { name: 'Link from' })
-    await act(() => userEvent.selectOptions($source, '/first-page'))
+    await userEvent.selectOptions($source, '/first-page')
 
     $conditions = screen.getByRole('link', {
       name: 'Add a new condition'
@@ -180,15 +180,15 @@ describe('LinkEdit', () => {
     const $target = screen.getByRole('combobox', { name: 'Link to' })
     const $button = screen.getByRole('button', { name: 'Save' })
 
-    await act(() => userEvent.selectOptions($source, '/first-page'))
-    await act(() => userEvent.selectOptions($target, '/summary'))
+    await userEvent.selectOptions($source, '/first-page')
+    await userEvent.selectOptions($target, '/summary')
 
     const $condition = screen.getByRole('combobox', {
       name: 'Select a condition'
     })
 
-    await act(() => userEvent.selectOptions($condition, 'hasUKPassport'))
-    await act(() => userEvent.click($button))
+    await userEvent.selectOptions($condition, 'hasUKPassport')
+    await userEvent.click($button)
 
     await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
 
@@ -217,11 +217,11 @@ describe('LinkEdit', () => {
       ])
     )
 
-    await act(() => userEvent.selectOptions($source, '/first-page'))
-    await act(() => userEvent.selectOptions($target, '/second-page'))
+    await userEvent.selectOptions($source, '/first-page')
+    await userEvent.selectOptions($target, '/second-page')
 
-    await act(() => userEvent.selectOptions($condition, ''))
-    await act(() => userEvent.click($button))
+    await userEvent.selectOptions($condition, '')
+    await userEvent.click($button)
 
     await waitFor(() => expect(save).toHaveBeenCalledTimes(2))
 
@@ -260,7 +260,7 @@ describe('LinkEdit', () => {
       </RenderWithContext>
     )
 
-    await act(() => userEvent.click(screen.getByRole('button')))
+    await userEvent.click(screen.getByRole('button'))
 
     await waitFor(() => expect(save).not.toHaveBeenCalled())
 

--- a/designer/client/src/LinkEdit.test.tsx
+++ b/designer/client/src/LinkEdit.test.tsx
@@ -7,7 +7,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen, within } from '@testing-library/dom'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -190,7 +190,7 @@ describe('LinkEdit', () => {
     await userEvent.selectOptions($condition, 'hasUKPassport')
     await userEvent.click($button)
 
-    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save).toHaveBeenCalledTimes(1)
 
     expect(save.mock.calls[0]).toEqual(
       expect.arrayContaining<FormDefinition>([
@@ -223,7 +223,7 @@ describe('LinkEdit', () => {
     await userEvent.selectOptions($condition, '')
     await userEvent.click($button)
 
-    await waitFor(() => expect(save).toHaveBeenCalledTimes(2))
+    expect(save).toHaveBeenCalledTimes(2)
 
     expect(save.mock.calls[1]).toEqual(
       expect.arrayContaining<FormDefinition>([
@@ -262,7 +262,7 @@ describe('LinkEdit', () => {
 
     await userEvent.click(screen.getByRole('button'))
 
-    await waitFor(() => expect(save).not.toHaveBeenCalled())
+    expect(save).not.toHaveBeenCalled()
 
     const summary = within(screen.getByRole('alert'))
     expect(summary.getByText('Enter link from')).toBeInTheDocument()

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -43,7 +43,7 @@ describe('ComponentCreate:', () => {
       screen.queryByRole('textbox', { name: 'Content' })
     ).not.toBeInTheDocument()
 
-    await act(() => userEvent.click($componentLink))
+    await userEvent.click($componentLink)
     await waitFor(() => screen.getAllByRole('textbox'))
 
     const $input = screen.getByRole('textbox', { name: 'Title' })
@@ -66,7 +66,7 @@ describe('ComponentCreate:', () => {
       name: 'Details'
     })
 
-    await act(() => userEvent.click($componentLink))
+    await userEvent.click($componentLink)
     await waitFor(() => screen.getAllByRole('textbox'))
 
     const $input = screen.getByRole('textbox', { name: 'Title' })
@@ -74,15 +74,15 @@ describe('ComponentCreate:', () => {
     const $button = screen.getByRole('button', { name: 'Save' })
 
     // Ensure fields are empty
-    await act(() => userEvent.clear($input))
-    await act(() => userEvent.clear($textarea))
+    await userEvent.clear($input)
+    await userEvent.clear($textarea)
 
     // Populate fields
-    await act(() => userEvent.type($input, 'Details'))
-    await act(() => userEvent.type($textarea, 'content'))
+    await userEvent.type($input, 'Details')
+    await userEvent.type($textarea, 'content')
 
     // Submit the form
-    await act(() => userEvent.click($button))
+    await userEvent.click($button)
 
     await waitFor(() => expect(save).toHaveBeenCalled())
 
@@ -122,7 +122,7 @@ describe('ComponentCreate:', () => {
     expect($componentLink).toBeInTheDocument()
 
     // Clicking component link opens a flyout
-    await act(() => userEvent.click($componentLink))
+    await userEvent.click($componentLink)
 
     const $buttonClose = screen.getAllByRole('button', {
       name: 'Close'
@@ -131,7 +131,7 @@ describe('ComponentCreate:', () => {
     expect($buttonClose).toBeInTheDocument()
 
     // Clicking close shows the list again
-    await act(() => userEvent.click($buttonClose))
+    await userEvent.click($buttonClose)
   })
 
   test('Should display error summary when validation fails', async () => {
@@ -145,7 +145,7 @@ describe('ComponentCreate:', () => {
       name: 'Details'
     })
 
-    await act(() => userEvent.click($componentLink))
+    await userEvent.click($componentLink)
     await waitFor(() => screen.getAllByRole('textbox'))
 
     const $input = screen.getByRole('textbox', { name: 'Title' })
@@ -153,11 +153,11 @@ describe('ComponentCreate:', () => {
     const $button = screen.getByRole('button', { name: 'Save' })
 
     // Ensure fields are empty
-    await act(() => userEvent.clear($input))
-    await act(() => userEvent.clear($textarea))
+    await userEvent.clear($input)
+    await userEvent.clear($textarea)
 
     // Submit the form
-    await act(() => userEvent.click($button))
+    await userEvent.click($button)
 
     const $errorSummary = screen.getByRole('alert', {
       name: 'There is a problem'

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -44,7 +44,6 @@ describe('ComponentCreate:', () => {
     ).not.toBeInTheDocument()
 
     await userEvent.click($componentLink)
-    await waitFor(() => screen.getAllByRole('textbox'))
 
     const $input = screen.getByRole('textbox', { name: 'Title' })
     const $textarea = screen.getByRole('textbox', { name: 'Content' })
@@ -67,7 +66,6 @@ describe('ComponentCreate:', () => {
     })
 
     await userEvent.click($componentLink)
-    await waitFor(() => screen.getAllByRole('textbox'))
 
     const $input = screen.getByRole('textbox', { name: 'Title' })
     const $textarea = screen.getByRole('textbox', { name: 'Content' })
@@ -84,7 +82,7 @@ describe('ComponentCreate:', () => {
     // Submit the form
     await userEvent.click($button)
 
-    await waitFor(() => expect(save).toHaveBeenCalled())
+    expect(save).toHaveBeenCalled()
 
     expect(save.mock.calls[0]).toEqual(
       expect.arrayContaining<FormDefinition>([
@@ -146,7 +144,6 @@ describe('ComponentCreate:', () => {
     })
 
     await userEvent.click($componentLink)
-    await waitFor(() => screen.getAllByRole('textbox'))
 
     const $input = screen.getByRole('textbox', { name: 'Title' })
     const $textarea = screen.getByRole('textbox', { name: 'Content' })

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.test.tsx
@@ -5,7 +5,7 @@ import {
   getPageDefaults
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -155,7 +155,7 @@ describe.each([
             name: i18n(`fieldTypeToName.${type}`)
           })
 
-          await act(() => userEvent.click($link))
+          await userEvent.click($link)
           expect(onSelectComponent).toHaveBeenCalledWith(
             expect.objectContaining({
               type

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
@@ -4,7 +4,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -82,7 +82,7 @@ describe('ComponentListSelect', () => {
       name: 'Select list'
     })
 
-    await act(() => userEvent.selectOptions($select, 'myList'))
+    await userEvent.selectOptions($select, 'myList')
 
     expect(screen.getByText('Edit list')).toBeInTheDocument()
   })
@@ -126,7 +126,7 @@ describe('ComponentListSelect', () => {
     )
 
     const $select = screen.getByRole('combobox', { name: 'Select list' })
-    await act(() => userEvent.selectOptions($select, 'Select a list'))
+    await userEvent.selectOptions($select, 'Select a list')
 
     expect(
       container.getElementsByClassName('govuk-form-group--error')

--- a/designer/client/src/components/FieldEditors/ListFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ListFieldEdit.test.tsx
@@ -6,7 +6,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render, type RenderResult } from '@testing-library/react'
+import { render, type RenderResult } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -132,7 +132,7 @@ describe('List field edit', () => {
         name: 'Select list'
       })
 
-      await act(() => userEvent.selectOptions($select, 'myList'))
+      await userEvent.selectOptions($select, 'myList')
 
       expect($select).toHaveValue('myList')
       expect($select.options[$select.selectedIndex].textContent).toBe('My list')

--- a/designer/client/src/components/Flyout/Flyout.test.tsx
+++ b/designer/client/src/components/Flyout/Flyout.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/dom'
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -71,7 +71,7 @@ describe('Flyout', () => {
       name: 'Close'
     })
 
-    await act(() => userEvent.click($close))
+    await userEvent.click($close)
 
     expect(HTMLDialogElement.prototype.close).toHaveBeenCalled()
   })

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -1,6 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -43,7 +43,7 @@ describe('Menu', () => {
       name: 'Summary'
     })
 
-    await act(() => userEvent.click($buttonSummary))
+    await userEvent.click($buttonSummary)
 
     const $dialog = screen.getByRole('dialog', {
       name: 'Edit summary'
@@ -55,7 +55,7 @@ describe('Menu', () => {
       name: 'Close'
     })
 
-    await act(() => userEvent.click($close))
+    await userEvent.click($close)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
@@ -70,7 +70,7 @@ describe('Menu', () => {
       name: 'Form overview'
     })
 
-    await act(() => userEvent.click($buttonFormOverview))
+    await userEvent.click($buttonFormOverview)
 
     const $dialog = screen.getByRole('dialog', {
       name: 'Form overview'
@@ -94,7 +94,7 @@ describe('Menu', () => {
     expect($panels[3]).toHaveClass('govuk-tabs__panel--hidden')
 
     // Click JSON tab link
-    await act(() => userEvent.click($tabs[1]))
+    await userEvent.click($tabs[1])
 
     // Only second tab panel (JSON) is visible
     expect($panels[0]).toHaveClass('govuk-tabs__panel--hidden')
@@ -116,7 +116,7 @@ describe('Menu', () => {
       name: 'Summary'
     })
 
-    await act(() => userEvent.click($buttonSummary))
+    await userEvent.click($buttonSummary)
 
     const $dialog = screen.getByRole('dialog', {
       name: 'Edit summary'
@@ -128,7 +128,7 @@ describe('Menu', () => {
       name: 'Save'
     })
 
-    await act(() => userEvent.click($buttonSave))
+    await userEvent.click($buttonSave)
     await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -1,6 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -129,7 +129,7 @@ describe('Menu', () => {
     })
 
     await userEvent.click($buttonSave)
-    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save).toHaveBeenCalledTimes(1)
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
 import React from 'react'
@@ -82,11 +82,12 @@ describe('Page', () => {
 
     // Open edit page
     await userEvent.click($buttonEdit)
-    await waitFor(() =>
-      screen.findByRole('dialog', {
+
+    expect(
+      screen.getByRole('dialog', {
         name: 'Edit page'
       })
-    )
+    ).toBeInTheDocument()
 
     const $buttonSave = screen.getByRole('button', {
       name: 'Save'
@@ -101,11 +102,12 @@ describe('Page', () => {
 
     // Open edit page
     await userEvent.click($buttonEdit)
-    await waitFor(() =>
-      screen.findByRole('dialog', {
+
+    expect(
+      screen.getByRole('dialog', {
         name: 'Edit page'
       })
-    )
+    ).toBeInTheDocument()
 
     const $close = screen.getByRole('button', {
       name: 'Close'

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
 import React from 'react'
@@ -81,7 +81,7 @@ describe('Page', () => {
     })
 
     // Open edit page
-    await act(() => userEvent.click($buttonEdit))
+    await userEvent.click($buttonEdit)
     await waitFor(() =>
       screen.findByRole('dialog', {
         name: 'Edit page'
@@ -93,14 +93,14 @@ describe('Page', () => {
     })
 
     // Save edit page
-    await act(() => userEvent.click($buttonSave))
+    await userEvent.click($buttonSave)
 
     expect(
       screen.queryByRole('button', { name: 'Save' })
     ).not.toBeInTheDocument()
 
     // Open edit page
-    await act(() => userEvent.click($buttonEdit))
+    await userEvent.click($buttonEdit)
     await waitFor(() =>
       screen.findByRole('dialog', {
         name: 'Edit page'
@@ -112,7 +112,7 @@ describe('Page', () => {
     })
 
     // Close edit page
-    await act(() => userEvent.click($close))
+    await userEvent.click($close)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
@@ -127,13 +127,13 @@ describe('Page', () => {
       name: 'Add component'
     })
 
-    await act(() => userEvent.click($buttonAdd))
+    await userEvent.click($buttonAdd)
 
     const $close = screen.getByRole('button', {
       name: 'Close'
     })
 
-    await act(() => userEvent.click($close))
+    await userEvent.click($close)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -1,6 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -89,8 +89,8 @@ describe('Visualisation', () => {
     )
 
     // Check link exists and has the expected label
-    const $lineTitle = await waitFor(() =>
-      screen.findByText('Edit link from link-source to link-target')
+    const $lineTitle = screen.getByText(
+      'Edit link from link-source to link-target'
     )
 
     // Check that link works when selected with the enter key

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -1,6 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -96,10 +96,8 @@ describe('Visualisation', () => {
     // Check that link works when selected with the enter key
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
-    await act(async () => {
-      $lineTitle.parentElement?.focus()
-      await userEvent.keyboard('[Enter]')
-    })
+    $lineTitle.parentElement?.focus()
+    await userEvent.keyboard('[Enter]')
 
     expect(
       screen.getByRole('dialog', {
@@ -107,15 +105,13 @@ describe('Visualisation', () => {
       })
     ).toBeInTheDocument()
 
-    await act(() => userEvent.click(screen.getByText('Close')))
+    await userEvent.click(screen.getByText('Close'))
 
     // Check that link works when selected with the space key
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
-    await act(async () => {
-      $lineTitle.parentElement?.focus()
-      await userEvent.keyboard('[Space]')
-    })
+    $lineTitle.parentElement?.focus()
+    await userEvent.keyboard('[Space]')
 
     expect(
       screen.queryByRole('dialog', {

--- a/designer/client/src/conditions/AbsoluteDateValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/dom'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -35,13 +35,11 @@ describe('AbsoluteDateValues', () => {
     await userEvent.type($month, '4')
     await userEvent.type($day, '26')
 
-    await waitFor(() =>
-      expect(updateValue).toHaveBeenCalledWith({
-        year: 2020,
-        month: 4,
-        day: 26
-      })
-    )
+    expect(updateValue).toHaveBeenCalledWith({
+      year: 2020,
+      month: 4,
+      day: 26
+    })
   })
 
   it('calls the updateValue prop if an existing date is edited', async () => {
@@ -64,13 +62,11 @@ describe('AbsoluteDateValues', () => {
     await userEvent.type($month, '4')
     await userEvent.type($day, '26')
 
-    await waitFor(() =>
-      expect(updateValue).toHaveBeenCalledWith({
-        year: 2020,
-        month: 4,
-        day: 26
-      })
-    )
+    expect(updateValue).toHaveBeenCalledWith({
+      year: 2020,
+      month: 4,
+      day: 26
+    })
   })
 
   it("doesn't call the updateValue prop if an valid day is not entered", async () => {

--- a/designer/client/src/conditions/AbsoluteDateValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.test.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/dom'
-import { act, render, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -31,9 +31,9 @@ describe('AbsoluteDateValues', () => {
     const $month = screen.getByRole('spinbutton', { name: 'Month' })
     const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
-    await act(() => userEvent.type($year, '2020'))
-    await act(() => userEvent.type($month, '4'))
-    await act(() => userEvent.type($day, '26'))
+    await userEvent.type($year, '2020')
+    await userEvent.type($month, '4')
+    await userEvent.type($day, '26')
 
     await waitFor(() =>
       expect(updateValue).toHaveBeenCalledWith({
@@ -60,9 +60,9 @@ describe('AbsoluteDateValues', () => {
     // Clear existing values
     await Promise.all([$year, $month, $day].map(userEvent.clear))
 
-    await act(() => userEvent.type($year, '2020'))
-    await act(() => userEvent.type($month, '4'))
-    await act(() => userEvent.type($day, '26'))
+    await userEvent.type($year, '2020')
+    await userEvent.type($month, '4')
+    await userEvent.type($day, '26')
 
     await waitFor(() =>
       expect(updateValue).toHaveBeenCalledWith({
@@ -81,9 +81,9 @@ describe('AbsoluteDateValues', () => {
     const $month = screen.getByRole('spinbutton', { name: 'Month' })
     const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
-    await act(() => userEvent.type($year, '2020'))
-    await act(() => userEvent.type($month, '4'))
-    await act(() => userEvent.type($day, '0'))
+    await userEvent.type($year, '2020')
+    await userEvent.type($month, '4')
+    await userEvent.type($day, '0')
 
     expect(updateValue).not.toHaveBeenCalled()
   })
@@ -95,8 +95,8 @@ describe('AbsoluteDateValues', () => {
     const $year = screen.getByRole('spinbutton', { name: 'Year' })
     const $month = screen.getByRole('spinbutton', { name: 'Month' })
 
-    await act(() => userEvent.type($year, '2020'))
-    await act(() => userEvent.type($month, '4'))
+    await userEvent.type($year, '2020')
+    await userEvent.type($month, '4')
 
     expect(updateValue).not.toHaveBeenCalled()
   })
@@ -108,8 +108,8 @@ describe('AbsoluteDateValues', () => {
     const $day = screen.getByRole('spinbutton', { name: 'Day' })
     const $year = screen.getByRole('spinbutton', { name: 'Year' })
 
-    await act(() => userEvent.type($year, '2020'))
-    await act(() => userEvent.type($day, '7'))
+    await userEvent.type($year, '2020')
+    await userEvent.type($day, '7')
 
     expect(updateValue).not.toHaveBeenCalled()
   })
@@ -121,8 +121,8 @@ describe('AbsoluteDateValues', () => {
     const $month = screen.getByRole('spinbutton', { name: 'Month' })
     const $day = screen.getByRole('spinbutton', { name: 'Day' })
 
-    await act(() => userEvent.type($month, '4'))
-    await act(() => userEvent.type($day, '23'))
+    await userEvent.type($month, '4')
+    await userEvent.type($day, '23')
 
     expect(updateValue).not.toHaveBeenCalled()
   })

--- a/designer/client/src/conditions/ConditionsEdit.test.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.test.tsx
@@ -6,7 +6,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -179,7 +179,7 @@ describe('ConditionsEdit', () => {
         name: condition.displayName
       })
 
-      await act(() => userEvent.click($link))
+      await userEvent.click($link)
 
       const $dialog = screen.getByRole('dialog', {
         name: 'Add or edit condition'

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -9,7 +9,7 @@ import {
   type Item
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import upperFirst from 'lodash/upperFirst.js'
 import React from 'react'
@@ -62,8 +62,8 @@ describe('InlineConditionsDefinitionValue', () => {
 
     const $input = screen.getByRole('textbox', { name: 'Value' })
 
-    await act(() => userEvent.clear($input))
-    await act(() => userEvent.type($input, 'new-value'))
+    await userEvent.clear($input)
+    await userEvent.type($input, 'new-value')
 
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: 'new-value',
@@ -94,7 +94,7 @@ describe('InlineConditionsDefinitionValue', () => {
       name: 'Value'
     })
 
-    await act(() => userEvent.clear($input))
+    await userEvent.clear($input)
 
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: '',
@@ -160,7 +160,7 @@ describe('InlineConditionsDefinitionValue', () => {
     )
 
     const $select = screen.getByRole('combobox', { name: 'Value' })
-    await act(() => userEvent.selectOptions($select, 'value1'))
+    await userEvent.selectOptions($select, 'value1')
 
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: 'Value 1',
@@ -194,7 +194,7 @@ describe('InlineConditionsDefinitionValue', () => {
     )
 
     const $select = screen.getByRole('combobox', { name: 'Value' })
-    await act(() => userEvent.selectOptions($select, 'true'))
+    await userEvent.selectOptions($select, 'true')
 
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: 'Value 1',
@@ -228,7 +228,7 @@ describe('InlineConditionsDefinitionValue', () => {
     )
 
     const $select = screen.getByRole('combobox', { name: 'Value' })
-    await act(() => userEvent.selectOptions($select, '42'))
+    await userEvent.selectOptions($select, '42')
 
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: 'Value 1',
@@ -262,7 +262,7 @@ describe('InlineConditionsDefinitionValue', () => {
     )
 
     const $select = screen.getByRole('combobox', { name: 'Value' })
-    await act(() => userEvent.selectOptions($select, ''))
+    await userEvent.selectOptions($select, '')
 
     expect(updateValueCallback).toHaveBeenLastCalledWith({
       display: '',

--- a/designer/client/src/list/ListItemEdit.test.tsx
+++ b/designer/client/src/list/ListItemEdit.test.tsx
@@ -7,7 +7,7 @@ import {
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
-import { act, render } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 
@@ -142,7 +142,7 @@ describe('ListItemEdit', () => {
       'Select a condition'
     )
 
-    await act(() => userEvent.selectOptions($select, 'MYWwRN'))
+    await userEvent.selectOptions($select, 'MYWwRN')
 
     expect($select).toHaveValue('MYWwRN')
     expect($select.options[$select.selectedIndex].textContent).toBe(


### PR DESCRIPTION
Quick tech debt PR to remove unnecessary `act()` and `waitFor()` calls in tests