### PR TITLE
Set up vendor bundle for React

### DIFF
--- a/designer/server/src/common/templates/layouts/page.njk
+++ b/designer/server/src/common/templates/layouts/page.njk
@@ -52,6 +52,5 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script type="module" src="{{ getAssetPath("shared.js") }}"></script>
   <script type="module" src="{{ getAssetPath("application.js") }}"></script>
 {% endblock %}

--- a/designer/server/src/views/forms/editor.njk
+++ b/designer/server/src/views/forms/editor.njk
@@ -30,6 +30,7 @@
 
 {% block bodyEnd %}
   {{ super() }}
+  <script type="module" src="{{ getAssetPath("vendor/react.js") }}"></script>
   <script type="module" src="{{ getAssetPath("editor.js") }}"></script>
 
   <!-- Form metadata JSON -->

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -161,10 +161,10 @@ export default /** @type {Configuration} */ ({
             return join('vendor', pkgName || modulePath)
           }
         },
-        shared: {
+        editor: {
           chunks: 'initial',
-          name: 'shared',
-          test: /node_modules/,
+          name: 'vendor/react',
+          test: /node_modules\/(focus-trap|i18next|react)/,
           usedExports: true
         }
       }

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -9,16 +9,19 @@ import WebpackAssetsManifest from 'webpack-assets-manifest'
 const { EnvironmentPlugin } = webpack
 const { NODE_ENV = 'development', REACT_LOG_LEVEL } = process.env
 
+const appDir = import.meta.dirname
+const rootDir = resolve(import.meta.dirname, '../')
+
 const govukFrontendPath = dirname(
-  resolvePkg.sync('govuk-frontend/package.json', {
-    basedir: import.meta.dirname
-  })
+  resolvePkg.sync('govuk-frontend/package.json', { basedir: appDir })
 )
 
 const govukFrontendLegacyPath = dirname(
-  resolvePkg.sync('govuk-frontend/package.json', {
-    basedir: resolve(import.meta.dirname, '../')
-  })
+  resolvePkg.sync('govuk-frontend/package.json', { basedir: rootDir })
+)
+
+const reactPath = dirname(
+  resolvePkg.sync('react/package.json', { basedir: appDir })
 )
 
 export default /** @type {Configuration} */ ({
@@ -224,11 +227,16 @@ export default /** @type {Configuration} */ ({
     alias: {
       '~': join(import.meta.dirname, 'client'),
       'govuk-frontend/dist': join(govukFrontendPath, 'dist'),
+      '/assets': join(govukFrontendPath, 'dist/govuk/assets'),
+
+      // Alias legacy GOV.UK Frontend to latest
       'govuk-frontend/govuk': [
         join(govukFrontendPath, 'dist/govuk'),
         join(govukFrontendLegacyPath, 'govuk')
       ],
-      '/assets': join(govukFrontendPath, 'dist/govuk/assets')
+
+      // Alias legacy React to latest
+      react: reactPath
     },
     extensions: ['.js', '.json', '.mjs'],
     extensionAlias: {

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -147,8 +147,22 @@ export default /** @type {Configuration} */ ({
     // Apply cache groups in production
     splitChunks: {
       cacheGroups: {
+        defaultVendors: {
+          /**
+           * Use npm package names
+           * @param {NormalModule} module
+           */
+          name({ userRequest }) {
+            const [[modulePath, pkgName]] = userRequest.matchAll(
+              /node_modules\/([^\\/]+)/g
+            )
+
+            // Move into /javascripts/vendor
+            return join('vendor', pkgName || modulePath)
+          }
+        },
         shared: {
-          chunks: 'all',
+          chunks: 'initial',
           name: 'shared',
           test: /node_modules/,
           usedExports: true
@@ -236,5 +250,5 @@ export default /** @type {Configuration} */ ({
 })
 
 /**
- * @import { Configuration } from 'webpack'
+ * @import { Configuration, NormalModule } from 'webpack'
  */


### PR DESCRIPTION
To speed up the forms designer I've moved the shared JavaScript bundle to legacy editor pages only

### Designer pages

```patch
- <script type="module" src="/javascripts/shared.[hash].min.js"></script>
  <script type="module" src="/javascripts/application.[hash].min.js"></script>
```

### Legacy editor pages

There's now a separate React vendor bundle which is only loaded when opening the legacy editor

```patch
- <script type="module" src="/javascripts/shared.[hash].min.js"></script>
+ <script type="module" src="/javascripts/vendor/react.[hash].min.js"></script>
  <script type="module" src="/javascripts/editor.[hash].min.js"></script>
```

## Before
Packages such as `react-dom`, `focus-trap-react`, `joi-browser` and `i18next` are loaded when unnecessary

<img width="1861" alt="Script bundles before" src="https://github.com/user-attachments/assets/64fe03f4-ac10-421f-8595-5387dc6cd75d">

## After
<img width="1861" alt="Script bundles after" src="https://github.com/user-attachments/assets/bbf87e6d-91df-4c90-ac56-ac75ff51bce4">
