### PR TITLE
Temporarily turn off Terser `mangle.properties`

### DIFF
--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -136,9 +136,6 @@ export default /** @type {Configuration} */ ({
           // Allow Terser to remove @preserve comments
           format: { comments: false },
 
-          // Allow Terser to shorten property names
-          mangle: { properties: true },
-
           // Include sources content from dependency source maps
           sourceMap: {
             includeSources: true


### PR DESCRIPTION
This PR temporarily turns off Terser `mangle.properties` added in:

* https://github.com/DEFRA/forms-designer/pull/499

Unfortunately we now use multiple webpack bundles that mangle each file differently. We're also importing packages with Babel transforms that hold the original property value in strings (https://github.com/terser/terser/issues/1265)

## Browser console error

E.g. The following browser console error was caused by `react` being named differently in two JS bundles

```console
TypeError: i.G is not a function. (In 'i.G((function(e,t){var n,r,o=e.className,a=e["q"],s=e.Y,l=e.W,c=e.hint,u=e.label,d=e.id,h=F(e,M),f=a;if(c){var v="".concat(d,"-hint");f+=" ".concat(v),n=i.createElement(D,j({},c,{id:v}))}if(s){var m=d?"".concat(d,"-error"):"";f+=" ".concat(m),r=i.createElement(R,j({},s,{id:m}))}return i.createElement("div",{className:"govuk-form-group".concat(s?" govuk-form-group--error":""," ").concat((null==l?void 0:l.className)||"")},i.createElement(P,j({},u,{htmlFor:d})),n,r,i.createElement("textarea",j({},h,{id:d,J:t,className:"govuk-textarea".concat(s?" govuk-textarea--error":""," ").concat(o||""),q:f.trim()||null})))}))', 'i.G' is undefined)
```