### PR TITLE
Remove unused “Skip summary” feature

### DIFF
--- a/designer/client/src/DeclarationEdit.test.tsx
+++ b/designer/client/src/DeclarationEdit.test.tsx
@@ -1,0 +1,87 @@
+import { type FormDefinition } from '@defra/forms-model'
+import { screen } from '@testing-library/dom'
+import { render, type RenderResult } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+
+import { DeclarationEdit } from '~/src/DeclarationEdit.jsx'
+import { RenderWithContext } from '~/test/helpers/renderers.jsx'
+
+describe('Declaration Edit', () => {
+  let onSave: jest.Mock
+  let save: jest.Mock
+
+  let data: FormDefinition
+  let result: RenderResult
+
+  beforeEach(() => {
+    onSave = jest.fn()
+    save = jest.fn()
+
+    data = {
+      pages: [],
+      lists: [],
+      sections: [],
+      conditions: []
+    }
+
+    result = render(
+      <RenderWithContext data={data} save={save}>
+        <DeclarationEdit onSave={onSave} />
+      </RenderWithContext>
+    )
+  })
+
+  it('should render textarea', () => {
+    const $textarea = screen.getByRole('textbox', {
+      name: 'Declaration',
+      description:
+        'The declaration can include HTML and the `govuk-prose-scope` css class is available. Use this on a wrapping element to apply default govuk styles.'
+    })
+
+    expect($textarea).toBeInTheDocument()
+    expect($textarea).toHaveValue('')
+  })
+
+  it('should render textarea with existing declaration', () => {
+    result.unmount()
+
+    const updated = structuredClone(data)
+    updated.declaration = 'I do solemnly declare'
+
+    render(
+      <RenderWithContext data={updated} save={save}>
+        <DeclarationEdit onSave={onSave} />
+      </RenderWithContext>
+    )
+
+    const $textarea = screen.getByRole('textbox', { name: 'Declaration' })
+    expect($textarea).toHaveValue(updated.declaration)
+  })
+
+  it('should render save button', () => {
+    const $button = screen.getByRole('button', { name: 'Save' })
+    expect($button).toBeInTheDocument()
+  })
+
+  it('should save definition without empty declaration', async () => {
+    const $button = screen.getByRole('button', { name: 'Save' })
+    await userEvent.click($button)
+
+    expect(onSave).toHaveBeenCalled()
+    expect(save).toHaveBeenCalledWith(data)
+  })
+
+  it('should save definition without updated declaration', async () => {
+    const $textarea = screen.getByRole('textbox', { name: 'Declaration' })
+    const $button = screen.getByRole('button', { name: 'Save' })
+
+    await userEvent.type($textarea, 'I do solemnly declare')
+    await userEvent.click($button)
+
+    const updated = structuredClone(data)
+    updated.declaration = 'I do solemnly declare'
+
+    expect(onSave).toHaveBeenCalled()
+    expect(save).toHaveBeenCalledWith(updated)
+  })
+})

--- a/designer/client/src/DeclarationEdit.tsx
+++ b/designer/client/src/DeclarationEdit.tsx
@@ -24,7 +24,6 @@ export class DeclarationEdit extends Component<Props> {
     const formData = new window.FormData(e.currentTarget)
 
     definition.declaration = formData.get('declaration')?.toString()
-    definition.skipSummary = formData.get('skip-summary') === 'on'
 
     try {
       await save(definition)
@@ -36,42 +35,10 @@ export class DeclarationEdit extends Component<Props> {
 
   render() {
     const { data } = this.context
-    const { declaration, skipSummary } = data
+    const { declaration } = data
 
     return (
       <form onSubmit={this.onSubmit} autoComplete="off" noValidate>
-        <div className="govuk-form-group">
-          <fieldset
-            className="govuk-fieldset"
-            aria-describedby="skip-summary-hint"
-          >
-            <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">
-              Skip summary page?
-            </legend>
-            <div className="govuk-hint" id="skip-summary-hint">
-              The user will not be shown a summary page, and will continue to
-              pay and/or the application complete page.
-            </div>
-            <div className="govuk-radios" data-module="govuk-radios">
-              <div className="govuk-checkboxes__item">
-                <input
-                  className="govuk-checkboxes__input"
-                  id="skip-summary"
-                  name="skip-summary"
-                  type="checkbox"
-                  defaultChecked={skipSummary}
-                />
-                <label
-                  className="govuk-label govuk-checkboxes__label"
-                  htmlFor="skip-summary"
-                >
-                  Skip summary
-                </label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-
         <Textarea
           id="field-declaration"
           name="declaration"

--- a/designer/client/src/DeclarationEdit.tsx
+++ b/designer/client/src/DeclarationEdit.tsx
@@ -1,6 +1,11 @@
 // @ts-expect-error -- No types available
 import { Textarea } from '@xgovformbuilder/govuk-react-jsx'
-import { Component, type ContextType, type FormEvent } from 'react'
+import {
+  Component,
+  type ChangeEvent,
+  type ContextType,
+  type FormEvent
+} from 'react'
 
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import { DataContext } from '~/src/context/DataContext.js'
@@ -9,9 +14,23 @@ interface Props {
   onSave: () => void
 }
 
-export class DeclarationEdit extends Component<Props> {
+interface State {
+  declaration?: string
+}
+
+export class DeclarationEdit extends Component<Props, State> {
   declare context: ContextType<typeof DataContext>
   static readonly contextType = DataContext
+
+  state: State = {}
+
+  componentDidMount() {
+    const { data } = this.context
+
+    this.setState({
+      declaration: data.declaration
+    })
+  }
 
   onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -19,11 +38,10 @@ export class DeclarationEdit extends Component<Props> {
 
     const { onSave } = this.props
     const { save, data } = this.context
+    const { declaration } = this.state
 
     const definition = structuredClone(data)
-    const formData = new window.FormData(e.currentTarget)
-
-    definition.declaration = formData.get('declaration')?.toString()
+    definition.declaration = declaration
 
     try {
       await save(definition)
@@ -33,9 +51,16 @@ export class DeclarationEdit extends Component<Props> {
     }
   }
 
+  onChangeDeclaration = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const { value: declaration } = e.target
+
+    this.setState({
+      declaration: declaration || undefined
+    })
+  }
+
   render() {
-    const { data } = this.context
-    const { declaration } = data
+    const { declaration } = this.state
 
     return (
       <form onSubmit={this.onSubmit} autoComplete="off" noValidate>
@@ -56,7 +81,8 @@ export class DeclarationEdit extends Component<Props> {
               </>
             )
           }}
-          defaultValue={declaration}
+          value={declaration}
+          onChange={this.onChangeDeclaration}
         />
 
         <button className="govuk-button" type="submit">

--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -27,4 +27,18 @@ describe('Form definition schema', () => {
       expect(result.error).toBeUndefined()
     })
   })
+
+  describe('Summary', () => {
+    it("should remove legacy 'skipSummary' flag", () => {
+      // @ts-expect-error - Allow invalid property for test
+      definition.skipSummary = true
+
+      const result = formDefinitionSchema.validate(definition, {
+        abortEarly: false
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.value).not.toHaveProperty('skipSummary')
+    })
+  })
 })

--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -8,7 +8,6 @@ const baseConfiguration: FormDefinition = {
   lists: [],
   sections: [],
   conditions: [],
-  skipSummary: false,
   phaseBanner: {}
 }
 

--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -1,29 +1,30 @@
 import { formDefinitionSchema } from '~/src/form/form-definition/index.js'
 import { type FormDefinition } from '~/src/form/form-definition/types.js'
 
-const baseConfiguration: FormDefinition = {
-  metadata: {},
-  startPage: '/first-page',
-  pages: [],
-  lists: [],
-  sections: [],
-  conditions: [],
-  phaseBanner: {}
-}
+describe('Form definition schema', () => {
+  let definition: FormDefinition
 
-test('allows feedback URL to be an empty string when feedbackForm is false', () => {
-  const goodConfiguration = {
-    ...baseConfiguration,
-    feedback: {
-      feedbackForm: false,
-      url: ''
-    },
-    name: 'Schema fix 3'
-  }
-
-  const { error } = formDefinitionSchema.validate(goodConfiguration, {
-    abortEarly: false
+  beforeEach(() => {
+    definition = {
+      pages: [],
+      lists: [],
+      sections: [],
+      conditions: []
+    }
   })
 
-  expect(error).toBeUndefined()
+  describe('Feedback', () => {
+    it("should allow empty feedback URL when 'feedbackForm' is false", () => {
+      definition.feedback = {
+        feedbackForm: false,
+        url: ''
+      }
+
+      const result = formDefinitionSchema.validate(definition, {
+        abortEarly: false
+      })
+
+      expect(result.error).toBeUndefined()
+    })
+  })
 })

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -254,6 +254,7 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
     lists: Joi.array<List>().items(listSchema).unique('name').unique('title'),
     metadata: Joi.object({ a: Joi.any() }).unknown().optional(),
     declaration: Joi.string().allow('').optional(),
+    skipSummary: Joi.any().strip(),
     phaseBanner: phaseBannerSchema.optional(),
     outputEmail: Joi.string()
       .email({ tlds: { allow: ['uk'] } })

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -254,7 +254,6 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
     lists: Joi.array<List>().items(listSchema).unique('name').unique('title'),
     metadata: Joi.object({ a: Joi.any() }).unknown().optional(),
     declaration: Joi.string().allow('').optional(),
-    skipSummary: Joi.boolean().optional().default(false),
     phaseBanner: phaseBannerSchema.optional(),
     outputEmail: Joi.string()
       .email({ tlds: { allow: ['uk'] } })

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -142,6 +142,7 @@ export interface FormDefinition {
   feedback?: Feedback
   phaseBanner?: PhaseBanner
   declaration?: string
+  skipSummary?: never
   metadata?: Record<string, unknown>
   outputEmail?: string
 }

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -141,7 +141,6 @@ export interface FormDefinition {
   name?: string
   feedback?: Feedback
   phaseBanner?: PhaseBanner
-  skipSummary?: boolean
   declaration?: string
   metadata?: Record<string, unknown>
   outputEmail?: string


### PR DESCRIPTION
This PR removes the unused "Skip summary" feature which won't be part of upcoming design changes

See related PR in **forms-runner**

* https://github.com/DEFRA/forms-runner/pull/516