### PR TITLE
Remove "missing section" check from `updateSection()` helper

### DIFF
--- a/designer/client/src/data/section/updateSection.test.ts
+++ b/designer/client/src/data/section/updateSection.test.ts
@@ -1,0 +1,159 @@
+import {
+  type FormDefinition,
+  type Page,
+  type Section
+} from '@defra/forms-model'
+
+import { updateSection } from '~/src/data/section/updateSection.js'
+
+describe('updateSection', () => {
+  let sections: Section[]
+  let pages: Page[]
+  let data: FormDefinition
+
+  beforeEach(() => {
+    sections = [
+      {
+        name: 'section1',
+        title: 'Section 1'
+      },
+      {
+        name: 'section2',
+        title: 'Section 2'
+      },
+      {
+        name: 'section3',
+        title: 'Section 3'
+      }
+    ]
+
+    pages = [
+      {
+        title: 'page1',
+        path: '/1',
+        section: 'section1',
+        next: [{ path: '/2' }],
+        components: []
+      },
+
+      {
+        title: 'page2',
+        path: '/2',
+        section: 'section2',
+        next: [{ path: '/3' }],
+        components: []
+      },
+
+      {
+        title: 'page3',
+        path: '/3',
+        next: [],
+        section: 'section2',
+        components: []
+      }
+    ]
+
+    data = {
+      pages,
+      lists: [],
+      sections,
+      conditions: []
+    }
+  })
+
+  it('throws if no section could be found', () => {
+    expect(() =>
+      updateSection(data, 'sectionUnknown', {
+        name: 'section 4',
+        title: 'Section 4'
+      })
+    ).toThrow()
+  })
+
+  it('successfully updates a section title', () => {
+    const sectionsBefore = structuredClone(sections)
+
+    const { sections: sectionsAfter } = updateSection(data, 'section1', {
+      name: 'section1',
+      title: 'Section updated'
+    })
+
+    expect(sectionsBefore).toEqual(sections)
+    expect(sectionsAfter).toEqual([
+      {
+        name: 'section1',
+        title: 'Section updated'
+      },
+      {
+        name: 'section2',
+        title: 'Section 2'
+      },
+      {
+        name: 'section3',
+        title: 'Section 3'
+      }
+    ])
+  })
+
+  it('successfully updates a section name', () => {
+    const sectionsBefore = structuredClone(sections)
+
+    const { sections: sectionsAfter } = updateSection(data, 'section1', {
+      name: 'sectionUpdated',
+      title: 'Section 1'
+    })
+
+    expect(sectionsBefore).toEqual(sections)
+    expect(sectionsAfter).toEqual([
+      {
+        name: 'sectionUpdated',
+        title: 'Section 1'
+      },
+      {
+        name: 'section2',
+        title: 'Section 2'
+      },
+      {
+        name: 'section3',
+        title: 'Section 3'
+      }
+    ])
+  })
+
+  it('successfully updates a section name in pages that use it', () => {
+    const pagesBefore = structuredClone(pages)
+
+    const { pages: pagesAfter } = updateSection(data, 'section1', {
+      name: 'sectionUpdated',
+      title: 'Section updated'
+    })
+
+    expect(pagesBefore).toEqual(pages)
+    expect(pagesAfter).toEqual([
+      expect.objectContaining({
+        title: 'page1',
+        section: 'sectionUpdated'
+      }),
+      expect.objectContaining({
+        title: 'page2',
+        section: 'section2'
+      }),
+      expect.objectContaining({
+        title: 'page3',
+        section: 'section2'
+      })
+    ])
+  })
+
+  it('successfully updates a section name when not used by pages', () => {
+    const pagesBefore = structuredClone(pages)
+
+    const { pages: pagesAfter } = updateSection(data, 'section3', {
+      name: 'sectionUpdated',
+      title: 'Section updated'
+    })
+
+    expect(pagesBefore).toEqual(pages)
+    expect(pagesAfter).toEqual(pages)
+  })
+})

--- a/designer/client/src/data/section/updateSection.ts
+++ b/designer/client/src/data/section/updateSection.ts
@@ -14,34 +14,27 @@ export function updateSection(
   sectionName: string,
   sectionUpdate: Section
 ) {
-  try {
-    // Throw for missing section
-    findSection(data, sectionName)
-  } catch {
-    // Copy form definition
-    const definition = structuredClone(data)
-    const { pages, sections } = definition
+  // Copy form definition
+  const definition = structuredClone(data)
+  const { pages, sections } = definition
 
-    // Find section
-    const sectionEdit = findSection({ sections }, sectionName)
+  // Find section
+  const sectionEdit = findSection({ sections }, sectionName)
 
-    // Update pages with previous section name
-    if (sectionEdit.name !== sectionUpdate.name) {
-      const pagesToUpdate = pages
-        .filter(hasComponents)
-        .filter((page) => page.section === sectionName)
+  // Update pages with previous section name
+  if (sectionEdit.name !== sectionUpdate.name) {
+    const pagesToUpdate = pages
+      .filter(hasComponents)
+      .filter((page) => page.section === sectionName)
 
-      // Update page section
-      for (const page of pagesToUpdate) {
-        page.section = sectionUpdate.name
-      }
+    // Update page section
+    for (const page of pagesToUpdate) {
+      page.section = sectionUpdate.name
     }
-
-    // Update section properties
-    Object.assign(sectionEdit, sectionUpdate)
-
-    return definition
   }
 
-  return data
+  // Update section properties
+  Object.assign(sectionEdit, sectionUpdate)
+
+  return definition
 }


### PR DESCRIPTION
This PR fixes the `updateSection()` helper to ensure section edits are saved for [bug #449547](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/449547)

Checks for missing sections were accidentally copied in https://github.com/DEFRA/forms-designer/commit/1117787f0c4bc1e2b3160ba3b514b8b92bc562a9 from `addSection()` into `updateSection()`