### PR TITLE
Prevent GOV.UK Frontend “already initialised” Tabs error

### DIFF
--- a/designer/client/src/components/Tabs/Tabs.tsx
+++ b/designer/client/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import { Tabs as TabsJS } from 'govuk-frontend'
-import { useEffect, useRef, type ComponentProps } from 'react'
+import { useEffect, useRef, useState, type ComponentProps } from 'react'
 
 interface Props extends ComponentProps<'div'> {
   idPrefix?: string
@@ -18,14 +18,14 @@ export function Tabs(props: Readonly<Props>) {
   title ??= 'Contents'
 
   const tabsRef = useRef<HTMLDivElement>(null)
+  const [instance, setInstance] = useState<TabsJS>()
 
   useEffect(() => {
-    if (tabsRef.current) {
-      // eslint-disable-next-line no-new
-      new TabsJS(tabsRef.current)
+    if (!instance && tabsRef.current) {
+      setInstance(new TabsJS(tabsRef.current))
       onInit?.()
     }
-  }, [tabsRef, onInit])
+  }, [instance, tabsRef, onInit])
 
   const tabContent = items.map((item, index) => {
     const { id, label, panel, ...linkAttributes } = item


### PR DESCRIPTION
This PR fixes [bug #466616](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/466616)

We were accidentally double-rendering the GOV.UK Frontend [**Tabs** component](https://design-system.service.gov.uk/components/tabs/)

This is now thrown by [`govuk-frontend@5.7.0`](https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.0) since https://github.com/alphagov/govuk-frontend/pull/5272