### PR TITLE
Add missing `environment: production` to npm publish job

### DIFF
--- a/.github/workflows/publish-model.yml
+++ b/.github/workflows/publish-model.yml
@@ -60,6 +60,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: [build]
+    environment: production
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Quick fix to add `environment: production` missed from https://github.com/DEFRA/forms-designer/pull/523

