### PR TITLE
Make notification email optional

### DIFF
--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -40,11 +40,7 @@ export const teamEmailSchema = Joi.string()
 
 export const phoneSchema = Joi.string().trim()
 
-export const emailAddressSchema = Joi.string()
-  .email({ tlds: { allow: ['uk'] } })
-  .trim()
-  .pattern(/\.gov\.uk$|\.org\.uk$/)
-  .required()
+export const emailAddressSchema = Joi.string().email().trim().required()
 export const emailResponseTimeSchema = Joi.string().trim().required()
 export const emailSchema = Joi.object<FormMetadataContactEmail>().keys({
   address: emailAddressSchema,
@@ -77,6 +73,11 @@ export const privacyNoticeUrlSchema = Joi.string()
   })
   .trim()
 
+export const notificationEmailAddressSchema = Joi.string()
+  .email({ tlds: { allow: ['uk'] } })
+  .trim()
+  .pattern(/\.gov\.uk$|\.org\.uk$/)
+
 export const authoredAtSchema = Joi.date().iso().required()
 export const authorIdSchema = Joi.string().trim().required()
 export const authorDisplayNameSchema = Joi.string().trim().required()
@@ -89,7 +90,7 @@ export const formMetadataInputKeys = {
   contact: contactSchema,
   submissionGuidance: submissionGuidanceSchema,
   privacyNoticeUrl: privacyNoticeUrlSchema,
-  notificationEmail: emailAddressSchema
+  notificationEmail: notificationEmailAddressSchema
 }
 
 /**


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/342247

Notification email schema re-used the contact email schema, but that is `required()`.
Added a separate schema for it.