### PR TITLE
Remove editor support for component/section name

### DIFF
--- a/designer/client/src/ComponentEdit.test.tsx
+++ b/designer/client/src/ComponentEdit.test.tsx
@@ -7,29 +7,31 @@ import {
   hasListField,
   OperatorName,
   type ComponentDef,
-  type FormDefinition
+  type FormDefinition,
+  type Page
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
 import { render } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import lowerFirst from 'lodash/lowerFirst.js'
 
-import { ComponentTypeEdit } from '~/src/ComponentTypeEdit.jsx'
+import { ComponentEdit } from '~/src/ComponentEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
-describe('ComponentTypeEdit', () => {
+describe('ComponentEdit', () => {
+  let page: Page
   let data: FormDefinition
 
   beforeEach(() => {
+    page = {
+      title: 'First page',
+      path: '/first-page',
+      next: [],
+      components: []
+    }
+
     data = {
-      pages: [
-        {
-          title: 'First page',
-          path: '/first-page',
-          next: [],
-          components: []
-        }
-      ],
+      pages: [page],
       lists: [
         {
           name: 'myList',
@@ -274,7 +276,7 @@ describe('ComponentTypeEdit', () => {
         selectCondition: true
       }
     ]
-  ])('Component type edit: %s', (type, options) => {
+  ])('Component edit: %s', (type, options) => {
     let selectedComponent: ComponentDef
 
     beforeEach(() => {
@@ -282,7 +284,7 @@ describe('ComponentTypeEdit', () => {
 
       render(
         <RenderWithContext data={data} state={{ selectedComponent }}>
-          <ComponentTypeEdit />
+          <ComponentEdit page={page} onSave={jest.fn()} />
         </RenderWithContext>
       )
     })

--- a/designer/client/src/ComponentEdit.tsx
+++ b/designer/client/src/ComponentEdit.tsx
@@ -32,7 +32,7 @@ export function ComponentEdit(props: Readonly<Props>) {
   const [isDeleting, setIsDeleting] = useState(false)
 
   const { page, onSave } = props
-  const { initialName, selectedComponent, errors, hasValidated = false } = state
+  const { selectedComponent, errors, hasValidated = false } = state
 
   const hasErrors = hasValidationErrors(errors)
   const onHandleSave = useCallback(handleSave, [handleSave])
@@ -69,7 +69,7 @@ export function ComponentEdit(props: Readonly<Props>) {
     const definition = updateComponent(
       data,
       page,
-      initialName,
+      selectedComponent.name,
       selectedComponent
     )
 

--- a/designer/client/src/ComponentTypeEdit.test.tsx
+++ b/designer/client/src/ComponentTypeEdit.test.tsx
@@ -73,7 +73,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.AutocompleteField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -86,7 +85,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.CheckboxesField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -99,7 +97,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.DatePartsField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -112,7 +109,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.Details,
       {
-        name: false,
         hint: false,
         title: true,
         hideTitle: false,
@@ -125,7 +121,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.EmailAddressField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -138,7 +133,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.Html,
       {
-        name: false,
         hint: false,
         title: false,
         hideTitle: false,
@@ -151,7 +145,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.InsetText,
       {
-        name: false,
         hint: false,
         title: false,
         hideTitle: false,
@@ -164,7 +157,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.List,
       {
-        name: false,
         hint: true,
         title: true,
         hideTitle: true,
@@ -177,7 +169,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.MonthYearField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -190,7 +181,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.MultilineTextField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -203,7 +193,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.NumberField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -216,7 +205,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.RadiosField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -229,7 +217,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.SelectField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -242,7 +229,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.TelephoneNumberField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -255,7 +241,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.TextField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -268,7 +253,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.UkAddressField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: true,
@@ -281,7 +265,6 @@ describe('ComponentTypeEdit', () => {
     [
       ComponentType.YesNoField,
       {
-        name: true,
         hint: true,
         title: true,
         hideTitle: false,
@@ -386,27 +369,6 @@ describe('ComponentTypeEdit', () => {
         })
 
         expect($textarea).not.toBeInTheDocument()
-      })
-    }
-
-    if (options.name) {
-      it("should render 'Component name' input", () => {
-        const $input = screen.getByRole<HTMLInputElement>('textbox', {
-          name: 'Component name',
-          description:
-            'This is generated automatically and does not show on the page. Only change it if you are using an integration that requires you to, for example GOV.UK Notify. It must not contain spaces.'
-        })
-
-        expect($input).toBeInTheDocument()
-        expect($input).toHaveValue(selectedComponent.name)
-      })
-    } else {
-      it("should not render 'Component name' input", () => {
-        const $input = screen.queryByRole('textbox', {
-          name: 'Component name'
-        })
-
-        expect($input).not.toBeInTheDocument()
       })
     }
 

--- a/designer/client/src/FieldEdit.test.tsx
+++ b/designer/client/src/FieldEdit.test.tsx
@@ -49,7 +49,7 @@ describe('Field Edit', () => {
     const $checkboxes = screen.queryAllByRole('checkbox')
     const $selects = screen.queryAllByRole('combobox')
 
-    expect($inputs).toHaveLength(3)
+    expect($inputs).toHaveLength(2)
     expect($checkboxes).toHaveLength(1)
     expect($selects).toHaveLength(0)
   })
@@ -87,7 +87,7 @@ describe('Field Edit', () => {
     const $checkboxes = screen.queryAllByRole('checkbox')
     const $selects = screen.queryAllByRole('combobox')
 
-    expect($inputs).toHaveLength(3)
+    expect($inputs).toHaveLength(2)
     expect($checkboxes).toHaveLength(1)
     expect($selects).toHaveLength(0)
   })

--- a/designer/client/src/FieldEdit.tsx
+++ b/designer/client/src/FieldEdit.tsx
@@ -10,7 +10,6 @@ import { Input, Textarea } from '@xgovformbuilder/govuk-react-jsx'
 import classNames from 'classnames'
 import { useContext, type ChangeEvent, type ReactNode } from 'react'
 
-import { ErrorMessage } from '~/src/components/ErrorMessage/ErrorMessage.jsx'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { ComponentContext } from '~/src/reducers/component/componentReducer.jsx'
 import { Fields, Options } from '~/src/reducers/component/types.js'
@@ -151,43 +150,6 @@ export function FieldEdit() {
       )}
       {hasInput && (
         <>
-          <div
-            className={classNames({
-              'govuk-form-group': true,
-              'govuk-form-group--error': errors.name
-            })}
-          >
-            <label className="govuk-label govuk-label--s" htmlFor="field-name">
-              {i18n('common.componentNameField.title')}
-            </label>
-            <div className="govuk-hint" id="field-name-hint">
-              {i18n('name.hint')}
-            </div>
-            {errors.name && (
-              <ErrorMessage id="field-name-error">
-                {errors.name.children}
-              </ErrorMessage>
-            )}
-            <input
-              className={classNames({
-                'govuk-input govuk-input--width-20': true,
-                'govuk-input--error': errors.name
-              })}
-              id="field-name"
-              aria-describedby={
-                'field-name-hint' + (errors.name ? 'field-name-error' : '')
-              }
-              name="name"
-              type="text"
-              value={selectedComponent.name}
-              onChange={(e) => {
-                dispatch({
-                  name: Fields.EDIT_NAME,
-                  payload: e.target.value
-                })
-              }}
-            />
-          </div>
           <div className="govuk-checkboxes govuk-form-group">
             <div className="govuk-checkboxes__item">
               <input

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -53,10 +53,6 @@
       "helpText": "Apply CSS classes to this field. For example, ‘govuk-input govuk-!-width-full’",
       "title": "Classes"
     },
-    "componentNameField": {
-      "helpText": "This is generated automatically and does not show on the page. Only change it if you are using an integration that requires you to, for example GOV.UK Notify. It must not contain spaces.",
-      "title": "Component name"
-    },
     "componentOptionalOption": {
       "helpText": "Tick this box if users do not need to complete this field to progress through the form",
       "title": "Make {{component, lowerFirst}} optional"

--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -379,10 +379,6 @@
     "editHeader": {
       "title": "Edit sections"
     },
-    "nameField": {
-      "helpText": "Automatically populated. It does not show on the page. You usually do not need to change it unless an integration requires it. It must not contain spaces.",
-      "title": "Section name"
-    },
     "titleField": {
       "helpText": "Appears above the page title. However, if these titles are the same, the form will only show the page title.",
       "title": "Section title"

--- a/designer/client/src/reducers/component/componentReducer.fields.ts
+++ b/designer/client/src/reducers/component/componentReducer.fields.ts
@@ -8,11 +8,6 @@ import { Fields } from '~/src/reducers/component/types.js'
 
 export type FieldsReducerActions =
   | {
-      name: Fields.EDIT_NAME
-      payload: string
-      as?: undefined
-    }
-  | {
       name: Fields.EDIT_TITLE
       payload: string
       as: Extract<ComponentDef, { title: string }>
@@ -48,10 +43,6 @@ export function fieldsReducer(state: ComponentState, action: ReducerActions) {
   stateNew.hasValidated = false
 
   switch (name) {
-    case Fields.EDIT_NAME:
-      selectedComponent.name = payload
-      break
-
     case Fields.EDIT_TITLE: {
       if (type === as.type) {
         selectedComponent.title = payload

--- a/designer/client/src/reducers/component/componentReducer.test.tsx
+++ b/designer/client/src/reducers/component/componentReducer.test.tsx
@@ -74,14 +74,12 @@ describe('Component reducer', () => {
     }
 
     const state: ComponentState = {
-      initialName: component1.name,
       selectedComponent: component1,
       hasValidated: true,
       errors: {}
     }
 
     expect(componentReducer(state, action)).toEqual({
-      initialName: component1.name,
       selectedComponent: { ...component1, title },
       errors: expect.any(Object),
       hasValidated: false
@@ -95,14 +93,12 @@ describe('Component reducer', () => {
     }
 
     const state: ComponentState = {
-      initialName: component1.name,
       selectedComponent: component1,
       hasValidated: false,
       errors: {}
     }
 
     expect(componentReducer(state, action)).toEqual({
-      initialName: component1.name,
       selectedComponent: component1,
       errors: expect.any(Object),
       hasValidated: true

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -39,7 +39,7 @@ export interface ComponentState {
   selectedComponent?: ComponentDef
   hasValidated?: boolean
   showDeleteWarning?: boolean
-  errors: Partial<ErrorList<'title' | 'name' | 'content' | 'list'>>
+  errors: Partial<ErrorList<'title' | 'content' | 'list'>>
 }
 
 export type ReducerActions =

--- a/designer/client/src/reducers/component/componentReducer.tsx
+++ b/designer/client/src/reducers/component/componentReducer.tsx
@@ -9,7 +9,6 @@ import {
 
 import { type ErrorList } from '~/src/ErrorSummary.jsx'
 import { logger } from '~/src/common/helpers/logging/logger.js'
-import randomId from '~/src/randomId.js'
 import {
   fieldsReducer,
   type FieldsReducerActions
@@ -35,7 +34,6 @@ import {
 } from '~/src/reducers/component/types.js'
 
 export interface ComponentState {
-  initialName: string
   selectedComponent?: ComponentDef
   hasValidated?: boolean
   showDeleteWarning?: boolean
@@ -104,12 +102,9 @@ export function componentReducer(
 }
 
 export function initComponentState(
-  props?: Readonly<Partial<Omit<ComponentState, 'initialName'>>>
+  props?: Readonly<Partial<ComponentState>>
 ): ComponentState {
-  const { selectedComponent } = props ?? {}
-
   return {
-    initialName: selectedComponent?.name ?? randomId(),
     errors: {},
     ...props
   }

--- a/designer/client/src/reducers/component/componentReducer.validations.ts
+++ b/designer/client/src/reducers/component/componentReducer.validations.ts
@@ -1,5 +1,4 @@
 import {
-  hasContent,
   hasContentField,
   hasListField,
   hasTitle,
@@ -9,7 +8,7 @@ import { type Root } from 'joi'
 
 import { i18n } from '~/src/i18n/i18n.jsx'
 import { type ComponentState } from '~/src/reducers/component/componentReducer.jsx'
-import { validateName, validateRequired } from '~/src/validations.js'
+import { validateRequired } from '~/src/validations.js'
 
 export function fieldComponentValidations(
   component: ComponentDef | undefined,
@@ -20,13 +19,6 @@ export function fieldComponentValidations(
   if (hasTitle(component)) {
     errors.title = validateRequired('field-title', component.title, {
       label: i18n('common.titleField.title'),
-      schema
-    })
-  }
-
-  if (!hasContent(component)) {
-    errors.name = validateName('field-name', component?.name, {
-      label: i18n('common.componentNameField.title'),
       schema
     })
   }

--- a/designer/client/src/reducers/component/types.ts
+++ b/designer/client/src/reducers/component/types.ts
@@ -24,7 +24,6 @@ export enum Schema {
  */
 export enum Fields {
   EDIT_TITLE = 'EDIT_TITLE',
-  EDIT_NAME = 'EDIT_NAME',
   EDIT_HELP = 'EDIT_HELP',
   EDIT_CONTENT = 'EDIT_CONTENT',
   EDIT_LIST = 'EDIT_LIST'

--- a/designer/client/src/section/SectionEdit.test.tsx
+++ b/designer/client/src/section/SectionEdit.test.tsx
@@ -5,27 +5,19 @@ import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 import { RenderWithContext } from '~/test/helpers/renderers.jsx'
 
 describe('Section edit fields', () => {
-  test('should display titles and help texts', () => {
+  it('should display title and hint text', () => {
     render(
       <RenderWithContext>
         <SectionEdit onSave={jest.fn()} />
       </RenderWithContext>
     )
 
-    const $sectionTitleLabel = screen.getByText('Section title')
-    const $sectionTitleContent = screen.getByText(
-      'Appears above the page title. However, if these titles are the same, the form will only show the page title.'
-    )
+    const $sectionTitle = screen.getByRole('textbox', {
+      name: 'Section title',
+      description:
+        'Appears above the page title. However, if these titles are the same, the form will only show the page title.'
+    })
 
-    expect($sectionTitleLabel).toBeInTheDocument()
-    expect($sectionTitleContent).toBeInTheDocument()
-
-    const $sectionNameLabel = screen.getByText('Section name')
-    const $sectionNameContent = screen.getByText(
-      'Automatically populated. It does not show on the page. You usually do not need to change it unless an integration requires it. It must not contain spaces.'
-    )
-
-    expect($sectionNameLabel).toBeInTheDocument()
-    expect($sectionNameContent).toBeInTheDocument()
+    expect($sectionTitle).toBeInTheDocument()
   })
 })

--- a/designer/client/src/section/SectionsEdit.tsx
+++ b/designer/client/src/section/SectionsEdit.tsx
@@ -1,4 +1,3 @@
-import { type Section } from '@defra/forms-model'
 import { Component, type ContextType, type MouseEvent } from 'react'
 
 import { Flyout } from '~/src/components/Flyout/Flyout.jsx'
@@ -11,8 +10,8 @@ import { SectionEdit } from '~/src/section/SectionEdit.jsx'
 type Props = Record<string, never>
 
 interface State {
+  selectedSection?: string
   isEditingSection?: boolean
-  section?: Section
 }
 
 export class SectionsEdit extends Component<Props, State> {
@@ -21,30 +20,33 @@ export class SectionsEdit extends Component<Props, State> {
 
   state: State = {}
 
-  onClickSection = (e: MouseEvent, section?: Section) => {
+  onClickSection = (e: MouseEvent, selectedSection?: string) => {
     e.preventDefault()
 
     this.setState({
-      section,
+      selectedSection,
       isEditingSection: true
     })
   }
 
   closeFlyout = (sectionName?: string) => {
-    const { data } = this.context
-    const { section } = this.state
-
     this.setState({
-      isEditingSection: false,
-      section: sectionName ? findSection(data, sectionName) : section
+      selectedSection: sectionName,
+      isEditingSection: false
     })
   }
 
   render() {
     const { data } = this.context
-    const { section, isEditingSection } = this.state
+    const { selectedSection, isEditingSection } = this.state
 
     const { sections } = data
+
+    // Find section by name
+    const section =
+      isEditingSection && selectedSection
+        ? findSection(data, selectedSection)
+        : undefined
 
     return (
       <>
@@ -54,7 +56,7 @@ export class SectionsEdit extends Component<Props, State> {
               <a
                 className="govuk-link"
                 href="#section-edit"
-                onClick={(e) => this.onClickSection(e, section)}
+                onClick={(e) => this.onClickSection(e, section.name)}
               >
                 {section.title}
               </a>
@@ -77,7 +79,7 @@ export class SectionsEdit extends Component<Props, State> {
             <Flyout
               id="section-edit"
               title={
-                section?.title
+                section
                   ? i18n('section.editTitle', { title: section.title })
                   : i18n('section.add')
               }

--- a/designer/client/src/validations.ts
+++ b/designer/client/src/validations.ts
@@ -47,26 +47,6 @@ export const validateRequired: Validator<string> = (id, value, options) => {
   })
 }
 
-/**
- * No spaces validator
- */
-export const validateNoSpaces: Validator<string> = (id, value, options) => {
-  const { label, message, schema } = options
-
-  return validateCustom(id, value, {
-    label,
-    message: message ?? 'errors.spaces',
-    schema: schema.string().regex(/\s/, { invert: true }).required()
-  })
-}
-
-/**
- * Auto populated name validator
- */
-export const validateName: Validator<string> = (...args) => {
-  return validateRequired(...args) ?? validateNoSpaces(...args)
-}
-
 type Validator<
   ValueType extends ValidatorValue,
   OptionsType = {


### PR DESCRIPTION
This PR removes editor support for the generated "name" field from components and sections

I've also removed all unnecessary state where `initialName` or `section` was held for comparison

<img width="544" alt="Generated name field" src="https://github.com/user-attachments/assets/d0f09bb2-4669-4b9b-a05a-e8ccc3e6563e">
