### PR TITLE
Add Sonar generic test execution report + coverage

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -82,16 +82,23 @@ jobs:
 
         task:
           - description: Prettier
+            name: lint-prettier
             run: npm run format:check
+            cache: .cache/prettier
 
           - description: EditorConfig
+            name: lint-editorconfig
             run: npm run lint:editorconfig
 
           - description: ESLint
+            name: lint-js
             run: npm run lint:js
+            cache: .cache/eslint
 
           - description: TypeScript compiler
-            run: npm run lint:types
+            name: lint-types
+            run: npm run lint:types -- --incremental --pretty
+            cache: '**/*.tsbuildinfo'
 
     steps:
       - name: Checkout
@@ -118,6 +125,15 @@ jobs:
             designer/client/dist
             designer/server/dist
             model/dist
+
+      - name: Cache task
+        if: ${{ matrix.task.cache }}
+        uses: actions/cache@v4
+        with:
+          enableCrossOsArchive: true
+          save-always: true
+          key: ${{ matrix.task.name }}-${{ runner.os }}
+          path: ${{ matrix.task.cache }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -101,6 +101,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
           key: npm-install-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           path: |
             designer/node_modules
@@ -111,6 +112,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
           key: npm-build-${{ runner.os }}-${{ github.sha }}
           path: |
             designer/client/dist
@@ -151,6 +153,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
           key: npm-install-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           path: |
             designer/node_modules
@@ -161,6 +164,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
           key: npm-build-${{ runner.os }}-${{ github.sha }}
           path: |
             designer/client/dist
@@ -208,6 +212,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
           key: test-unit-${{ runner.os }}
           path: coverage
 

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -177,6 +177,7 @@ jobs:
         uses: actions/cache@v4
         with:
           enableCrossOsArchive: true
+          save-always: true
           key: ${{ matrix.task.name }}-${{ runner.os }}
           path: ${{ matrix.task.cache }}
 
@@ -184,6 +185,7 @@ jobs:
         run: ${{ matrix.task.run }}
 
       - name: Save test coverage
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4.4.0
         with:
           name: ${{ matrix.task.description }} coverage (${{ matrix.runner }})
@@ -192,6 +194,7 @@ jobs:
 
   analysis:
     name: Analysis
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [build, tasks]
 

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -183,6 +183,13 @@ jobs:
       - name: Run task
         run: ${{ matrix.task.run }}
 
+      - name: Save test coverage
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: ${{ matrix.task.description }} coverage (${{ matrix.runner }})
+          path: coverage
+          if-no-files-found: ignore
+
   analysis:
     name: Analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -159,7 +159,9 @@ jobs:
           - description: Unit tests
             name: test-unit
             run: npm run test
-            cache: coverage
+            cache: |
+              coverage
+              report.xml
 
     steps:
       - name: Checkout
@@ -230,7 +232,9 @@ jobs:
           enableCrossOsArchive: true
           fail-on-cache-miss: true
           key: test-unit-${{ runner.os }}
-          path: coverage
+          path: |
+            coverage
+            report.xml
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3.0.0

--- a/.github/workflows/publish-model.yml
+++ b/.github/workflows/publish-model.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
           key: npm-install-model-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           path: |
             model/node_modules
@@ -82,6 +83,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           enableCrossOsArchive: true
+          fail-on-cache-miss: true
           key: npm-build-model-${{ runner.os }}-${{ github.sha }}
           path: model/dist
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,7 @@ node_modules
 npm-debug.log
 coverage
 .cache
-report.html
-report.json
-unit-test.html
+report.xml
 /dist/
 */dist/
 

--- a/designer/babel.config.cjs
+++ b/designer/babel.config.cjs
@@ -53,8 +53,7 @@ module.exports = {
               '.js': ''
             }
           }
-        ],
-        'babel-plugin-transform-import-meta'
+        ]
       ]
     }
   }

--- a/designer/client/babel.config.cjs
+++ b/designer/client/babel.config.cjs
@@ -72,8 +72,7 @@ module.exports = {
               '.jsx': ''
             }
           }
-        ],
-        'babel-plugin-transform-import-meta'
+        ]
       ]
     }
   }

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ export const projectDefaults = {
     '^.+\\.(cjs|js|jsx|mjs|ts|tsx)$': [
       'babel-jest',
       {
+        browserslistEnv: 'node',
         plugins: ['transform-import-meta'],
         rootMode: 'upward'
       }

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@
  * @type {Partial<Config>}
  */
 export const defaults = {
+  coverageProvider: 'v8',
   maxWorkers: '50%',
   reporters: ['default', ['github-actions', { silent: false }], 'summary'],
   silent: true

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,8 +15,13 @@ export const defaults = {
 export const projectDefaults = {
   extensionsToTreatAsEsm: ['.jsx', '.ts', '.tsx'],
   clearMocks: true,
+  collectCoverageFrom: ['<rootDir>/src/**/*.{cjs,js,jsx,mjs,ts,tsx}'],
   coverageDirectory: '<rootDir>/coverage',
-  coveragePathIgnorePatterns: ['<rootDir>/test/', '<rootDir>/dist/'],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    '<rootDir>/dist/',
+    '<rootDir>/test/'
+  ],
   modulePathIgnorePatterns: ['<rootDir>/coverage/', '<rootDir>/dist/'],
   resetModules: true,
   restoreMocks: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,6 +24,7 @@ export const projectDefaults = {
     '^.+\\.(cjs|js|jsx|mjs|ts|tsx)$': [
       'babel-jest',
       {
+        plugins: ['transform-import-meta'],
         rootMode: 'upward'
       }
     ]

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+const { CI } = process.env
+
 /**
  * Jest config defaults
  * @type {Partial<Config>}
@@ -5,7 +7,25 @@
 export const defaults = {
   coverageProvider: 'v8',
   maxWorkers: '50%',
-  reporters: ['default', ['github-actions', { silent: false }], 'summary'],
+  reporters: CI
+    ? [
+        [
+          'github-actions',
+          {
+            silent: false
+          }
+        ],
+        [
+          '@casualbot/jest-sonar-reporter',
+          {
+            outputName: 'report.xml',
+            suiteName: 'forms-designer',
+            relativePaths: true
+          }
+        ],
+        'summary'
+      ]
+    : ['default', 'summary'],
   silent: true
 }
 

--- a/model/babel.config.cjs
+++ b/model/babel.config.cjs
@@ -52,8 +52,7 @@ module.exports = {
               '.js': ''
             }
           }
-        ],
-        'babel-plugin-transform-import-meta'
+        ]
       ]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@babel/core": "^7.25.7",
         "@babel/preset-env": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
+        "@casualbot/jest-sonar-reporter": "^2.4.0",
         "@types/eslint": "^8.56.12",
         "@types/jest": "^29.5.13",
         "@types/node": "^22.7.4",
@@ -2140,6 +2141,21 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.1.0.tgz",
       "integrity": "sha512-+2Mx67Y3skJ4NCD/qNSdBJNWtu6x6Qr53jeNg+QcwiL6mt0wK+3jwHH2x1p7xaYH6Ve2JKOVn0OxU35WsmqI9A==",
       "dev": true
+    },
+    "node_modules/@casualbot/jest-sonar-reporter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@casualbot/jest-sonar-reporter/-/jest-sonar-reporter-2.4.0.tgz",
+      "integrity": "sha512-RTLup4WsQsLDlJYb01IjW2rMGcVq9F732VME2Qs1MxEgYaBcNZoI10ac+DwNOb8Rd3vP/ghrVZMoalMyn6isBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "1.0.4",
+        "uuid": "8.3.2",
+        "xml": "1.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -13922,6 +13938,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -14034,17 +14063,6 @@
         "shellwords": "^0.1.1",
         "uuid": "^8.3.0",
         "which": "^2.0.2"
-      }
-    },
-    "node_modules/node-notifier/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-releases": {
@@ -18209,6 +18227,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -18804,6 +18832,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/core": "^7.25.7",
     "@babel/preset-env": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
+    "@casualbot/jest-sonar-reporter": "^2.4.0",
     "@types/eslint": "^8.56.12",
     "@types/jest": "^29.5.13",
     "@types/node": "^22.7.4",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.links.scm=https://github.com/DEFRA/forms-designer
 sonar.links.issue=https://github.com/DEFRA/forms-designer/issues
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.testExecutionReportPaths=report.xml
 sonar.sourceEncoding=UTF-8
 
 sonar.sources=designer/client/src,designer/server/src,model/src


### PR DESCRIPTION
This PR outputs [Sonar generic test execution report](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/test-coverage/generic-test-data/#generic-test-execution) XML and adds lint task caching

It also switches to the [Jest `v8` coverage provider](https://jestjs.io/docs/configuration#coverageprovider-string) and adjusts Babel output to make minimal transforms