### PR TITLE
Prevent 30px jump on `<Visualisation>` render

### DIFF
--- a/designer/client/src/components/Visualisation/Lines.tsx
+++ b/designer/client/src/components/Visualisation/Lines.tsx
@@ -1,17 +1,13 @@
-import { Component, type ContextType } from 'react'
+import { Component } from 'react'
 
 import { LinkEdit } from '~/src/LinkEdit.jsx'
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
 import { RenderInPortal } from '~/src/components/RenderInPortal/RenderInPortal.jsx'
-import {
-  type Edge,
-  type Pos
-} from '~/src/components/Visualisation/getLayout.js'
-import { DataContext } from '~/src/context/DataContext.js'
+import { type Edge } from '~/src/components/Visualisation/getLayout.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 
 interface Props {
-  layout: Pos
+  edges: Edge[]
 }
 
 interface State {
@@ -19,9 +15,6 @@ interface State {
 }
 
 export class Lines extends Component<Props, State> {
-  declare context: ContextType<typeof DataContext>
-  static readonly contextType = DataContext
-
   state: State = {}
 
   editLink = (edge: Edge) => {
@@ -35,12 +28,12 @@ export class Lines extends Component<Props, State> {
   }
 
   render() {
-    const { layout } = this.props
+    const { edges } = this.props
 
     return (
       <>
-        <svg height={layout.height} width={layout.width} className="line">
-          {layout.edges.map((edge) => {
+        <svg className="line">
+          {edges.map((edge) => {
             const { source, target, points, label } = edge
 
             const pointsString = points.map((p) => `${p.x},${p.y}`).join(' ')

--- a/designer/client/src/components/Visualisation/Visualisation.tsx
+++ b/designer/client/src/components/Visualisation/Visualisation.tsx
@@ -44,7 +44,7 @@ export function Visualisation() {
             <Page key={page.path} page={page} layout={layout?.nodes[index]} />
           ))}
 
-          {layout && <Lines layout={layout} />}
+          {layout && <Lines edges={layout.edges} />}
         </div>
       </div>
     </div>

--- a/designer/client/src/components/Visualisation/visualisation.scss
+++ b/designer/client/src/components/Visualisation/visualisation.scss
@@ -31,11 +31,20 @@ $govuk-breakpoints: (
 
   .page {
     position: absolute;
+    left: 30px;
     width: 240px;
     margin-bottom: 10px;
     box-sizing: border-box;
     background-color: govuk-colour("white");
     border: 2px solid govuk-colour("black");
+
+    // Hide during layout calculation
+    visibility: hidden;
+
+    // Show after layout calculation
+    &[style] {
+      visibility: visible;
+    }
 
     &:focus-within {
       box-shadow: 0 0 0 6px $govuk-focus-colour;

--- a/designer/client/src/components/Visualisation/visualisation.scss
+++ b/designer/client/src/components/Visualisation/visualisation.scss
@@ -63,6 +63,11 @@ $govuk-breakpoints: (
     }
   }
 
+  .line {
+    width: 100%;
+    height: 100%;
+  }
+
   .line__condition {
     display: flex;
 

--- a/designer/client/src/stylesheets/editor.scss
+++ b/designer/client/src/stylesheets/editor.scss
@@ -619,5 +619,6 @@ p code {
 }
 
 .govuk-main-wrapper--editor {
+  min-height: govuk-em(600px, $context-font-size: 16);
   padding-bottom: 0;
 }


### PR DESCRIPTION
Another minor visual fix

This PR adds `left: 30px` to CSS to prevent a horizontal jump when `<Visualisation>` renders

I've also removed `width` and `height` from the `<Line>` SVG since it's always 100% of the page wrapper