### PR TITLE
Reduce initial editor JavaScript by 247 KiB

### DIFF
--- a/designer/client/jest.environment.js
+++ b/designer/client/jest.environment.js
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
 import { initI18n } from '~/src/i18n/i18n.jsx'
+import translation from '~/src/i18n/translations/en.translation.json'
 
 /**
  * Polyfill `window.matchMedia()` for GOV.UK Frontend
@@ -52,7 +53,9 @@ beforeAll(async () => {
   // Flag GOV.UK Frontend as supported
   document.body.classList.add('govuk-frontend-supported')
 
-  await initI18n()
+  await initI18n({
+    resources: { en: { translation } }
+  })
 })
 
 beforeEach(() => {

--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -47,11 +47,16 @@ export function ComponentEdit(props: Readonly<Props>) {
     })
   }, [hasValidated, hasErrors, isSaving, isDeleting, onHandleSave])
 
-  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
     e.stopPropagation()
 
-    dispatch({ name: Meta.VALIDATE })
+    const { default: schema } = await import('joi')
+
+    dispatch({
+      name: Meta.VALIDATE,
+      payload: schema
+    })
   }
 
   async function handleSave() {

--- a/designer/client/src/LinkEdit.tsx
+++ b/designer/client/src/LinkEdit.tsx
@@ -5,7 +5,7 @@ import {
   type Page
 } from '@defra/forms-model'
 import classNames from 'classnames'
-import Joi from 'joi'
+import { type Root } from 'joi'
 import {
   Component,
   type ChangeEvent,
@@ -111,8 +111,10 @@ export class LinkEdit extends Component<Props, State> {
       selectedCondition: this.state.selectedCondition
     }
 
+    const { default: schema } = await import('joi')
+
     // Check for valid form payload
-    if (!this.validate(payload)) {
+    if (!this.validate(payload, schema)) {
       return
     }
 
@@ -192,24 +194,26 @@ export class LinkEdit extends Component<Props, State> {
     })
   }
 
-  validate = (payload: Partial<Form>): payload is Form => {
+  validate = (payload: Partial<Form>, schema: Root): payload is Form => {
     const { isEditingLink, edgeFrom } = this.state
     const { pageFrom, pageTo } = payload
 
     const errors: State['errors'] = {}
 
     errors.from = validateRequired('link-from', pageFrom?.path, {
-      label: i18n('addLink.linkFrom.title')
+      label: i18n('addLink.linkFrom.title'),
+      schema
     })
 
     errors.to = validateRequired('link-to', pageTo?.path, {
-      label: i18n('addLink.linkTo.title')
+      label: i18n('addLink.linkTo.title'),
+      schema
     })
 
     errors.to ??= validateCustom('link-to', [pageFrom?.path, pageTo?.path], {
       message: 'errors.unique',
       label: 'Linked pages',
-      schema: Joi.array().unique()
+      schema: schema.array().unique()
     })
 
     if (pageFrom && pageTo) {
@@ -222,7 +226,7 @@ export class LinkEdit extends Component<Props, State> {
         errors.to ??= validateCustom('link-to', index, {
           message: 'errors.duplicate',
           label: 'Link between pages',
-          schema: Joi.number().max(-1)
+          schema: schema.number().max(-1)
         })
       }
     }

--- a/designer/client/src/PageCreate.tsx
+++ b/designer/client/src/PageCreate.tsx
@@ -12,7 +12,7 @@ import {
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
-import Joi from 'joi'
+import { type Root } from 'joi'
 import {
   Component,
   type ChangeEvent,
@@ -114,8 +114,10 @@ export class PageCreate extends Component<Props, State> {
       controller: controller ? defaults.controller : undefined
     }
 
+    const { default: schema } = await import('joi')
+
     // Check for valid form payload
-    if (!this.validate(payload)) {
+    if (!this.validate(payload, schema)) {
       return
     }
 
@@ -151,7 +153,7 @@ export class PageCreate extends Component<Props, State> {
     }
   }
 
-  validate = (payload: Partial<Form>): payload is Form => {
+  validate = (payload: Partial<Form>, schema: Root): payload is Form => {
     const { data } = this.context
     const { title, path, controller } = payload
 
@@ -159,11 +161,13 @@ export class PageCreate extends Component<Props, State> {
 
     errors.controller = validateRequired('page-controller', controller, {
       label: i18n('addPage.controllerOption.title'),
-      message: 'addPage.controllerOption.option'
+      message: 'addPage.controllerOption.option',
+      schema
     })
 
     errors.title = validateRequired('page-title', title, {
-      label: i18n('addPage.pageTitleField.title')
+      label: i18n('addPage.pageTitleField.title'),
+      schema
     })
 
     errors.path = validateCustom(
@@ -172,7 +176,7 @@ export class PageCreate extends Component<Props, State> {
       {
         message: 'errors.duplicate',
         label: `Path '${path}'`,
-        schema: Joi.array().unique()
+        schema: schema.array().unique()
       }
     )
 

--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -15,7 +15,7 @@ import {
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
-import Joi from 'joi'
+import { type Root } from 'joi'
 import {
   Component,
   type ChangeEvent,
@@ -111,8 +111,10 @@ export class PageEdit extends Component<Props, State> {
       controller: controller ? defaults.controller : undefined
     }
 
+    const { default: schema } = await import('joi')
+
     // Check for valid form payload
-    if (!this.validate(payload)) {
+    if (!this.validate(payload, schema)) {
       return
     }
 
@@ -163,7 +165,7 @@ export class PageEdit extends Component<Props, State> {
     }
   }
 
-  validate = (payload: Partial<Form>): payload is Form => {
+  validate = (payload: Partial<Form>, schema: Root): payload is Form => {
     const { controller } = this.state
 
     const { title, path } = payload
@@ -172,24 +174,26 @@ export class PageEdit extends Component<Props, State> {
 
     errors.controller = validateRequired('page-controller', controller, {
       label: i18n('addPage.controllerOption.title'),
-      message: 'addPage.controllerOption.option'
+      message: 'addPage.controllerOption.option',
+      schema
     })
 
     errors.title = validateRequired('page-title', title, {
-      label: i18n('addPage.pageTitleField.title')
+      label: i18n('addPage.pageTitleField.title'),
+      schema
     })
 
     // Path '/status' not allowed
     errors.path = validateCustom('page-path', path, {
       message: 'page.errors.pathStart',
-      schema: Joi.string().disallow(ControllerPath.Status)
+      schema: schema.string().disallow(ControllerPath.Status)
     })
 
     // Path '/start' not allowed
     if (controller !== ControllerType.Start) {
       errors.path ??= validateCustom('page-path', path, {
         message: 'page.errors.pathStart',
-        schema: Joi.string().disallow(ControllerPath.Start)
+        schema: schema.string().disallow(ControllerPath.Start)
       })
     }
 
@@ -197,7 +201,7 @@ export class PageEdit extends Component<Props, State> {
     if (controller !== ControllerType.Summary) {
       errors.path ??= validateCustom('page-path', path, {
         message: 'page.errors.pathSummary',
-        schema: Joi.string().disallow(ControllerPath.Summary)
+        schema: schema.string().disallow(ControllerPath.Summary)
       })
     }
 

--- a/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
+++ b/designer/client/src/components/ComponentCreate/ComponentCreate.tsx
@@ -52,11 +52,16 @@ function useComponentCreate(props: Readonly<Props>) {
     })
   }, [hasValidated, hasErrors, isSaving, onHandleSave])
 
-  function handleSubmit(e: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
     e.stopPropagation()
 
-    dispatch({ name: Meta.VALIDATE })
+    const { default: schema } = await import('joi')
+
+    dispatch({
+      name: Meta.VALIDATE,
+      payload: schema
+    })
   }
 
   async function handleSave() {

--- a/designer/client/src/components/Menu/Menu.tsx
+++ b/designer/client/src/components/Menu/Menu.tsx
@@ -1,5 +1,4 @@
 import { hasComponents, hasListField } from '@defra/forms-model'
-import { highlightAll } from 'prismjs'
 import { useContext } from 'react'
 
 import { DeclarationEdit } from '~/src/DeclarationEdit.jsx'
@@ -219,7 +218,15 @@ export function Menu() {
             <Tabs
               title={i18n('menu.overview')}
               items={overviewTabs}
-              onInit={highlightAll}
+              onInit={async () => {
+                const [{ highlightAll }] = await Promise.all([
+                  import('prismjs'),
+                  // @ts-expect-error -- No types available
+                  import('prismjs/components/prism-json.js')
+                ])
+
+                highlightAll()
+              }}
               className="app-tabs--overview"
             ></Tabs>
           </Flyout>

--- a/designer/client/src/conditions/InlineConditions.tsx
+++ b/designer/client/src/conditions/InlineConditions.tsx
@@ -6,6 +6,7 @@ import {
   type ConditionWrapper
 } from '@defra/forms-model'
 import classNames from 'classnames'
+import { type Root } from 'joi'
 import {
   Component,
   type ChangeEvent,
@@ -124,8 +125,10 @@ export class InlineConditions extends Component<Props, State> {
       displayName: conditions.name
     }
 
+    const { default: schema } = await import('joi')
+
     // Check for valid form payload
-    if (!this.validate(payload)) {
+    if (!this.validate(payload, schema)) {
       return
     }
 
@@ -194,13 +197,14 @@ export class InlineConditions extends Component<Props, State> {
     })
   }
 
-  validate = (payload: Partial<Form>): payload is Form => {
+  validate = (payload: Partial<Form>, schema: Root): payload is Form => {
     const { displayName } = payload
 
     const errors: State['errors'] = {}
 
     errors.name = validateRequired('cond-name', displayName, {
-      label: i18n('conditions.enterName')
+      label: i18n('conditions.enterName'),
+      schema
     })
 
     this.setState({ errors })

--- a/designer/client/src/hooks/list/useListItem/types.ts
+++ b/designer/client/src/hooks/list/useListItem/types.ts
@@ -1,4 +1,5 @@
 import { type Item } from '@defra/forms-model'
+import { type Root } from 'joi'
 import { type ChangeEvent } from 'react'
 
 import { type FormItem } from '~/src/reducers/listReducer.jsx'
@@ -10,7 +11,7 @@ export interface ListItemHook {
   handleHintChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
   prepareForDelete: () => void
   prepareForSubmit: () => void
-  validate: (payload: Partial<FormItem>) => boolean
+  validate: (payload: Partial<FormItem>, schema: Root) => boolean
   value?: Item['value']
   condition?: string
   text?: string

--- a/designer/client/src/hooks/list/useListItem/useListItem.tsx
+++ b/designer/client/src/hooks/list/useListItem/useListItem.tsx
@@ -1,4 +1,4 @@
-import Joi from 'joi'
+import { type Root } from 'joi'
 
 import { findListItem } from '~/src/data/list/findList.js'
 import { type ListItemHook } from '~/src/hooks/list/useListItem/types.js'
@@ -55,7 +55,10 @@ export function useListItem(
     })
   }
 
-  function validate(payload: Partial<FormItem>): payload is FormItem {
+  function validate(
+    payload: Partial<FormItem>,
+    schema: Root
+  ): payload is FormItem {
     const { text, value } = payload.selectedItem ?? {}
 
     const titles =
@@ -71,23 +74,25 @@ export function useListItem(
     const errors: ListState['listItemErrors'] = {}
 
     errors.title = validateRequired('title', text, {
-      label: i18n('list.item.title')
+      label: i18n('list.item.title'),
+      schema
     })
 
     errors.title ??= validateCustom('title', [...titles, text], {
       message: 'errors.duplicate',
       label: `Item text '${text}'`,
-      schema: Joi.array().unique()
+      schema: schema.array().unique()
     })
 
     errors.value = validateRequired('value', value?.toString(), {
-      label: i18n('list.item.value')
+      label: i18n('list.item.value'),
+      schema
     })
 
     errors.value ??= validateCustom('value', [...values, value], {
       message: 'errors.duplicate',
       label: `Item value '${value}'`,
-      schema: Joi.array().unique()
+      schema: schema.array().unique()
     })
 
     dispatch({

--- a/designer/client/src/i18n/i18n.tsx
+++ b/designer/client/src/i18n/i18n.tsx
@@ -16,8 +16,8 @@ const DEFAULT_SETTINGS: InitOptions<HttpBackendOptions> = {
   }
 }
 
-export const initI18n = async (settings = DEFAULT_SETTINGS) => {
-  await I18next.use(Backend).init(settings)
+export const initI18n = async (settings?: InitOptions<HttpBackendOptions>) => {
+  await I18next.use(Backend).init({ ...DEFAULT_SETTINGS, ...settings })
 
   I18next.services.formatter?.add('lowerFirst', lowerFirst)
   I18next.services.formatter?.add('upperFirst', upperFirst)

--- a/designer/client/src/i18n/i18n.tsx
+++ b/designer/client/src/i18n/i18n.tsx
@@ -1,22 +1,15 @@
 import I18next, { type InitOptions, type TOptions } from 'i18next'
-import Backend from 'i18next-http-backend'
+import Backend, { type HttpBackendOptions } from 'i18next-http-backend'
 import lowerFirst from 'lodash/lowerFirst.js'
 import upperFirst from 'lodash/upperFirst.js'
 
-import enCommonTranslations from '~/src/i18n/translations/en.translation.json'
-
-const DEFAULT_SETTINGS: InitOptions = {
+const DEFAULT_SETTINGS: InitOptions<HttpBackendOptions> = {
   lng: 'en',
   fallbackLng: 'en',
   debug: false,
   interpolation: {
     escapeValue: false,
     skipOnVariables: false
-  },
-  resources: {
-    en: {
-      translation: enCommonTranslations
-    }
   },
   backend: {
     loadPath: '/assets/translations/{{lng}}.{{ns}}.json'

--- a/designer/client/src/index.tsx
+++ b/designer/client/src/index.tsx
@@ -8,44 +8,62 @@ import { initI18n } from '~/src/i18n/i18n.jsx'
 
 import 'prismjs/components/prism-json.js'
 
-initI18n().catch((error: unknown) => {
-  logger.error(error, 'I18n')
-})
+interface Props {
+  container: HTMLElement
+}
 
-const $container = document.querySelector('.app-form-editor')
-const $definition = document.querySelector('.app-form-definition')
-const $metadata = document.querySelector('.app-form-metadata')
+export class App extends Component<Props> {
+  metadata: FormMetadata
+  definition: FormDefinition
+  previewUrl: string
 
-export class App extends Component {
-  render() {
+  constructor(props: Props) {
+    super(props)
+
+    const $definition = document.querySelector('.app-form-definition')
+    const $metadata = document.querySelector('.app-form-metadata')
+
+    // Extract from HTML data-* attributes
+    const { previewUrl } = props.container.dataset
+
     if (
-      !($container instanceof HTMLElement) ||
       !($metadata instanceof HTMLScriptElement) ||
       !($definition instanceof HTMLScriptElement) ||
-      !$container.dataset.previewUrl ||
       !$definition.textContent ||
-      !$metadata.textContent
+      !$metadata.textContent ||
+      !previewUrl
     ) {
       throw new Error('Missing form data')
     }
 
-    let definition: FormDefinition | undefined
-    let metadata: FormMetadata | undefined
+    this.definition = JSON.parse($definition.textContent) as FormDefinition
+    this.metadata = JSON.parse($metadata.textContent) as FormMetadata
+    this.previewUrl = previewUrl
+  }
 
-    try {
-      definition = JSON.parse($definition.textContent) as FormDefinition
-      metadata = JSON.parse($metadata.textContent) as FormMetadata
-    } catch (error) {
-      logger.error(error, 'App')
-      throw error
-    }
-
-    // Extract from HTML data-* attributes
-    const { previewUrl } = $container.dataset
+  render() {
     return (
-      <Designer meta={metadata} data={definition} previewUrl={previewUrl} />
+      <Designer
+        meta={this.metadata}
+        data={this.definition}
+        previewUrl={this.previewUrl}
+      />
     )
   }
 }
 
-ReactDOM.render(<App />, $container)
+function initApp() {
+  const $root = document.querySelector('.app-form-editor')
+
+  if (!($root instanceof HTMLElement)) {
+    throw new Error('Missing form data')
+  }
+
+  ReactDOM.render(<App container={$root} />, $root)
+}
+
+initI18n()
+  .then(initApp)
+  .catch((error: unknown) => {
+    logger.error(error, 'App')
+  })

--- a/designer/client/src/index.tsx
+++ b/designer/client/src/index.tsx
@@ -6,8 +6,6 @@ import { Designer } from '~/src/Designer.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import { initI18n } from '~/src/i18n/i18n.jsx'
 
-import 'prismjs/components/prism-json.js'
-
 interface Props {
   container: HTMLElement
 }

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -1,7 +1,7 @@
 import { hasListField } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
-import Joi from 'joi'
+import { type Root } from 'joi'
 import {
   useContext,
   type ChangeEvent,
@@ -80,18 +80,22 @@ function useListEdit() {
     })
   }
 
-  function validate(payload: Partial<FormList>): payload is FormList {
+  function validate(
+    payload: Partial<FormList>,
+    schema: Root
+  ): payload is FormList {
     const { selectedList } = payload
 
     const errors: ListState['errors'] = {}
 
     errors.title = validateRequired('list-title', selectedList?.title, {
-      label: i18n('list.title')
+      label: i18n('list.title'),
+      schema
     })
 
     errors.listItems = validateCustom('list-items', selectedList?.items, {
       message: 'list.errors.empty',
-      schema: Joi.array().min(1)
+      schema: schema.array().min(1)
     })
 
     listDispatch({
@@ -110,8 +114,10 @@ function useListEdit() {
       selectedList
     }
 
+    const { default: schema } = await import('joi')
+
     // Check for valid form payload
-    if (!validate(payload)) {
+    if (!validate(payload, schema)) {
       return
     }
 

--- a/designer/client/src/list/ListItemEdit.tsx
+++ b/designer/client/src/list/ListItemEdit.tsx
@@ -45,7 +45,7 @@ export function ListItemEdit() {
     throw new Error('Component must support lists')
   }
 
-  const handleSubmit = (
+  const handleSubmit = async (
     e: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement>
   ) => {
     e.preventDefault()
@@ -55,8 +55,10 @@ export function ListItemEdit() {
       selectedItem
     }
 
+    const { default: schema } = await import('joi')
+
     // Check for valid form payload
-    if (!validate(payload)) {
+    if (!validate(payload, schema)) {
       return
     }
 

--- a/designer/client/src/reducers/component/componentReducer.meta.ts
+++ b/designer/client/src/reducers/component/componentReducer.meta.ts
@@ -1,4 +1,5 @@
 import { type ComponentDef } from '@defra/forms-model'
+import { type Root } from 'joi'
 
 import {
   type ComponentState,
@@ -14,8 +15,13 @@ export type MetaReducerActions =
       as?: undefined
     }
   | {
-      name: Meta.SET_COMPONENT | Meta.VALIDATE
+      name: Meta.SET_COMPONENT
       payload?: undefined
+      as?: undefined
+    }
+  | {
+      name: Meta.VALIDATE
+      payload: Root
       as?: undefined
     }
   | {
@@ -44,7 +50,7 @@ export function metaReducer(state: ComponentState, action: ReducerActions) {
       break
 
     case Meta.VALIDATE:
-      stateNew.errors = fieldComponentValidations(selectedComponent)
+      stateNew.errors = fieldComponentValidations(selectedComponent, payload)
       stateNew.hasValidated = true
       break
   }

--- a/designer/client/src/reducers/component/componentReducer.test.tsx
+++ b/designer/client/src/reducers/component/componentReducer.test.tsx
@@ -1,4 +1,5 @@
 import { ComponentType, type ComponentDef } from '@defra/forms-model'
+import Joi from 'joi'
 
 import { fieldsReducer } from '~/src/reducers/component/componentReducer.fields.js'
 import {
@@ -89,7 +90,8 @@ describe('Component reducer', () => {
 
   test('componentReducer sets hasValidated: true', () => {
     const action: ReducerActions = {
-      name: Meta.VALIDATE
+      name: Meta.VALIDATE,
+      payload: Joi
     }
 
     const state: ComponentState = {

--- a/designer/client/src/reducers/component/componentReducer.validations.ts
+++ b/designer/client/src/reducers/component/componentReducer.validations.ts
@@ -5,35 +5,43 @@ import {
   hasTitle,
   type ComponentDef
 } from '@defra/forms-model'
+import { type Root } from 'joi'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { type ComponentState } from '~/src/reducers/component/componentReducer.jsx'
 import { validateName, validateRequired } from '~/src/validations.js'
 
-export function fieldComponentValidations(component?: ComponentDef) {
+export function fieldComponentValidations(
+  component: ComponentDef | undefined,
+  schema: Root
+) {
   const errors: ComponentState['errors'] = {}
 
   if (hasTitle(component)) {
     errors.title = validateRequired('field-title', component.title, {
-      label: i18n('common.titleField.title')
+      label: i18n('common.titleField.title'),
+      schema
     })
   }
 
   if (!hasContent(component)) {
     errors.name = validateName('field-name', component?.name, {
-      label: i18n('common.componentNameField.title')
+      label: i18n('common.componentNameField.title'),
+      schema
     })
   }
 
   if (hasContentField(component)) {
     errors.content = validateRequired('field-content', component.content, {
-      label: 'Content'
+      label: 'Content',
+      schema
     })
   }
 
   if (hasListField(component)) {
     errors.list = validateRequired('field-options-list', component.list, {
-      message: 'list.errors.select'
+      message: 'list.errors.select',
+      schema
     })
   }
 

--- a/designer/client/src/section/SectionEdit.tsx
+++ b/designer/client/src/section/SectionEdit.tsx
@@ -1,6 +1,7 @@
 import { type Section } from '@defra/forms-model'
 // @ts-expect-error -- No types available
 import { Input } from '@xgovformbuilder/govuk-react-jsx'
+import { type Root } from 'joi'
 import {
   Component,
   type ChangeEvent,
@@ -73,8 +74,10 @@ export class SectionEdit extends Component<Props, State> {
       title: title?.trim()
     }
 
+    const { default: schema } = await import('joi')
+
     // Check for valid form payload
-    if (!this.validate(payload)) {
+    if (!this.validate(payload, schema)) {
       return
     }
 
@@ -99,17 +102,19 @@ export class SectionEdit extends Component<Props, State> {
     }
   }
 
-  validate = (payload: Partial<Form>): payload is Form => {
+  validate = (payload: Partial<Form>, schema: Root): payload is Form => {
     const { name, title } = payload
 
     const errors: State['errors'] = {}
 
     errors.title = validateRequired('section-title', title, {
-      label: i18n('sectionEdit.titleField.title')
+      label: i18n('sectionEdit.titleField.title'),
+      schema
     })
 
     errors.name = validateName('section-name', name, {
-      label: i18n('sectionEdit.nameField.title')
+      label: i18n('sectionEdit.nameField.title'),
+      schema
     })
 
     this.setState({ errors })

--- a/designer/client/src/validations.ts
+++ b/designer/client/src/validations.ts
@@ -1,4 +1,4 @@
-import Joi, { type Schema } from 'joi'
+import { type Root, type Schema } from 'joi'
 
 import { type ErrorListItem } from '~/src/ErrorSummary.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
@@ -38,12 +38,12 @@ export function validateCustom(
  * Required field validator
  */
 export const validateRequired: Validator<string> = (id, value, options) => {
-  const message = options.message ?? 'errors.required'
+  const { label, message, schema } = options
 
   return validateCustom(id, value, {
-    label: options.label,
-    message,
-    schema: Joi.string().required()
+    label,
+    message: message ?? 'errors.required',
+    schema: schema.string().required()
   })
 }
 
@@ -51,12 +51,12 @@ export const validateRequired: Validator<string> = (id, value, options) => {
  * No spaces validator
  */
 export const validateNoSpaces: Validator<string> = (id, value, options) => {
-  const message = options.message ?? 'errors.spaces'
+  const { label, message, schema } = options
 
   return validateCustom(id, value, {
-    label: options.label,
-    message,
-    schema: Joi.string().regex(/\s/, { invert: true }).required()
+    label,
+    message: message ?? 'errors.spaces',
+    schema: schema.string().regex(/\s/, { invert: true }).required()
   })
 }
 
@@ -72,6 +72,7 @@ type Validator<
   OptionsType = {
     label?: string
     message?: string
+    schema: Root
   }
 > = (
   id: string,

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -136,6 +136,9 @@ export default /** @type {Configuration} */ ({
           // Allow Terser to remove @preserve comments
           format: { comments: false },
 
+          // Allow Terser to shorten property names
+          mangle: { properties: true },
+
           // Include sources content from dependency source maps
           sourceMap: {
             includeSources: true


### PR DESCRIPTION
This PR follows on from https://github.com/DEFRA/forms-designer/pull/497

Whilst the legacy editor is still around, we can improve it's page load performance a lot

I've added lazy loading via `await import()` using the same approach as **forms-runner** in:

* https://github.com/DEFRA/forms-runner/pull/222

### Before

```console
  editor (721 KiB)
      javascripts/vendor/react.8c6b7e2.min.js
      javascripts/editor.99c8b02.min.js
```

### After

```console
  editor (474 KiB)
      javascripts/vendor/react.40cbdb4.min.js
      javascripts/editor.dad8440.min.js
```

**Update:** Drops down to 466 KiB when https://github.com/DEFRA/forms-designer/pull/493 is included

## Lazy loading

The following optimisations have been included:

1. **Remove `en.translation.json` from bundle**
We already use `i18next` to download `/assets/translations/*.json`

2. **Lazy load `joi` when form validation runs**
Moved to `/javascripts/vendor/joi.[hash].min.js`

3. **Lazy load `prismjs` when code syntax highlighting is used**
Moved to `/javascripts/vendor/prismjs.[hash].min.js`

## Minification

I've enabled [Terser `mangle: { properties: true }`](https://terser.org/docs/options/#mangle-properties-options) to reduce repetitive names during object property access:
 
```patch
+        }({}), a = function(e) {
+            return e.t = "StartPageController", e.l = "HomePageController", e.u = "PageController", 
+            e.h = "FileUploadPageController", e.i = "SummaryPageController", e.o = "StatusPageController", 
+            e;
-        }({}), s = function(e) {
-            return e.Start = "StartPageController", e.Home = "HomePageController", e.Page = "PageController", 
-            e.FileUpload = "FileUploadPageController", e.Summary = "SummaryPageController", 
-            e.Status = "StatusPageController", e;
         }({});
+        const s = [ {
+            name: a.t,
-        const a = [ {
-            name: s.Start,
             path: "./pages/start.js"
         }, {
+            name: a.l,
-            name: s.Home,
             path: "./pages/home.js"
         }, {
+            name: a.u,
-            name: s.Page,
             path: "./pages/page.js"
         }, {
+            name: a.h,
-            name: s.FileUpload,
             path: "./pages/file-upload.js"
         }, {
+            name: a.i,
-            name: s.Summary,
             path: "./pages/summary.js"
         }, {
+            name: a.o,
-            name: s.Status,
             path: "./pages/status.js"
+        } ], l = s.map((({name: e}) => e)), c = Object.freeze([ {
-        } ], l = a.map((({name: e}) => e)), c = Object.freeze([ {
```