### PR TITLE
Add manual publish via `workflow_dispatch`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ on:
       - 'Dockerfile'
       - '!**/*.test.*'
 
+  workflow_dispatch:
+
 concurrency:
   group: publish
 


### PR DESCRIPTION
Adds manual "Run workflow" feature already added to:

* https://github.com/DEFRA/forms-manager/pull/340
* https://github.com/DEFRA/forms-runner/pull/455

This is so we can publish https://github.com/DEFRA/forms-designer/pull/584 without requiring source code changes