### PR TITLE
Remove unused home page type etc

### DIFF
--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -7,7 +7,6 @@ import {
   hasFormComponents,
   hasNext,
   hasRepeater,
-  hasSection,
   slugify,
   type Page
 } from '@defra/forms-model'
@@ -110,7 +109,7 @@ export class PageEdit extends Component<Props, State> {
     this.setState({
       path: page.path,
       title: page.title,
-      selectedSection: hasSection(page) ? page.section : undefined,
+      selectedSection: hasComponents(page) ? page.section : undefined,
       repeatTitle: hasRepeater(page) ? page.repeat.options.title : undefined
     })
   }

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -1,7 +1,6 @@
 import {
   ControllerType,
   hasComponents,
-  hasSection,
   slugify,
   type ComponentDef,
   type Page as PageType
@@ -45,7 +44,7 @@ const ComponentList = (props: Readonly<{ page: PageType }>) => {
     return null
   }
 
-  const { components = [] } = page
+  const { components } = page
 
   return (
     <ul className="app-results">
@@ -73,7 +72,10 @@ export const Page = (
   const [isEditingPage, setIsEditingPage] = useState(false)
   const [isCreatingComponent, setIsCreatingComponent] = useState(false)
 
-  const section = hasSection(page) ? findSection(data, page.section) : undefined
+  const section =
+    hasComponents(page) && page.section
+      ? findSection(data, page.section)
+      : undefined
 
   const pageId = slugify(page.path)
   const headingId = `${pageId}-heading`

--- a/designer/client/src/data/component/fields.ts
+++ b/designer/client/src/data/component/fields.ts
@@ -5,7 +5,6 @@ import {
   hasFormField,
   hasListField,
   hasRepeater,
-  hasSection,
   type ConditionalComponentType,
   type ConditionalComponentsDef,
   type FormDefinition,
@@ -52,7 +51,10 @@ export function pageToFields(
   this: FormDefinition,
   page: Extract<Page, { next: Link[] }>
 ) {
-  const section = hasSection(page) ? findSection(this, page.section) : undefined
+  const section =
+    hasComponents(page) && page.section
+      ? findSection(this, page.section)
+      : undefined
 
   return page.components
     .filter(hasConditionSupport)

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -45,7 +45,7 @@ export interface PageQuestion extends PageBase {
 }
 
 export interface PageRepeat extends PageBase {
-  controller?: ControllerType.Repeat
+  controller: ControllerType.Repeat
   repeat: Repeat
   section?: string | undefined
   next: Link[]
@@ -53,7 +53,7 @@ export interface PageRepeat extends PageBase {
 }
 
 export interface PageFileUpload extends PageBase {
-  controller?: ControllerType.FileUpload
+  controller: ControllerType.FileUpload
   section?: string | undefined
   next: Link[]
   components: ComponentDef[]

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -31,7 +31,7 @@ export interface Repeat {
 
 export interface PageStart extends PageBase {
   path: ControllerPath.Start | string
-  controller: ControllerType.Start | ControllerType.Home
+  controller: ControllerType.Start
   section?: string | undefined
   next: Link[]
   components: ComponentDef[]

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -79,14 +79,6 @@ export type Page =
   | PageSummary
   | PageStatus
 
-export type RequiredField<
-  Type extends Partial<object>,
-  KeyType extends keyof Type
-> = Omit<Type, KeyType> &
-  Required<{
-    [Key in KeyType]: Type[Key]
-  }>
-
 export interface Section {
   name: string
   title: string

--- a/model/src/pages/controller-types.ts
+++ b/model/src/pages/controller-types.ts
@@ -6,10 +6,6 @@ export const ControllerTypes = [
     path: './pages/start.js'
   },
   {
-    name: ControllerType.Home,
-    path: './pages/home.js'
-  },
-  {
     name: ControllerType.Page,
     path: './pages/page.js'
   },

--- a/model/src/pages/enums.ts
+++ b/model/src/pages/enums.ts
@@ -6,7 +6,6 @@ export enum ControllerPath {
 
 export enum ControllerType {
   Start = 'StartPageController',
-  Home = 'HomePageController',
   Page = 'PageController',
   Repeat = 'RepeatPageController',
   FileUpload = 'FileUploadPageController',

--- a/model/src/pages/helpers.test.ts
+++ b/model/src/pages/helpers.test.ts
@@ -1,7 +1,120 @@
 import { ControllerTypes } from '~/src/pages/controller-types.js'
-import { controllerNameFromPath } from '~/src/pages/helpers.js'
+import { ControllerType } from '~/src/pages/enums.js'
+import {
+  controllerNameFromPath,
+  getPageDefaults,
+  hasComponents,
+  hasFormComponents,
+  hasNext,
+  hasRepeater
+} from '~/src/pages/helpers.js'
+import { PageTypes } from '~/src/pages/page-types.js'
 
 describe('helpers', () => {
+  describe('getPageDefaults', () => {
+    it.each([...PageTypes])(
+      "returns page defaults for page type '$controller'",
+      (page) => {
+        const { controller } = page
+        expect(getPageDefaults({ controller })).toEqual(page)
+      }
+    )
+  })
+
+  describe('hasComponents', () => {
+    const supported = [
+      ControllerType.Start,
+      ControllerType.Page,
+      ControllerType.FileUpload,
+      ControllerType.Repeat
+    ]
+
+    it.each(
+      PageTypes.filter(({ controller }) => {
+        return !!controller && supported.includes(controller)
+      })
+    )("returns true for supported page type '$controller'", (page) =>
+      expect(hasComponents(page)).toBe(true)
+    )
+
+    it.each(
+      PageTypes.filter(({ controller }) => {
+        return !!controller && !supported.includes(controller)
+      })
+    )("returns false for unsupported page type '$controller'", (page) =>
+      expect(hasComponents(page)).toBe(false)
+    )
+  })
+
+  describe('hasFormComponents', () => {
+    const supported = [
+      ControllerType.Page,
+      ControllerType.FileUpload,
+      ControllerType.Repeat
+    ]
+
+    it.each(
+      PageTypes.filter(({ controller }) => {
+        return !!controller && supported.includes(controller)
+      })
+    )("returns true for supported page type '$controller'", (page) =>
+      expect(hasFormComponents(page)).toBe(true)
+    )
+
+    it.each(
+      PageTypes.filter(({ controller }) => {
+        return !!controller && !supported.includes(controller)
+      })
+    )("returns false for unsupported page type '$controller'", (page) =>
+      expect(hasFormComponents(page)).toBe(false)
+    )
+  })
+
+  describe('hasNext', () => {
+    const supported = [
+      ControllerType.Start,
+      ControllerType.Page,
+      ControllerType.FileUpload,
+      ControllerType.Repeat
+    ]
+
+    it.each(
+      PageTypes.filter(({ controller }) => {
+        return !!controller && supported.includes(controller)
+      })
+    )("returns true for supported page type '$controller'", (page) =>
+      expect(hasNext(page)).toBe(true)
+    )
+
+    it.each(
+      PageTypes.filter(({ controller }) => {
+        return !!controller && !supported.includes(controller)
+      })
+    )("returns false for unsupported page type '$controller'", (page) =>
+      expect(hasNext(page)).toBe(false)
+    )
+  })
+
+  describe('hasRepeater', () => {
+    const supported = [ControllerType.Repeat]
+
+    it.each(
+      PageTypes.filter(({ controller }) => {
+        return !!controller && supported.includes(controller)
+      })
+    )("returns true for supported page type '$controller'", (page) =>
+      expect(hasRepeater(page)).toBe(true)
+    )
+
+    it.each(
+      PageTypes.filter(({ controller }) => {
+        return !!controller && !supported.includes(controller)
+      })
+    )("returns false for unsupported page type '$controller'", (page) =>
+      expect(hasRepeater(page)).toBe(false)
+    )
+  })
+
   describe('controllerNameFromPath', () => {
     it.each([...ControllerTypes])(
       "returns controller name for '$path' legacy path",

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -4,9 +4,7 @@ import {
   type Page,
   type PageFileUpload,
   type PageQuestion,
-  type PageRepeat,
-  type PageStart,
-  type RequiredField
+  type PageRepeat
 } from '~/src/form/form-definition/types.js'
 import {
   ControllerNames,
@@ -52,18 +50,6 @@ export function hasFormComponents(
 ): page is PageQuestion | PageFileUpload {
   const controller = controllerNameFromPath(page?.controller)
   return hasComponents(page) && controller !== ControllerType.Start
-}
-
-/**
- * Check page has sections
- */
-export function hasSection(
-  page?: Partial<Page>
-): page is
-  | RequiredField<PageStart, 'section'>
-  | RequiredField<PageQuestion, 'section'>
-  | RequiredField<PageFileUpload, 'section'> {
-  return hasNext(page) && typeof page.section === 'string'
 }
 
 /**

--- a/model/src/pages/index.ts
+++ b/model/src/pages/index.ts
@@ -12,7 +12,6 @@ export {
   hasFormComponents,
   hasNext,
   hasRepeater,
-  hasSection,
   isControllerName
 } from '~/src/pages/helpers.js'
 


### PR DESCRIPTION
This PR includes some tidy ups and test coverage:

* Remove unused "Home page" controller type
* Remove unnecessary helper `hasSection()`

Plus adds test coverage for these helpers:

* `getPageDefaults()`
* `hasComponents()`
* `hasFormComponents()`
* `hasNext()`
* `hasRepeater()`