### PR TITLE
Bug(401603): Remove editor button when form is live

### DIFF
--- a/designer/server/src/models/forms/form-lifecycle.js
+++ b/designer/server/src/models/forms/form-lifecycle.js
@@ -11,7 +11,7 @@ export function confirmationPageViewModel(form, errorList) {
   const pageTitle = 'Are you sure you want to make the draft live?'
 
   const formPath = formOverviewPath(form.slug)
-  const navigation = getFormSpecificNavigation(formPath, '', form)
+  const navigation = getFormSpecificNavigation(formPath, form, '')
 
   return {
     navigation,

--- a/designer/server/src/models/forms/form-lifecycle.js
+++ b/designer/server/src/models/forms/form-lifecycle.js
@@ -11,7 +11,7 @@ export function confirmationPageViewModel(form, errorList) {
   const pageTitle = 'Are you sure you want to make the draft live?'
 
   const formPath = formOverviewPath(form.slug)
-  const navigation = getFormSpecificNavigation(formPath)
+  const navigation = getFormSpecificNavigation(formPath, '', form)
 
   return {
     navigation,

--- a/designer/server/src/models/forms/form-lifecycle.js
+++ b/designer/server/src/models/forms/form-lifecycle.js
@@ -11,7 +11,7 @@ export function confirmationPageViewModel(form, errorList) {
   const pageTitle = 'Are you sure you want to make the draft live?'
 
   const formPath = formOverviewPath(form.slug)
-  const navigation = getFormSpecificNavigation(formPath, form, '')
+  const navigation = getFormSpecificNavigation(formPath, form)
 
   return {
     navigation,

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -32,7 +32,7 @@ export function overviewViewModel(metadata, notification) {
   const pageTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
 
-  const navigation = getFormSpecificNavigation(formPath, 'Overview')
+  const navigation = getFormSpecificNavigation(formPath, 'Overview', metadata)
 
   return {
     backLink: formsLibraryBackLink,
@@ -90,7 +90,7 @@ export function editorViewModel(metadata, definition) {
   const pageTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
 
-  const navigation = getFormSpecificNavigation(formPath, 'Editor')
+  const navigation = getFormSpecificNavigation(formPath, 'Editor', metadata)
 
   return {
     backLink: formOverviewBackLink(metadata.slug),
@@ -111,13 +111,19 @@ export function editorViewModel(metadata, definition) {
  * a page, that page will have isActive:true set.
  * @param {string} formPath
  * @param {string} activePage
+ * @param {FormMetadata} metadata
  */
-export function getFormSpecificNavigation(formPath, activePage = '') {
-  return [
+export function getFormSpecificNavigation(formPath, activePage = '', metadata) {
+  const navigationItems = [
     ['Forms library', formsLibraryPath],
-    ['Overview', formPath],
-    ['Editor', `${formPath}/editor`]
-  ].map((item) =>
+    ['Overview', formPath]
+  ]
+
+  if (metadata.draft) {
+    navigationItems.push(['Editor', `${formPath}/editor`])
+  }
+
+  return navigationItems.map((item) =>
     buildEntry(item[0], item[1], { isActive: item[0] === activePage })
   )
 }

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -32,7 +32,7 @@ export function overviewViewModel(metadata, notification) {
   const pageTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
 
-  const navigation = getFormSpecificNavigation(formPath, 'Overview', metadata)
+  const navigation = getFormSpecificNavigation(formPath, metadata, 'Overview')
 
   return {
     backLink: formsLibraryBackLink,
@@ -90,7 +90,7 @@ export function editorViewModel(metadata, definition) {
   const pageTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
 
-  const navigation = getFormSpecificNavigation(formPath, 'Editor', metadata)
+  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
 
   return {
     backLink: formOverviewBackLink(metadata.slug),
@@ -113,7 +113,7 @@ export function editorViewModel(metadata, definition) {
  * @param {string} activePage
  * @param {FormMetadata} metadata
  */
-export function getFormSpecificNavigation(formPath, activePage = '', metadata) {
+export function getFormSpecificNavigation(formPath, metadata, activePage = '') {
   const navigationItems = [
     ['Forms library', formsLibraryPath],
     ['Overview', formPath]

--- a/designer/server/src/models/forms/library.test.js
+++ b/designer/server/src/models/forms/library.test.js
@@ -1,0 +1,274 @@
+import { buildEntry } from '~/src/common/nunjucks/context/build-navigation.js'
+import {
+  editorViewModel,
+  getFormSpecificNavigation,
+  overviewViewModel
+} from '~/src/models/forms/library.js'
+import { formOverviewPath, formsLibraryPath } from '~/src/models/links.js'
+
+describe('Forms Library Models', () => {
+  const formSlug = 'test-form-slug'
+  const formPath = formOverviewPath(formSlug)
+
+  const draftAuthor = {
+    id: 'f50ceeed-b7a4-47cf-a498-094efc99f8bc',
+    displayName: 'Enrique Chase'
+  }
+
+  const liveAuthor = {
+    id: 'e57d007c-4d5a-4c9f-8d8c-0890a3a16215',
+    displayName: 'Amelia Smith'
+  }
+
+  const now = new Date()
+
+  /**
+   * @satisfies {FormMetadata}
+   */
+  const metadataWithDraft = {
+    id: '661e4ca5039739ef2902b214',
+    slug: formSlug,
+    title: 'Test Form',
+    organisation: 'Defra',
+    teamName: 'Defra Forms',
+    teamEmail: 'defraforms@defra.gov.uk',
+    createdAt: now,
+    createdBy: draftAuthor,
+    updatedAt: now,
+    updatedBy: draftAuthor,
+    draft: {
+      createdAt: now,
+      createdBy: draftAuthor,
+      updatedAt: now,
+      updatedBy: draftAuthor
+    },
+    live: undefined
+  }
+
+  /**
+   * @satisfies {FormMetadata}
+   */
+  const metadataWithLive = {
+    id: '661e4ca5039739ef2902b214',
+    slug: formSlug,
+    title: 'Test Form',
+    organisation: 'Defra',
+    teamName: 'Defra Forms',
+    teamEmail: 'defraforms@defra.gov.uk',
+    createdAt: now,
+    createdBy: liveAuthor,
+    updatedAt: now,
+    updatedBy: liveAuthor,
+    draft: undefined,
+    live: {
+      createdAt: now,
+      createdBy: liveAuthor,
+      updatedAt: now,
+      updatedBy: liveAuthor
+    }
+  }
+
+  describe('getFormSpecificNavigation', () => {
+    describe('with draft existing', () => {
+      test('includes Editor link', () => {
+        const navigation = getFormSpecificNavigation(
+          formPath,
+          metadataWithDraft,
+          'Overview'
+        )
+
+        expect(navigation).toEqual([
+          buildEntry('Forms library', formsLibraryPath, { isActive: false }),
+          buildEntry('Overview', formPath, { isActive: true }),
+          buildEntry('Editor', `${formPath}/editor`, { isActive: false })
+        ])
+      })
+
+      test('Editor page is active when activePage is "Editor"', () => {
+        const navigation = getFormSpecificNavigation(
+          formPath,
+          metadataWithDraft,
+          'Editor'
+        )
+
+        expect(navigation).toEqual([
+          buildEntry('Forms library', formsLibraryPath, { isActive: false }),
+          buildEntry('Overview', formPath, { isActive: false }),
+          buildEntry('Editor', `${formPath}/editor`, { isActive: true })
+        ])
+      })
+    })
+
+    describe('without draft', () => {
+      test('does not include Editor link', () => {
+        const navigation = getFormSpecificNavigation(
+          formPath,
+          metadataWithLive,
+          'Overview'
+        )
+
+        expect(navigation).toEqual([
+          buildEntry('Forms library', formsLibraryPath, { isActive: false }),
+          buildEntry('Overview', formPath, { isActive: true })
+        ])
+      })
+
+      test('Editor link is not included even when activePage is "Editor"', () => {
+        const navigation = getFormSpecificNavigation(
+          formPath,
+          metadataWithLive,
+          'Editor'
+        )
+
+        expect(navigation).toEqual([
+          buildEntry('Forms library', formsLibraryPath, { isActive: false }),
+          buildEntry('Overview', formPath, { isActive: false })
+        ])
+      })
+    })
+
+    describe('with invalid activePage', () => {
+      test('no navigation item is active when activePage does not match any item', () => {
+        const navigation = getFormSpecificNavigation(
+          formPath,
+          metadataWithDraft,
+          'NonExistingPage'
+        )
+
+        expect(navigation).toEqual([
+          buildEntry('Forms library', formsLibraryPath, { isActive: false }),
+          buildEntry('Overview', formPath, { isActive: false }),
+          buildEntry('Editor', `${formPath}/editor`, { isActive: false })
+        ])
+      })
+    })
+
+    describe('with default activePage', () => {
+      test('no navigation item is active when activePage is defaulted', () => {
+        const navigation = getFormSpecificNavigation(
+          formPath,
+          metadataWithDraft
+        )
+
+        expect(navigation).toEqual([
+          buildEntry('Forms library', formsLibraryPath, { isActive: false }),
+          buildEntry('Overview', formPath, { isActive: false }),
+          buildEntry('Editor', `${formPath}/editor`, { isActive: false })
+        ])
+      })
+    })
+  })
+
+  describe('overviewViewModel', () => {
+    describe('with draft existing', () => {
+      test('returns correct view model structure', () => {
+        const notificationMessage = 'Form updated successfully'
+        const viewModel = overviewViewModel(
+          metadataWithDraft,
+          notificationMessage
+        )
+
+        expect(viewModel).toMatchObject({
+          navigation: getFormSpecificNavigation(
+            formPath,
+            metadataWithDraft,
+            'Overview'
+          ),
+          backLink: {
+            href: formsLibraryPath,
+            text: 'Back to forms library'
+          },
+          pageHeading: {
+            text: metadataWithDraft.title,
+            size: 'large'
+          },
+          notification: notificationMessage,
+          formManage: {
+            action: `${formPath}/editor`,
+            method: 'GET',
+            buttons: [
+              {
+                text: 'Edit draft',
+                classes: 'govuk-button--secondary-quiet'
+              },
+              {
+                text: 'Make draft live',
+                attributes: {
+                  formaction: `${formPath}/make-draft-live`
+                }
+              }
+            ]
+          }
+        })
+      })
+    })
+
+    describe('without draft', () => {
+      test('returns correct view model structure', () => {
+        const notificationMessage = 'Form updated successfully'
+        const viewModel = overviewViewModel(
+          metadataWithLive,
+          notificationMessage
+        )
+
+        expect(viewModel).toMatchObject({
+          navigation: getFormSpecificNavigation(
+            formPath,
+            metadataWithLive,
+            'Overview'
+          ),
+          backLink: {
+            href: formsLibraryPath,
+            text: 'Back to forms library'
+          },
+          pageHeading: {
+            text: metadataWithLive.title,
+            size: 'large'
+          },
+          notification: notificationMessage,
+          formManage: {
+            action: `${formPath}/create-draft-from-live`,
+            method: 'POST',
+            buttons: [
+              {
+                text: 'Create draft to edit'
+              }
+            ]
+          }
+        })
+      })
+    })
+  })
+
+  describe('editorViewModel', () => {
+    test('returns correct view model structure', () => {
+      const mockDefinition = {
+        name: 'Test Form Definition',
+        pages: [],
+        conditions: [],
+        sections: [],
+        lists: []
+      }
+
+      const viewModel = editorViewModel(metadataWithDraft, mockDefinition)
+
+      expect(viewModel).toMatchObject({
+        navigation: getFormSpecificNavigation(
+          formPath,
+          metadataWithDraft,
+          'Editor'
+        ),
+        formDefinition: mockDefinition,
+        form: metadataWithDraft,
+        backLink: {
+          href: `/library/${formSlug}`,
+          text: 'Back to form overview'
+        }
+      })
+    })
+  })
+})
+
+/**
+ * @import { FormMetadata } from '@defra/forms-model'
+ */

--- a/designer/server/src/models/forms/library.test.js
+++ b/designer/server/src/models/forms/library.test.js
@@ -70,7 +70,7 @@ describe('Forms Library Models', () => {
 
   describe('getFormSpecificNavigation', () => {
     describe('with draft existing', () => {
-      test('includes Editor link', () => {
+      it('includes Editor link', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithDraft,
@@ -84,7 +84,7 @@ describe('Forms Library Models', () => {
         ])
       })
 
-      test('Editor page is active when activePage is "Editor"', () => {
+      it('shows Editor page as active when activePage is "Editor"', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithDraft,
@@ -100,7 +100,7 @@ describe('Forms Library Models', () => {
     })
 
     describe('without draft', () => {
-      test('does not include Editor link', () => {
+      it('does not include Editor link', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithLive,
@@ -113,7 +113,7 @@ describe('Forms Library Models', () => {
         ])
       })
 
-      test('Editor link is not included even when activePage is "Editor"', () => {
+      it('excludes Editor link even when activePage is "Editor"', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithLive,
@@ -128,7 +128,7 @@ describe('Forms Library Models', () => {
     })
 
     describe('with invalid activePage', () => {
-      test('no navigation item is active when activePage does not match any item', () => {
+      it('shows no navigation item as active when activePage does not match any item', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithDraft,
@@ -144,7 +144,7 @@ describe('Forms Library Models', () => {
     })
 
     describe('with default activePage', () => {
-      test('no navigation item is active when activePage is defaulted', () => {
+      it('shows no navigation item as active when activePage is defaulted', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithDraft
@@ -161,7 +161,7 @@ describe('Forms Library Models', () => {
 
   describe('overviewViewModel', () => {
     describe('with draft existing', () => {
-      test('returns correct view model structure', () => {
+      it('returns correct view model structure', () => {
         const notificationMessage = 'Form updated successfully'
         const viewModel = overviewViewModel(
           metadataWithDraft,
@@ -204,7 +204,7 @@ describe('Forms Library Models', () => {
     })
 
     describe('without draft', () => {
-      test('returns correct view model structure', () => {
+      it('returns correct view model structure', () => {
         const notificationMessage = 'Form updated successfully'
         const viewModel = overviewViewModel(
           metadataWithLive,
@@ -241,7 +241,7 @@ describe('Forms Library Models', () => {
   })
 
   describe('editorViewModel', () => {
-    test('returns correct view model structure', () => {
+    it('returns correct view model structure', () => {
       const mockDefinition = {
         name: 'Test Form Definition',
         pages: [],


### PR DESCRIPTION
This PR removes the `Editor` button when a form is live. It also increases test coverage by adding a test suite for `library.js`.