### PR TITLE
Escape single quotes in condition values when building the expression

### DIFF
--- a/model/src/conditions/condition-model.test.ts
+++ b/model/src/conditions/condition-model.test.ts
@@ -1689,4 +1689,65 @@ describe('condition model', () => {
       expect(returned).toBe(underTest)
     })
   })
+
+  describe('escaping condition values', () => {
+    beforeEach(() => {
+      underTest.add(
+        new Condition(
+          new ConditionField('badger', ComponentType.TextField, 'Badger'),
+          OperatorName.Is,
+          new ConditionValue("Zebra's")
+        )
+      )
+      underTest.add(new ConditionRef('under18', 'Under 18', Coordinator.OR))
+      underTest.add(
+        new Condition(
+          new ConditionField('squiffy', ComponentType.TextField, 'Squiffy'),
+          OperatorName.Is,
+          new ConditionValue("Donkey's"),
+          Coordinator.AND
+        )
+      )
+      underTest.add(
+        new Condition(
+          new ConditionField('duration', ComponentType.NumberField, 'Duration'),
+          OperatorName.IsAtLeast,
+          new ConditionValue('10'),
+          Coordinator.OR
+        )
+      )
+      underTest.add(
+        new Condition(
+          new ConditionField(
+            'birthday',
+            ComponentType.DatePartsField,
+            'Birthday'
+          ),
+          OperatorName.Is,
+          new ConditionValue('10/10/2019'),
+          Coordinator.OR
+        )
+      )
+      underTest.add(
+        new Condition(
+          new ConditionField('squiffy', ComponentType.TextField, 'Squiffy'),
+          OperatorName.IsNot,
+          new ConditionValue("K'plah's!"),
+          Coordinator.AND
+        )
+      )
+    })
+
+    test('single quotes are escaped in toExpression', () => {
+      expect(underTest.toExpression()).toBe(
+        "badger == 'Zebra\\'s' or (under18 and squiffy == 'Donkey\\'s') or duration >= 10 or (birthday == '10/10/2019' and squiffy != 'K\\'plah\\'s!')"
+      )
+    })
+
+    test('single quotes are not escaped in toPresentationString', () => {
+      expect(underTest.toPresentationString()).toBe(
+        "'Badger' is 'Zebra's' or ('Under 18' and 'Squiffy' is 'Donkey's') or 'Duration' is at least '10' or ('Birthday' is '10/10/2019' and 'Squiffy' is not 'K'plah's!')"
+      )
+    })
+  })
 })

--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -163,7 +163,7 @@ function formatValue(
     return value.toExpression()
   }
 
-  return `'${value.toExpression()}'`
+  return `'${value.toExpression().replace(/'/g, "\\'")}'`
 }
 
 export const absoluteDateOperatorNames = Object.keys(

--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -160,10 +160,10 @@ function formatValue(
     field.type === ComponentType.NumberField ||
     field.type === ComponentType.YesNoField
   ) {
-    return value.toExpression()
+    return value.toValue()
   }
 
-  return `'${value.toExpression().replace(/'/g, "\\'")}'`
+  return `'${value.toValue().replace(/'/g, "\\'")}'`
 }
 
 export const absoluteDateOperatorNames = Object.keys(

--- a/model/src/conditions/condition-value-abstract.ts
+++ b/model/src/conditions/condition-value-abstract.ts
@@ -5,7 +5,7 @@ export class ConditionValueAbstract {
     )
   }
 
-  toExpression(): string {
+  toValue(): string {
     throw new Error(
       'Unsupported Operation. Method toExpression has not been implemented'
     )

--- a/model/src/conditions/condition-values.ts
+++ b/model/src/conditions/condition-values.ts
@@ -31,7 +31,7 @@ export class ConditionValue extends ConditionValueAbstract {
     return this.display
   }
 
-  toExpression() {
+  toValue() {
     return this.value
   }
 
@@ -77,7 +77,7 @@ export class RelativeDateValue extends ConditionValueAbstract {
     return `${this.period} ${this.unit} ${this.direction}`
   }
 
-  toExpression(): string {
+  toValue(): string {
     const period =
       this.direction === DateDirections.PAST
         ? 0 - Number(this.period)


### PR DESCRIPTION
Condition values that contain any single quotes would cause the form definition to fail to load in `forms-runner`.
This is because the condition expression itself is [wrapped in single quotes](https://github.com/DEFRA/forms-designer/blob/e4230d468acd3187256cc806787ef4d2daf2db04/model/src/conditions/condition-operators.ts#L166). This causes an exception when the expression is subsequently [passed into](https://github.com/DEFRA/forms-runner/blob/main/src/server/plugins/engine/models/FormModel.ts#L154) `expr-eval` inside `forms-runner`.

This PR escapes any single quotes found in the condition values when building the expression.