### PR TITLE
Add list type radio selection to the form

### DIFF
--- a/designer/client/src/hooks/list/useListItem/useListItem.tsx
+++ b/designer/client/src/hooks/list/useListItem/useListItem.tsx
@@ -1,4 +1,4 @@
-import { type Root } from 'joi'
+import Joi, { type Root } from 'joi'
 
 import { findListItem } from '~/src/data/list/findList.js'
 import { type ListItemHook } from '~/src/hooks/list/useListItem/types.js'

--- a/designer/client/src/hooks/list/useListItem/useListItem.tsx
+++ b/designer/client/src/hooks/list/useListItem/useListItem.tsx
@@ -1,4 +1,4 @@
-import Joi, { type Root } from 'joi'
+import { type Root } from 'joi'
 
 import { findListItem } from '~/src/data/list/findList.js'
 import { type ListItemHook } from '~/src/hooks/list/useListItem/types.js'
@@ -93,7 +93,7 @@ export function useListItem(
       errors.value ??= validateCustom('value', value, {
         message: 'errors.number',
         label: `Item value '${value}'`,
-        schema: Joi.number().required()
+        schema: schema.number().required()
       })
     }
 

--- a/designer/client/src/hooks/list/useListItem/useListItem.tsx
+++ b/designer/client/src/hooks/list/useListItem/useListItem.tsx
@@ -89,6 +89,14 @@ export function useListItem(
       schema
     })
 
+    if (selectedList?.type === 'number') {
+      errors.value ??= validateCustom('value', value, {
+        message: 'errors.number',
+        label: `Item value '${value}'`,
+        schema: Joi.number().required()
+      })
+    }
+
     errors.value ??= validateCustom('value', [...values, value], {
       message: 'errors.duplicate',
       label: `Item value '${value}'`,

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -153,7 +153,8 @@
     "required": "Enter {{field, lowerFirst}}",
     "unique": "{{field, upperFirst}} must not match",
     "spaces": "{{field, upperFirst}} must not include spaces",
-    "duplicate": "{{field, upperFirst}} already exists"
+    "duplicate": "{{field, upperFirst}} already exists",
+    "number": "{{field, upperFirst}} must be a number"
   },
   "fieldEdit": {
     "conditions": {

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -280,9 +280,11 @@
     "title": "List title",
     "titleHint": "Enter a unique name for your list",
     "type": "List type",
-    "typeHint": "Value type for your list",
-    "typeHintString": "String hint text",
-    "typeHintNumber": "Number hint text"
+    "typeHint": "Select how list values should be stored",
+    "typeString": "Text",
+    "typeNumber": "Numeric",
+    "typeHintString": "Value will be stored as text",
+    "typeHintNumber": "Value will be stored as a number"
   },
   "listContentEditComponent": {
     "bulletField": {

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -277,7 +277,11 @@
       "option": "Select a list"
     },
     "title": "List title",
-    "titleHint": "Enter a unique name for your list"
+    "titleHint": "Enter a unique name for your list",
+    "type": "List type",
+    "typeHint": "Value type for your list",
+    "typeHintString": "String hint text",
+    "typeHintNumber": "Number hint text"
   },
   "listContentEditComponent": {
     "bulletField": {

--- a/designer/client/src/list/ListEdit.test.tsx
+++ b/designer/client/src/list/ListEdit.test.tsx
@@ -40,7 +40,7 @@ describe('ListEdit', () => {
 
     const $listCaption = screen.getByText('List items')
     const $listHint = screen.getByText('Enter a unique name for your list')
-    const $listType = screen.getByText('Value type for your list')
+    const $listType = screen.getByText('List type')
     const $listLink = screen.getByText('Add a new list item')
 
     expect($listCaption).toBeInTheDocument()

--- a/designer/client/src/list/ListEdit.test.tsx
+++ b/designer/client/src/list/ListEdit.test.tsx
@@ -40,10 +40,12 @@ describe('ListEdit', () => {
 
     const $listCaption = screen.getByText('List items')
     const $listHint = screen.getByText('Enter a unique name for your list')
+    const $listType = screen.getByText('Value type for your list')
     const $listLink = screen.getByText('Add a new list item')
 
     expect($listCaption).toBeInTheDocument()
     expect($listHint).toBeInTheDocument()
+    expect($listType).toBeInTheDocument()
     expect($listLink).toBeInTheDocument()
   })
 })

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -246,6 +246,9 @@ export function ListEdit() {
               <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
                 {i18n('list.type')}
               </legend>
+              <div id="list-type-hint" className="govuk-hint">
+                {i18n('list.typeHint')}
+              </div>
               <div
                 id="list-type"
                 className="govuk-radios govuk-radios--small"

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -196,63 +196,61 @@ export function ListEdit() {
       )}
 
       <form onSubmit={handleSubmit} autoComplete="off" noValidate>
-        <>
-          <Input
-            id="list-title"
-            name="title"
-            hint={{ children: i18n('list.titleHint') }}
-            label={{
-              className: 'govuk-label--s',
-              children: [i18n('list.title')]
-            }}
-            value={selectedList.title}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              listDispatch({
-                name: ListActions.EDIT_TITLE,
-                payload: e.target.value
-              })
+        <Input
+          id="list-title"
+          name="title"
+          hint={{ children: i18n('list.titleHint') }}
+          label={{
+            className: 'govuk-label--s',
+            children: [i18n('list.title')]
+          }}
+          value={selectedList.title}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            listDispatch({
+              name: ListActions.EDIT_TITLE,
+              payload: e.target.value
+            })
+          }
+          errorMessage={errors.title}
+        />
+        <Radios
+          id="list-type"
+          name="type"
+          hint={{ children: i18n('list.typeHint') }}
+          fieldset={{
+            legend: {
+              className: 'govuk-fieldset__legend--s',
+              children: [i18n('list.type')]
             }
-            errorMessage={errors.title}
-          />
-          <Radios
-            id="list-type"
-            name="type"
-            hint={{ children: i18n('list.typeHint') }}
-            fieldset={{
-              legend: {
-                className: 'govuk-fieldset__legend--s',
-                children: [i18n('list.type')]
-              }
-            }}
-            value={selectedList.type}
-            defaultValue="string"
-            items={[
-              {
-                children: ['String'],
-                value: 'string',
-                hint: {
-                  children: [i18n('list.typeHintString')]
-                },
-                disabled: !selectedList.isNew
+          }}
+          value={selectedList.type}
+          defaultValue="string"
+          items={[
+            {
+              children: ['String'],
+              value: 'string',
+              hint: {
+                children: [i18n('list.typeHintString')]
               },
-              {
-                children: ['Number'],
-                value: 'number',
-                hint: {
-                  children: [i18n('list.typeHintNumber')]
-                },
-                disabled: !selectedList.isNew
-              }
-            ]}
-            onChange={(e: ChangeEvent<HTMLInputElement>) =>
-              listDispatch({
-                name: ListActions.EDIT_TYPE,
-                payload: e.target.value
-              })
+              disabled: !selectedList.isNew
+            },
+            {
+              children: ['Number'],
+              value: 'number',
+              hint: {
+                children: [i18n('list.typeHintNumber')]
+              },
+              disabled: !selectedList.isNew
             }
-            errorMessage={errors.type}
-          />
-        </>
+          ]}
+          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+            listDispatch({
+              name: ListActions.EDIT_TYPE,
+              payload: e.target.value
+            })
+          }
+          errorMessage={errors.type}
+        />
 
         <div className="panel__results">
           <ListItems />

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -196,23 +196,63 @@ export function ListEdit() {
       )}
 
       <form onSubmit={handleSubmit} autoComplete="off" noValidate>
-        <Input
-          id="list-title"
-          name="title"
-          hint={{ children: i18n('list.titleHint') }}
-          label={{
-            className: 'govuk-label--s',
-            children: [i18n('list.title')]
-          }}
-          value={selectedList.title}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            listDispatch({
-              name: ListActions.EDIT_TITLE,
-              payload: e.target.value
-            })
-          }
-          errorMessage={errors.title}
-        />
+        <>
+          <Input
+            id="list-title"
+            name="title"
+            hint={{ children: i18n('list.titleHint') }}
+            label={{
+              className: 'govuk-label--s',
+              children: [i18n('list.title')]
+            }}
+            value={selectedList.title}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              listDispatch({
+                name: ListActions.EDIT_TITLE,
+                payload: e.target.value
+              })
+            }
+            errorMessage={errors.title}
+          />
+          <Radios
+            id="list-type"
+            name="type"
+            hint={{ children: i18n('list.typeHint') }}
+            fieldset={{
+              legend: {
+                className: 'govuk-fieldset__legend--s',
+                children: [i18n('list.type')]
+              }
+            }}
+            value={selectedList.type}
+            defaultValue="string"
+            items={[
+              {
+                children: ['String'],
+                value: 'string',
+                hint: {
+                  children: [i18n('list.typeHintString')]
+                },
+                disabled: !selectedList.isNew
+              },
+              {
+                children: ['Number'],
+                value: 'number',
+                hint: {
+                  children: [i18n('list.typeHintNumber')]
+                },
+                disabled: !selectedList.isNew
+              }
+            ]}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              listDispatch({
+                name: ListActions.EDIT_TYPE,
+                payload: e.target.value
+              })
+            }
+            errorMessage={errors.type}
+          />
+        </>
 
         <div className="panel__results">
           <ListItems />

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -1,4 +1,4 @@
-import { hasListField } from '@defra/forms-model'
+import { hasListField, type ListTypeContent } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import { type Root } from 'joi'
@@ -224,7 +224,6 @@ export function ListEdit() {
             }
           }}
           value={selectedList.type}
-          defaultValue="string"
           items={[
             {
               children: ['String'],
@@ -232,7 +231,7 @@ export function ListEdit() {
               hint: {
                 children: [i18n('list.typeHintString')]
               },
-              disabled: !selectedList.isNew
+              disabled: !!selectedList.items.length
             },
             {
               children: ['Number'],
@@ -240,13 +239,13 @@ export function ListEdit() {
               hint: {
                 children: [i18n('list.typeHintNumber')]
               },
-              disabled: !selectedList.isNew
+              disabled: !!selectedList.items.length
             }
           ]}
           onChange={(e: ChangeEvent<HTMLInputElement>) =>
             listDispatch({
               name: ListActions.EDIT_TYPE,
-              payload: e.target.value
+              payload: e.target.value as ListTypeContent
             })
           }
           errorMessage={errors.type}

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -189,6 +189,19 @@ export function ListEdit() {
     return null
   }
 
+  const listTypeRadioItems = [
+    {
+      value: 'string',
+      labelText: i18n('list.typeString'),
+      hintText: i18n('list.typeHintString')
+    },
+    {
+      value: 'number',
+      labelText: i18n('list.typeNumber'),
+      hintText: i18n('list.typeHintNumber')
+    }
+  ]
+
   return (
     <>
       {hasErrors && (
@@ -213,43 +226,70 @@ export function ListEdit() {
           }
           errorMessage={errors.title}
         />
-        <Radios
-          id="list-type"
-          name="type"
-          hint={{ children: i18n('list.typeHint') }}
-          fieldset={{
-            legend: {
-              className: 'govuk-fieldset__legend--s',
-              children: [i18n('list.type')]
-            }
-          }}
-          value={selectedList.type}
-          items={[
-            {
-              children: ['String'],
-              value: 'string',
-              hint: {
-                children: [i18n('list.typeHintString')]
-              },
-              disabled: !!selectedList.items.length
-            },
-            {
-              children: ['Number'],
-              value: 'number',
-              hint: {
-                children: [i18n('list.typeHintNumber')]
-              },
-              disabled: !!selectedList.items.length
-            }
-          ]}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            listDispatch({
-              name: ListActions.EDIT_TYPE,
-              payload: e.target.value as ListTypeContent
-            })
-          }
-          errorMessage={errors.type}
-        />
+
+        {selectedList.items.length ? (
+          <div className="govuk-form-group">
+            <span className="govuk-label govuk-label--s">
+              {i18n('list.type')}
+            </span>
+            <p className="govuk-body">
+              {`${
+                listTypeRadioItems.find(
+                  (item) => item.value === selectedList.type
+                )?.labelText
+              } values only`}
+            </p>
+          </div>
+        ) : (
+          <div className="govuk-form-group">
+            <fieldset className="govuk-fieldset">
+              <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
+                {i18n('list.type')}
+              </legend>
+              <div
+                id="list-type"
+                className="govuk-radios govuk-radios--small"
+                data-module="govuk-radios"
+              >
+                {listTypeRadioItems.map((item) => {
+                  const name = 'type'
+                  const id = `${name}-${item.value}`
+
+                  return (
+                    <div className="govuk-radios__item" key={item.value}>
+                      <input
+                        className="govuk-radios__input"
+                        id={id}
+                        name={name}
+                        type="radio"
+                        value={item.value}
+                        checked={selectedList.type === item.value}
+                        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                          listDispatch({
+                            name: ListActions.EDIT_TYPE,
+                            payload: e.target.value as ListTypeContent
+                          })
+                        }}
+                      />
+                      <label
+                        className="govuk-label govuk-radios__label"
+                        htmlFor={id}
+                      >
+                        {item.labelText}
+                      </label>
+                      <div
+                        id={`${id}-hint`}
+                        className="govuk-hint govuk-radios__hint"
+                      >
+                        {item.hintText}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </fieldset>
+          </div>
+        )}
 
         <div className="panel__results">
           <ListItems />

--- a/designer/client/src/list/ListItemEdit.tsx
+++ b/designer/client/src/list/ListItemEdit.tsx
@@ -109,7 +109,10 @@ export function ListItemEdit() {
           errorMessage={errors.title}
         />
         <Textarea
-          label={{ children: i18n('list.item.help') }}
+          label={{
+            className: 'govuk-label--s',
+            children: i18n('list.item.help')
+          }}
           hint={{ children: i18n('list.item.helpHint') }}
           value={description ?? ''}
           name="list-item-hint"
@@ -117,7 +120,10 @@ export function ListItemEdit() {
           onChange={handleHintChange}
         />
         <Input
-          label={{ children: [i18n('list.item.value')] }}
+          label={{
+            className: 'govuk-label--s',
+            children: [i18n('list.item.value')]
+          }}
           hint={{ children: [i18n('list.item.valueHint')] }}
           id="value"
           name="list-item-value"
@@ -126,7 +132,7 @@ export function ListItemEdit() {
           onChange={handleValueChange}
         />
         <div className="govuk-form-group">
-          <label className="govuk-label" htmlFor="condition">
+          <label className="govuk-label govuk-label--s" htmlFor="condition">
             {i18n('list.item.conditions')}
           </label>
           <div className="govuk-hint" id="condition-hint">

--- a/designer/client/src/reducers/listActions.tsx
+++ b/designer/client/src/reducers/listActions.tsx
@@ -1,5 +1,6 @@
 export enum ListActions {
   EDIT_TITLE = 'EDIT_TITLE',
+  EDIT_TYPE = 'EDIT_TYPE',
 
   SET_SELECTED_LIST = 'SET_SELECTED_LIST',
   ADD_NEW_LIST = 'ADD_NEW_LIST',

--- a/designer/client/src/reducers/listReducer.tsx
+++ b/designer/client/src/reducers/listReducer.tsx
@@ -1,10 +1,10 @@
 import {
-  type ListTypeContent,
   type FormDefinition,
   type Item,
-  type List
+  type List,
+  type ListTypeContent
 } from '@defra/forms-model'
-import React, {
+import {
   createContext,
   useContext,
   useMemo,

--- a/designer/client/src/reducers/listReducer.tsx
+++ b/designer/client/src/reducers/listReducer.tsx
@@ -1,4 +1,9 @@
-import { type ListTypeContent, type FormDefinition, type Item, type List } from '@defra/forms-model'
+import {
+  type ListTypeContent,
+  type FormDefinition,
+  type Item,
+  type List
+} from '@defra/forms-model'
 import React, {
   createContext,
   useContext,

--- a/designer/client/src/reducers/listReducer.tsx
+++ b/designer/client/src/reducers/listReducer.tsx
@@ -1,5 +1,5 @@
-import { type FormDefinition, type Item, type List } from '@defra/forms-model'
-import {
+import { type ListTypeContent, type FormDefinition, type Item, type List } from '@defra/forms-model'
+import React, {
   createContext,
   useContext,
   useMemo,
@@ -20,8 +20,8 @@ export interface ListState extends Partial<FormList>, Partial<FormItem> {
   initialItemText?: string
   initialItemValue?: Item['value']
   selectedItemIndex?: number
-  errors: Partial<ErrorList<'title' | 'listItems'>>
-  listItemErrors: Partial<ErrorList<'title' | 'value'>>
+  errors: Partial<ErrorList<'title' | 'type' | 'listItems'>>
+  listItemErrors: Partial<ErrorList<'title' | 'type' | 'value'>>
 }
 
 export interface FormList {
@@ -44,6 +44,7 @@ export type ListReducerActions =
   | {
       name:
         | ListActions.EDIT_TITLE
+        | ListActions.EDIT_TYPE
         | ListActions.EDIT_LIST_ITEM_TEXT
         | ListActions.EDIT_LIST_ITEM_VALUE
       payload: string
@@ -130,6 +131,10 @@ export function listReducer(state: ListState, action: ListReducerActions) {
   switch (name) {
     case ListActions.EDIT_TITLE:
       selectedList.title = payload
+      break
+
+    case ListActions.EDIT_TYPE:
+      selectedList.type = payload as ListTypeContent
       break
 
     case ListActions.ADD_LIST_ITEM: {

--- a/designer/client/src/reducers/listReducer.tsx
+++ b/designer/client/src/reducers/listReducer.tsx
@@ -49,10 +49,13 @@ export type ListReducerActions =
   | {
       name:
         | ListActions.EDIT_TITLE
-        | ListActions.EDIT_TYPE
         | ListActions.EDIT_LIST_ITEM_TEXT
         | ListActions.EDIT_LIST_ITEM_VALUE
       payload: string
+    }
+  | {
+      name: ListActions.EDIT_TYPE
+      payload: ListTypeContent
     }
   | {
       name:
@@ -139,7 +142,7 @@ export function listReducer(state: ListState, action: ListReducerActions) {
       break
 
     case ListActions.EDIT_TYPE:
-      selectedList.type = payload as ListTypeContent
+      selectedList.type = payload
       break
 
     case ListActions.ADD_LIST_ITEM: {


### PR DESCRIPTION
![Screenshot from 2024-11-07 16-00-38](https://github.com/user-attachments/assets/c0216356-3139-46c2-8858-48686414d6d9)

Closing this for now while there isn't a need for it.
The code in defra/forms-model and forms-runner to support numeric lists will remain but we'll pick up the designer part if a need for numeric lists ever arises, at which point we expect it'll be part of the new (non-reactjs) editor   