### PR TITLE
Add validation for duplicate condition, section and list titles

### DIFF
--- a/designer/client/src/i18n/translations/en.translation.json
+++ b/designer/client/src/i18n/translations/en.translation.json
@@ -116,7 +116,6 @@
     "displayName": "Display name",
     "displayNameHint": "Set a condition name that is easy to recognise. It appears as an option in the settings menus for the pages, components and links in a form.",
     "edit": "Edit condition",
-    "enterName": "Enter Name",
     "hint": "Set conditions for components and links to control the flow of a form. For example, a question page with a component for yes and no options could have link conditions based on which option a user selects.",
     "noFieldsAvailable": "You cannot add a condition as no components are available. Create a component on a page in the form. You can then add a condition.",
     "optional": "Conditions (optional)",

--- a/designer/client/src/list/ListEdit.tsx
+++ b/designer/client/src/list/ListEdit.tsx
@@ -38,7 +38,7 @@ function useListEdit() {
   const { data, save } = useContext(DataContext)
   const { state: listState, dispatch: listDispatch } = useContext(ListContext)
 
-  const { selectedList } = listState
+  const { initialTitle, selectedList } = listState
 
   function handleAddItem(e: MouseEvent<HTMLButtonElement>) {
     e.preventDefault()
@@ -88,10 +88,24 @@ function useListEdit() {
 
     const errors: ListState['errors'] = {}
 
+    const titles = data.lists
+      .filter(({ title }) => title !== initialTitle)
+      .map(({ title }) => title)
+
     errors.title = validateRequired('list-title', selectedList?.title, {
       label: i18n('list.title'),
       schema
     })
+
+    errors.title ??= validateCustom(
+      'list-title',
+      [...titles, selectedList?.title],
+      {
+        message: 'errors.duplicate',
+        label: i18n('list.title'),
+        schema: schema.array().unique()
+      }
+    )
 
     errors.listItems = validateCustom('list-items', selectedList?.items, {
       message: 'list.errors.empty',

--- a/designer/client/src/section/SectionEdit.tsx
+++ b/designer/client/src/section/SectionEdit.tsx
@@ -18,7 +18,11 @@ import { removeSection } from '~/src/data/section/removeSection.js'
 import { updateSection } from '~/src/data/section/updateSection.js'
 import { i18n } from '~/src/i18n/i18n.jsx'
 import randomId from '~/src/randomId.js'
-import { validateRequired, hasValidationErrors } from '~/src/validations.js'
+import {
+  hasValidationErrors,
+  validateCustom,
+  validateRequired
+} from '~/src/validations.js'
 
 interface Props {
   section?: Section
@@ -100,14 +104,29 @@ export class SectionEdit extends Component<Props, State> {
   }
 
   validate = (payload: Partial<Form>, schema: Root): payload is Form => {
-    const { title } = payload
+    const { data } = this.context
+    const { section } = this.props
 
     const errors: State['errors'] = {}
 
-    errors.title = validateRequired('section-title', title, {
+    const titles = data.sections
+      .filter(({ title }) => title !== section?.title)
+      .map(({ title }) => title)
+
+    errors.title = validateRequired('section-title', payload.title, {
       label: i18n('sectionEdit.titleField.title'),
       schema
     })
+
+    errors.title ??= validateCustom(
+      'section-title',
+      [...titles, payload.title],
+      {
+        message: 'errors.duplicate',
+        label: i18n('sectionEdit.titleField.title'),
+        schema: schema.array().unique()
+      }
+    )
 
     this.setState({ errors })
     return !hasValidationErrors(errors)

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -206,6 +206,7 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
     sections: Joi.array<Section>()
       .items(sectionsSchema)
       .unique('name')
+      .unique('title')
       .required(),
     conditions: Joi.array<ConditionWrapper>()
       .items(conditionWrapperSchema)

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -210,7 +210,7 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
     conditions: Joi.array<ConditionWrapper>()
       .items(conditionWrapperSchema)
       .unique('name'),
-    lists: Joi.array<List>().items(listSchema).unique('name'),
+    lists: Joi.array<List>().items(listSchema).unique('name').unique('title'),
     metadata: Joi.object({ a: Joi.any() }).unknown().optional(),
     declaration: Joi.string().allow('').optional(),
     skipSummary: Joi.boolean().optional().default(false),

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -209,7 +209,8 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
       .required(),
     conditions: Joi.array<ConditionWrapper>()
       .items(conditionWrapperSchema)
-      .unique('name'),
+      .unique('name')
+      .unique('displayName'),
     lists: Joi.array<List>().items(listSchema).unique('name').unique('title'),
     metadata: Joi.object({ a: Joi.any() }).unknown().optional(),
     declaration: Joi.string().allow('').optional(),

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -130,7 +130,7 @@ const pageSchema = Joi.object<Page>().keys({
   title: Joi.string().allow(''),
   section: Joi.string(),
   controller: Joi.string().optional(),
-  components: Joi.array<ComponentDef>().items(componentSchema),
+  components: Joi.array<ComponentDef>().items(componentSchema).unique('name'),
   next: Joi.array<Link>().items(nextSchema)
 })
 

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -92,8 +92,8 @@ const conditionWrapperSchema = Joi.object<ConditionWrapper>().keys({
 export const componentSchema = Joi.object<ComponentDef>()
   .keys({
     type: Joi.string<ComponentType>().required(),
-    name: Joi.string(),
-    title: Joi.string().allow(''),
+    name: Joi.string().required(),
+    title: Joi.string().required(),
     hint: Joi.string().allow('').optional(),
     options: Joi.object({
       rows: Joi.number().empty(''),
@@ -127,7 +127,7 @@ const nextSchema = Joi.object<Link>().keys({
  */
 const pageSchema = Joi.object<Page>().keys({
   path: Joi.string().required().disallow('/status'),
-  title: Joi.string().allow(''),
+  title: Joi.string().required(),
   section: Joi.string(),
   controller: Joi.string().optional(),
   components: Joi.array<ComponentDef>().items(componentSchema).unique('name'),
@@ -158,7 +158,7 @@ const numberListItemSchema = baseListItemSchema.append({
 
 const listSchema = Joi.object<List>().keys({
   name: Joi.string().required(),
-  title: Joi.string().allow(''),
+  title: Joi.string().required(),
   type: Joi.string().required().valid('string', 'number'),
   items: Joi.when('type', {
     is: 'string',


### PR DESCRIPTION
This PR adds missing editor validation for:

1. Duplicate condition display name
2. Duplicate section title
3. Duplicate list title

The corresponding schema have also been updated

<img width="540" alt="Duplicate check error message" src="https://github.com/user-attachments/assets/dfe32aae-4db7-4c8d-ae54-758383fd829b">
