### PR TITLE
Remove unused React imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -226,8 +226,8 @@ module.exports = {
       },
       extends: [
         'plugin:jsx-a11y/recommended',
-        'plugin:react/jsx-runtime',
         'plugin:react/recommended',
+        'plugin:react/jsx-runtime',
         'plugin:react-hooks/recommended'
       ],
       files: ['**/*.{jsx,tsx}'],

--- a/designer/client/src/Component.tsx
+++ b/designer/client/src/Component.tsx
@@ -6,12 +6,7 @@ import {
   type ComponentDef,
   type Page
 } from '@defra/forms-model'
-import React, {
-  useCallback,
-  useContext,
-  useState,
-  type ComponentProps
-} from 'react'
+import { useCallback, useContext, useState, type ComponentProps } from 'react'
 
 import { ComponentEdit } from '~/src/ComponentEdit.jsx'
 import { SortUpDown } from '~/src/SortUpDown.jsx'

--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -1,5 +1,5 @@
 import { hasComponents, type Page } from '@defra/forms-model'
-import React, {
+import {
   useCallback,
   useContext,
   useEffect,

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -13,7 +13,6 @@ import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
-import React from 'react'
 
 import { ComponentTypeEdit } from '~/src/ComponentTypeEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/ComponentTypeEdit.tsx
+++ b/designer/client/src/ComponentTypeEdit.tsx
@@ -1,9 +1,5 @@
 import { ComponentType, hasListField } from '@defra/forms-model'
-import React, {
-  useContext,
-  type JSXElementConstructor,
-  type ReactNode
-} from 'react'
+import { useContext, type JSXElementConstructor, type ReactNode } from 'react'
 
 import { FieldEdit } from '~/src/FieldEdit.jsx'
 import { ConditionEdit } from '~/src/components/FieldEditors/ConditionEdit.jsx'

--- a/designer/client/src/DeclarationEdit.tsx
+++ b/designer/client/src/DeclarationEdit.tsx
@@ -1,4 +1,4 @@
-import React, { Component, type ContextType, type FormEvent } from 'react'
+import { Component, type ContextType, type FormEvent } from 'react'
 
 import { Editor } from '~/src/Editor.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'

--- a/designer/client/src/Designer.tsx
+++ b/designer/client/src/Designer.tsx
@@ -3,7 +3,7 @@ import {
   type FormDefinition,
   type FormMetadata
 } from '@defra/forms-model'
-import React, { useCallback, useState, useMemo } from 'react'
+import { useCallback, useState, useMemo } from 'react'
 
 import { Menu } from '~/src/components/Menu/Menu.jsx'
 import { Visualisation } from '~/src/components/Visualisation/Visualisation.jsx'

--- a/designer/client/src/Editor.tsx
+++ b/designer/client/src/Editor.tsx
@@ -1,5 +1,5 @@
 import { highlight, languages } from 'prismjs'
-import React, { Component, type ComponentProps } from 'react'
+import { Component, type ComponentProps } from 'react'
 import SimpleEditor from 'react-simple-code-editor'
 
 type Props = {

--- a/designer/client/src/ErrorSummary.tsx
+++ b/designer/client/src/ErrorSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, type ReactNode } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 
 export interface ErrorListItem {
   href: string

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -5,7 +5,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { FieldEdit } from '~/src/FieldEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -8,7 +8,7 @@ import {
 // @ts-expect-error -- No types available
 import { Input, Textarea } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
-import React, { useContext, type ChangeEvent, type ReactNode } from 'react'
+import { useContext, type ChangeEvent, type ReactNode } from 'react'
 
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/LinkEdit.test.tsx
+++ b/designer/client/src/LinkEdit.test.tsx
@@ -9,7 +9,6 @@ import {
 import { screen, within } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { LinkEdit } from '~/src/LinkEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -6,7 +6,7 @@ import {
 } from '@defra/forms-model'
 import classNames from 'classnames'
 import Joi from 'joi'
-import React, {
+import {
   Component,
   type ChangeEvent,
   type ContextType,

--- a/designer/client/src/PageCreate.test.tsx
+++ b/designer/client/src/PageCreate.test.tsx
@@ -1,7 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { PageCreate } from '~/src/PageCreate.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -13,7 +13,7 @@ import {
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
 import Joi from 'joi'
-import React, {
+import {
   Component,
   type ChangeEvent,
   type ContextType,

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -16,7 +16,7 @@ import {
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
 import Joi from 'joi'
-import React, {
+import {
   Component,
   type ChangeEvent,
   type ContextType,

--- a/designer/client/src/SortUpDown.tsx
+++ b/designer/client/src/SortUpDown.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps } from 'react'
+import { type ComponentProps } from 'react'
 
 interface Props extends ComponentProps<'div'> {
   moveUp: Omit<SortButtonProps, 'direction'>

--- a/designer/client/src/components/Autocomplete/Autocomplete.test.tsx
+++ b/designer/client/src/components/Autocomplete/Autocomplete.test.tsx
@@ -1,7 +1,6 @@
 import { ComponentType } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { Autocomplete } from '~/src/components/Autocomplete/Autocomplete.jsx'
 import {

--- a/designer/client/src/components/Autocomplete/Autocomplete.tsx
+++ b/designer/client/src/components/Autocomplete/Autocomplete.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from '@defra/forms-model'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.test.tsx
@@ -2,7 +2,6 @@ import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { ComponentCreate } from '~/src/components/ComponentCreate/ComponentCreate.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -3,7 +3,7 @@ import {
   type ComponentTypes,
   type Page
 } from '@defra/forms-model'
-import React, {
+import {
   useCallback,
   useContext,
   useEffect,

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.test.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.test.tsx
@@ -7,7 +7,6 @@ import {
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { ComponentCreateList } from '~/src/components/ComponentCreate/ComponentCreateList.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreateList.tsx
@@ -9,7 +9,7 @@ import {
   type ComponentDef,
   type Page
 } from '@defra/forms-model'
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { isComponentAllowed } from '~/src/helpers.js'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.test.tsx
@@ -6,7 +6,6 @@ import {
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { ComponentListSelect } from '~/src/components/ComponentListSelect/ComponentListSelect.jsx'
 import { RenderListEditorWithContext } from '~/test/helpers/renderers-lists.jsx'

--- a/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
+++ b/designer/client/src/components/ComponentListSelect/ComponentListSelect.tsx
@@ -1,6 +1,6 @@
 import { hasListField } from '@defra/forms-model'
 import classNames from 'classnames'
-import React, {
+import {
   useContext,
   useEffect,
   useState,

--- a/designer/client/src/components/CssClasses/CssClasses.tsx
+++ b/designer/client/src/components/CssClasses/CssClasses.tsx
@@ -1,5 +1,5 @@
 import { ComponentType, hasContent, hasFormField } from '@defra/forms-model'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'

--- a/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.tsx
+++ b/designer/client/src/components/CustomValidationMessage/CustomValidationMessage.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from '@defra/forms-model'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'

--- a/designer/client/src/components/DataPrettyPrint/DataPrettyPrint.tsx
+++ b/designer/client/src/components/DataPrettyPrint/DataPrettyPrint.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps } from 'react'
+import { type ComponentProps } from 'react'
 
 interface Props extends Omit<ComponentProps<'pre'>, 'children'> {
   children: object

--- a/designer/client/src/components/ErrorMessage/ErrorMessage.test.tsx
+++ b/designer/client/src/components/ErrorMessage/ErrorMessage.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 

--- a/designer/client/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/designer/client/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { type ComponentProps } from 'react'
+import { type ComponentProps } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 

--- a/designer/client/src/components/FieldEditors/ConditionEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ConditionEdit.test.tsx
@@ -9,7 +9,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { ConditionEdit } from '~/src/components/FieldEditors/ConditionEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/ConditionEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ConditionEdit.tsx
@@ -1,5 +1,5 @@
 import { hasConditionSupport } from '@defra/forms-model'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { DataContext } from '~/src/context/DataContext.js'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/FieldEditors/ContentEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ContentEdit.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { ContentEdit } from '~/src/components/FieldEditors/ContentEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/ContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ContentEdit.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, hasContentField } from '@defra/forms-model'
 import classNames from 'classnames'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { Editor } from '~/src/Editor.jsx'
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'

--- a/designer/client/src/components/FieldEditors/DateFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/DateFieldEdit.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { DateFieldEdit } from '~/src/components/FieldEditors/DateFieldEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/DateFieldEdit.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from '@defra/forms-model'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/FieldEditors/FileUploadFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/FileUploadFieldEdit.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { FileUploadFieldEdit } from '~/src/components/FieldEditors/FileUploadFieldEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/FileUploadFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/FileUploadFieldEdit.tsx
@@ -1,7 +1,7 @@
 import { ComponentType } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Textarea } from '@xgovformbuilder/govuk-react-jsx'
-import React, { useContext, type ChangeEvent } from 'react'
+import { useContext, type ChangeEvent } from 'react'
 
 import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/FieldEditors/ListContentEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.test.tsx
@@ -7,7 +7,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { ListContentEdit } from '~/src/components/FieldEditors/ListContentEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/ListContentEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ListContentEdit.tsx
@@ -1,6 +1,6 @@
 import { ComponentType, type ListTypeOption } from '@defra/forms-model'
 import upperFirst from 'lodash/upperFirst.js'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/FieldEditors/ListFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/ListFieldEdit.test.tsx
@@ -8,7 +8,6 @@ import {
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { ListFieldEdit } from '~/src/components/FieldEditors/ListFieldEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/ListFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/ListFieldEdit.tsx
@@ -1,5 +1,5 @@
 import { hasListField } from '@defra/forms-model'
-import React, { useContext, type ReactNode } from 'react'
+import { useContext, type ReactNode } from 'react'
 
 import { ComponentListSelect } from '~/src/components/ComponentListSelect/ComponentListSelect.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'

--- a/designer/client/src/components/FieldEditors/MultilineTextFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/MultilineTextFieldEdit.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { MultilineTextFieldEdit } from '~/src/components/FieldEditors/MultilineTextFieldEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/MultilineTextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/MultilineTextFieldEdit.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from '@defra/forms-model'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { TextFieldEdit } from '~/src/components/FieldEditors/TextFieldEdit.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/FieldEditors/NumberFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/NumberFieldEdit.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { NumberFieldEdit } from '~/src/components/FieldEditors/NumberFieldEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/NumberFieldEdit.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from '@defra/forms-model'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/FieldEditors/SelectFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/SelectFieldEdit.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { SelectFieldEdit } from '~/src/components/FieldEditors/SelectFieldEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/SelectFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/SelectFieldEdit.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from '@defra/forms-model'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { Autocomplete } from '~/src/components/Autocomplete/Autocomplete.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.test.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render, type RenderResult } from '@testing-library/react'
-import React from 'react'
 
 import { TextFieldEdit } from '~/src/components/FieldEditors/TextFieldEdit.jsx'
 import { RenderComponent } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
+++ b/designer/client/src/components/FieldEditors/TextFieldEdit.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from '@defra/forms-model'
-import React, { useContext, type ReactNode } from 'react'
+import { useContext, type ReactNode } from 'react'
 
 import { Autocomplete } from '~/src/components/Autocomplete/Autocomplete.jsx'
 import { CssClasses } from '~/src/components/CssClasses/CssClasses.jsx'

--- a/designer/client/src/components/Flyout/Flyout.test.tsx
+++ b/designer/client/src/components/Flyout/Flyout.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/Flyout/Flyout.tsx
+++ b/designer/client/src/components/Flyout/Flyout.tsx
@@ -1,5 +1,5 @@
 import FocusTrap from 'focus-trap-react'
-import React, {
+import {
   useContext,
   useEffect,
   useRef,

--- a/designer/client/src/components/Menu/Menu.test.tsx
+++ b/designer/client/src/components/Menu/Menu.test.tsx
@@ -2,7 +2,6 @@ import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { Menu } from '~/src/components/Menu/Menu.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers'

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -1,6 +1,6 @@
 import { hasComponents, hasListField } from '@defra/forms-model'
 import { highlightAll } from 'prismjs'
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { DeclarationEdit } from '~/src/DeclarationEdit.jsx'
 import { LinkEdit } from '~/src/LinkEdit.jsx'

--- a/designer/client/src/components/Menu/SubMenu.tsx
+++ b/designer/client/src/components/Menu/SubMenu.tsx
@@ -1,10 +1,5 @@
 import { type FormDefinition } from '@defra/forms-model'
-import React, {
-  useContext,
-  useRef,
-  type ChangeEvent,
-  type MouseEvent
-} from 'react'
+import { useContext, useRef, type ChangeEvent, type MouseEvent } from 'react'
 
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import { type MenuItemHook } from '~/src/components/Menu/useMenuItem.jsx'

--- a/designer/client/src/components/Page/Page.test.tsx
+++ b/designer/client/src/components/Page/Page.test.tsx
@@ -3,7 +3,6 @@ import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
-import React from 'react'
 
 import { Page } from '~/src/components/Page/Page.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -5,7 +5,7 @@ import {
   type ComponentDef,
   type Page as PageType
 } from '@defra/forms-model'
-import React, { useContext, useState, type CSSProperties } from 'react'
+import { useContext, useState, type CSSProperties } from 'react'
 
 import { Component } from '~/src/Component.jsx'
 import { PageEdit } from '~/src/PageEdit.jsx'

--- a/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
+++ b/designer/client/src/components/RenderInPortal/RenderInPortal.test.tsx
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
 

--- a/designer/client/src/components/Tabs/Tabs.tsx
+++ b/designer/client/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import { Tabs as TabsJS } from 'govuk-frontend'
-import React, { useEffect, useRef, type ComponentProps } from 'react'
+import { useEffect, useRef, type ComponentProps } from 'react'
 
 interface Props extends ComponentProps<'div'> {
   idPrefix?: string

--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -1,4 +1,4 @@
-import React, { Component, type ContextType } from 'react'
+import { Component, type ContextType } from 'react'
 
 import { LinkEdit } from '~/src/LinkEdit.jsx'
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'

--- a/designer/client/src/components/Visualisation/Visualisation.test.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.test.tsx
@@ -2,7 +2,6 @@ import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { Visualisation } from '~/src/components/Visualisation/Visualisation.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/components/Visualisation/Visualisation.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-  type RefObject
-} from 'react'
+import { useContext, useEffect, useRef, useState, type RefObject } from 'react'
 
 import { Page } from '~/src/components/Page/Page.jsx'
 import { Lines } from '~/src/components/Visualisation/Lines.jsx'

--- a/designer/client/src/conditions/AbsoluteDateValues.test.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { AbsoluteDateValues } from '~/src/conditions/AbsoluteDateValues.jsx'
 

--- a/designer/client/src/conditions/AbsoluteDateValues.tsx
+++ b/designer/client/src/conditions/AbsoluteDateValues.tsx
@@ -1,5 +1,5 @@
 import { isValid } from 'date-fns'
-import React, { useEffect, useState, type ChangeEvent } from 'react'
+import { useEffect, useState, type ChangeEvent } from 'react'
 
 import { tryParseInt } from '~/src/conditions/inline-condition-helpers.js'
 

--- a/designer/client/src/conditions/ConditionsEdit.test.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.test.tsx
@@ -8,7 +8,6 @@ import {
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { ConditionsEdit } from '~/src/conditions/ConditionsEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/conditions/ConditionsEdit.tsx
+++ b/designer/client/src/conditions/ConditionsEdit.tsx
@@ -1,5 +1,5 @@
 import { ConditionsModel, type ConditionWrapper } from '@defra/forms-model'
-import React, { useContext, useState, type MouseEvent } from 'react'
+import { useContext, useState, type MouseEvent } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'

--- a/designer/client/src/conditions/InlineConditions.test.tsx
+++ b/designer/client/src/conditions/InlineConditions.test.tsx
@@ -1,7 +1,6 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { InlineConditions } from '~/src/conditions/InlineConditions.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/conditions/InlineConditions.tsx
+++ b/designer/client/src/conditions/InlineConditions.tsx
@@ -6,7 +6,7 @@ import {
   type ConditionWrapper
 } from '@defra/forms-model'
 import classNames from 'classnames'
-import React, {
+import {
   Component,
   type ChangeEvent,
   type ContextType,

--- a/designer/client/src/conditions/InlineConditionsDefinition.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinition.tsx
@@ -20,7 +20,7 @@ import {
   type RelativeDateValue
 } from '@defra/forms-model'
 import upperFirst from 'lodash/upperFirst.js'
-import React, { Component, type ChangeEvent } from 'react'
+import { Component, type ChangeEvent } from 'react'
 
 import { InlineConditionsDefinitionValue } from '~/src/conditions/InlineConditionsDefinitionValue.jsx'
 import { type FieldDef } from '~/src/data/component/fields.js'

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.test.tsx
@@ -12,7 +12,6 @@ import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import upperFirst from 'lodash/upperFirst.js'
-import React from 'react'
 
 import { InlineConditionsDefinitionValue } from '~/src/conditions/InlineConditionsDefinitionValue.jsx'
 import { type FieldDef } from '~/src/data/component/fields.js'

--- a/designer/client/src/conditions/InlineConditionsDefinitionValue.tsx
+++ b/designer/client/src/conditions/InlineConditionsDefinitionValue.tsx
@@ -11,7 +11,6 @@ import {
   type RelativeDateValue,
   type RelativeDateValueData
 } from '@defra/forms-model'
-import React from 'react'
 
 import {
   AbsoluteDateValues,

--- a/designer/client/src/conditions/InlineConditionsEdit.tsx
+++ b/designer/client/src/conditions/InlineConditionsEdit.tsx
@@ -12,12 +12,7 @@ import {
   type ConditionsModel
 } from '@defra/forms-model'
 import classNames from 'classnames'
-import React, {
-  Component,
-  Fragment,
-  type ChangeEvent,
-  type MouseEvent
-} from 'react'
+import { Component, Fragment, type ChangeEvent, type MouseEvent } from 'react'
 
 import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { InlineConditionsDefinition } from '~/src/conditions/InlineConditionsDefinition.jsx'

--- a/designer/client/src/conditions/RelativeDateValues.tsx
+++ b/designer/client/src/conditions/RelativeDateValues.tsx
@@ -5,7 +5,7 @@ import {
   type RelativeDateValueData
 } from '@defra/forms-model'
 import upperFirst from 'lodash/upperFirst.js'
-import React, { Component } from 'react'
+import { Component } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 

--- a/designer/client/src/conditions/SelectConditions.test.tsx
+++ b/designer/client/src/conditions/SelectConditions.test.tsx
@@ -6,7 +6,6 @@ import {
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { SelectConditions } from '~/src/conditions/SelectConditions.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/conditions/SelectConditions.tsx
+++ b/designer/client/src/conditions/SelectConditions.tsx
@@ -7,7 +7,7 @@ import {
 } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Select } from '@xgovformbuilder/govuk-react-jsx'
-import React, {
+import {
   Component,
   type ChangeEvent,
   type ContextType,

--- a/designer/client/src/conditions/SelectValues.tsx
+++ b/designer/client/src/conditions/SelectValues.tsx
@@ -3,7 +3,7 @@ import {
   type ConditionValueData,
   type Item
 } from '@defra/forms-model'
-import React, { type ChangeEvent } from 'react'
+import { type ChangeEvent } from 'react'
 
 import { type FieldDef } from '~/src/data/component/fields.js'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/conditions/TextValues.tsx
+++ b/designer/client/src/conditions/TextValues.tsx
@@ -1,5 +1,5 @@
 import { ConditionValue, type ConditionValueData } from '@defra/forms-model'
-import React, { type ChangeEvent } from 'react'
+import { type ChangeEvent } from 'react'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 

--- a/designer/client/src/index.tsx
+++ b/designer/client/src/index.tsx
@@ -1,5 +1,5 @@
 import { type FormMetadata, type FormDefinition } from '@defra/forms-model'
-import React, { Component } from 'react'
+import { Component } from 'react'
 import ReactDOM from 'react-dom'
 
 import { Designer } from '~/src/Designer.jsx'

--- a/designer/client/src/list/ListEdit.test.tsx
+++ b/designer/client/src/list/ListEdit.test.tsx
@@ -1,7 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { ListEdit } from '~/src/list/ListEdit.jsx'
 import { RenderListEditorWithContext } from '~/test/helpers/renderers-lists.jsx'

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -2,7 +2,7 @@ import { hasListField } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import Joi from 'joi'
-import React, {
+import {
   useContext,
   type ChangeEvent,
   type FormEvent,

--- a/designer/client/src/list/ListItemEdit.test.tsx
+++ b/designer/client/src/list/ListItemEdit.test.tsx
@@ -9,7 +9,6 @@ import {
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import React from 'react'
 
 import { ListItemEdit } from '~/src/list/ListItemEdit.jsx'
 import { RenderListEditorWithContext } from '~/test/helpers/renderers-lists.jsx'

--- a/designer/client/src/list/ListItemEdit.tsx
+++ b/designer/client/src/list/ListItemEdit.tsx
@@ -1,7 +1,7 @@
 import { hasListField } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input, Textarea } from '@xgovformbuilder/govuk-react-jsx'
-import React, { useContext, type FormEvent, type MouseEvent } from 'react'
+import { useContext, type FormEvent, type MouseEvent } from 'react'
 
 import { ErrorSummary } from '~/src/ErrorSummary.jsx'
 import { DataContext } from '~/src/context/DataContext.js'

--- a/designer/client/src/list/ListItems.tsx
+++ b/designer/client/src/list/ListItems.tsx
@@ -1,5 +1,5 @@
 import { slugify, type Item } from '@defra/forms-model'
-import React, { useCallback, useContext, type ComponentProps } from 'react'
+import { useCallback, useContext, type ComponentProps } from 'react'
 
 import { SortUpDown } from '~/src/SortUpDown.jsx'
 import { arrayMove } from '~/src/helpers.js'

--- a/designer/client/src/list/ListSelect.test.tsx
+++ b/designer/client/src/list/ListSelect.test.tsx
@@ -1,7 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { ListSelect } from '~/src/list/ListSelect.jsx'
 import { RenderListEditorWithContext } from '~/test/helpers/renderers-lists.jsx'

--- a/designer/client/src/list/ListSelect.tsx
+++ b/designer/client/src/list/ListSelect.tsx
@@ -1,5 +1,5 @@
 import { type List } from '@defra/forms-model'
-import React, { useContext, type MouseEvent } from 'react'
+import { useContext, type MouseEvent } from 'react'
 
 import { DataContext } from '~/src/context/DataContext.js'
 import { i18n } from '~/src/i18n/i18n.jsx'

--- a/designer/client/src/list/ListsEdit.tsx
+++ b/designer/client/src/list/ListsEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import { useContext } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -1,5 +1,5 @@
 import { type ComponentDef } from '@defra/forms-model'
-import React, {
+import {
   useMemo,
   useReducer,
   createContext,

--- a/designer/client/src/reducers/list/listsEditorReducer.tsx
+++ b/designer/client/src/reducers/list/listsEditorReducer.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   useMemo,
   useReducer,

--- a/designer/client/src/reducers/listReducer.tsx
+++ b/designer/client/src/reducers/listReducer.tsx
@@ -1,5 +1,5 @@
 import { type FormDefinition, type Item, type List } from '@defra/forms-model'
-import React, {
+import {
   createContext,
   useContext,
   useMemo,

--- a/designer/client/src/section/SectionEdit.test.tsx
+++ b/designer/client/src/section/SectionEdit.test.tsx
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
-import React from 'react'
 
 import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'

--- a/designer/client/src/section/SectionEdit.tsx
+++ b/designer/client/src/section/SectionEdit.tsx
@@ -1,7 +1,7 @@
 import { type Section } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
-import React, {
+import {
   Component,
   type ChangeEvent,
   type ContextType,

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -1,5 +1,5 @@
 import { type Section } from '@defra/forms-model'
-import React, { Component, type ContextType, type MouseEvent } from 'react'
+import { Component, type ContextType, type MouseEvent } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'

--- a/designer/client/test/helpers/renderers-lists.tsx
+++ b/designer/client/test/helpers/renderers-lists.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactElement } from 'react'
+import { type ReactElement } from 'react'
 
 import { type DataContextType } from '~/src/context/DataContext.js'
 import { type initComponentState } from '~/src/reducers/component/componentReducer.jsx'

--- a/designer/client/test/helpers/renderers.tsx
+++ b/designer/client/test/helpers/renderers.tsx
@@ -1,5 +1,5 @@
 import { type ComponentDef } from '@defra/forms-model'
-import React, { useMemo, useReducer, type ReactElement } from 'react'
+import { useMemo, useReducer, type ReactElement } from 'react'
 
 import { DataContext, type DataContextType } from '~/src/context/DataContext.js'
 import {

--- a/designer/client/tsconfig.json
+++ b/designer/client/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "lib": ["DOM", "ES2015"],
     "module": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
Another tech debt PR to remove unnecessary React imports from source

Read about [**Removing Unused React Imports** from Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports)