### PR TITLE
Consolidate helper `isLinkablePage()` into `hasNext()`

### DIFF
--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -41,7 +41,7 @@ export function getPageDefaults<PageType extends Page>(
 export function hasComponents(
   page?: Partial<Page>
 ): page is Extract<Page, { components: ComponentDef[] }> {
-  return isLinkablePage(page) && Array.isArray(page.components)
+  return hasNext(page) && Array.isArray(page.components)
 }
 
 /**
@@ -50,7 +50,7 @@ export function hasComponents(
 export function hasFormComponents(
   page?: Partial<Page>
 ): page is Extract<Page, { components: ComponentDef[] }> {
-  return isLinkablePage(page) && Array.isArray(page.components)
+  return hasNext(page) && Array.isArray(page.components)
 }
 
 /**
@@ -62,14 +62,7 @@ export function hasSection(
   | RequiredField<PageStart, 'section'>
   | RequiredField<PageQuestion, 'section'>
   | RequiredField<PageFileUpload, 'section'> {
-  return isLinkablePage(page) && typeof page.section === 'string'
-}
-
-/**
- * Check page has next link
- */
-export function hasNext(page?: Partial<Page>) {
-  return isLinkablePage(page)
+  return hasNext(page) && typeof page.section === 'string'
 }
 
 /**
@@ -82,9 +75,9 @@ export function isControllerName(
 }
 
 /**
- * Check page is linkable
+ * Check page has next link
  */
-export function isLinkablePage(
+export function hasNext(
   page?: Partial<Page>
 ): page is Extract<Page, { next: Link[] }> {
   if (!page || !('next' in page)) {

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -18,18 +18,17 @@ import { PageTypes } from '~/src/pages/page-types.js'
  * Return component defaults by type
  */
 export function getPageDefaults<PageType extends Page>(
-  page: Pick<PageType, 'controller'>
+  page?: Pick<PageType, 'controller'>
 ) {
-  const controller = controllerNameFromPath(
-    page.controller ?? ControllerType.Page
-  )
+  const nameOrPath = page?.controller ?? ControllerType.Page
+  const controller = controllerNameFromPath(nameOrPath)
 
   const defaults = PageTypes.find(
     (pageType) => pageType.controller === controller
   )
 
   if (!defaults) {
-    throw new Error(`Defaults not found for page type '${page.controller}'`)
+    throw new Error(`Defaults not found for page type '${nameOrPath}'`)
   }
 
   return structuredClone(defaults) as PageType
@@ -57,7 +56,7 @@ export function hasFormComponents(
  * Check page has sections
  */
 export function hasSection(
-  page: Partial<Page>
+  page?: Partial<Page>
 ): page is
   | RequiredField<PageStart, 'section'>
   | RequiredField<PageQuestion, 'section'>

--- a/model/src/pages/index.ts
+++ b/model/src/pages/index.ts
@@ -13,7 +13,6 @@ export {
   hasSection,
   hasNext,
   isControllerName,
-  isLinkablePage,
   isQuestionPage
 } from '~/src/pages/helpers.js'
 


### PR DESCRIPTION
This PR makes some `@defra/forms-model` changes to test out https://github.com/DEFRA/forms-designer/pull/523

1. Consolidate helper `isLinkablePage()` into `hasNext()`
2. Make `page` param optional in `getPageDefaults()` and `hasSection()` for consistency
