### PR TITLE
Fix Sonar code coverage not updating

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -159,9 +159,7 @@ jobs:
           - description: Unit tests
             name: test-unit
             run: npm run test
-            cache: |
-              coverage
-              report.xml
+            cache: coverage
 
     steps:
       - name: Checkout
@@ -232,9 +230,7 @@ jobs:
           enableCrossOsArchive: true
           fail-on-cache-miss: true
           key: test-unit-${{ runner.os }}
-          path: |
-            coverage
-            report.xml
+          path: coverage
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@v3.0.0

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -198,7 +198,7 @@ jobs:
         with:
           enableCrossOsArchive: true
           save-always: true
-          key: ${{ matrix.task.name }}-${{ runner.os }}
+          key: ${{ matrix.task.name }}-${{ runner.os }}-${{ github.sha }}
           path: ${{ matrix.task.cache }}
 
       - name: Run task
@@ -229,7 +229,7 @@ jobs:
         with:
           enableCrossOsArchive: true
           fail-on-cache-miss: true
-          key: test-unit-${{ runner.os }}
+          key: test-unit-${{ runner.os }}-${{ github.sha }}
           path: coverage
 
       - name: SonarCloud Scan

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ node_modules
 npm-debug.log
 coverage
 .cache
-report.xml
 /dist/
 */dist/
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,6 @@ const { CI } = process.env
  * @type {Partial<Config>}
  */
 export const defaults = {
-  coverageProvider: 'v8',
   maxWorkers: '50%',
   reporters: CI
     ? [

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,23 +7,7 @@ const { CI } = process.env
 export const defaults = {
   maxWorkers: '50%',
   reporters: CI
-    ? [
-        [
-          'github-actions',
-          {
-            silent: false
-          }
-        ],
-        [
-          '@casualbot/jest-sonar-reporter',
-          {
-            outputName: 'report.xml',
-            suiteName: 'forms-designer',
-            relativePaths: true
-          }
-        ],
-        'summary'
-      ]
+    ? [['github-actions', { silent: false }], 'summary']
     : ['default', 'summary'],
   silent: true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@babel/core": "^7.25.7",
         "@babel/preset-env": "^7.25.7",
         "@babel/preset-typescript": "^7.25.7",
-        "@casualbot/jest-sonar-reporter": "^2.4.0",
         "@types/eslint": "^8.56.12",
         "@types/jest": "^29.5.13",
         "@types/node": "^22.7.4",
@@ -2141,21 +2140,6 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.1.0.tgz",
       "integrity": "sha512-+2Mx67Y3skJ4NCD/qNSdBJNWtu6x6Qr53jeNg+QcwiL6mt0wK+3jwHH2x1p7xaYH6Ve2JKOVn0OxU35WsmqI9A==",
       "dev": true
-    },
-    "node_modules/@casualbot/jest-sonar-reporter": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@casualbot/jest-sonar-reporter/-/jest-sonar-reporter-2.4.0.tgz",
-      "integrity": "sha512-RTLup4WsQsLDlJYb01IjW2rMGcVq9F732VME2Qs1MxEgYaBcNZoI10ac+DwNOb8Rd3vP/ghrVZMoalMyn6isBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "1.0.4",
-        "uuid": "8.3.2",
-        "xml": "1.0.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -13938,19 +13922,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -18233,6 +18204,8 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -18832,13 +18805,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@babel/core": "^7.25.7",
     "@babel/preset-env": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
-    "@casualbot/jest-sonar-reporter": "^2.4.0",
     "@types/eslint": "^8.56.12",
     "@types/jest": "^29.5.13",
     "@types/node": "^22.7.4",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,6 @@ sonar.links.scm=https://github.com/DEFRA/forms-designer
 sonar.links.issue=https://github.com/DEFRA/forms-designer/issues
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.testExecutionReportPaths=report.xml
 sonar.sourceEncoding=UTF-8
 
 sonar.sources=designer/client/src,designer/server/src,model/src


### PR DESCRIPTION
This PR includes three changes:

1. Switching back to Babel + Istanbul code coverage to fix missing coverage for type imports
2. Cache the jest code coverage against `github.sha` to ensure timestamps change per commit
3. Remove the generic test execution `report.xml` added in [#534](https://github.com/DEFRA/forms-designer/pull/534) as SonarCloud isn't using it

Whilst debugging 1) the coverage was updating but perhaps Sonar looks at the parent directory timestamp?

Creating the coverage report from scratch (versus overwriting each time) seems to solve the problem