### PR TITLE
Add error page for HTTP 400

### DIFF
--- a/designer/server/src/plugins/errorPage.ts
+++ b/designer/server/src/plugins/errorPage.ts
@@ -7,6 +7,7 @@ import {
 import { errorViewModel } from '~/src/models/errors.js'
 
 const errorCodes = new Map([
+  [400, 'Sorry, there is a problem with the service'],
   [403, 'You do not have access to this service'],
   [404, 'Page not found'],
   [500, 'Sorry, there is a problem with the service']

--- a/designer/server/src/views/400.njk
+++ b/designer/server/src/views/400.njk
@@ -5,7 +5,7 @@
   {% call appPageBody({
     heading: pageHeading
   }) %}
-    <p class="govuk-body">The service couldn't process your request.</p>
+    <p class="govuk-body">The service could not process your request.</p>
     <p class="govuk-body"><a href="mailto:defraforms@defra.gov.uk" class="govuk-link">Contact the Defra forms team</a> to report this error.</p>
   {% endcall %}
 {% endblock %}

--- a/designer/server/src/views/400.njk
+++ b/designer/server/src/views/400.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}

--- a/designer/server/src/views/400.njk
+++ b/designer/server/src/views/400.njk
@@ -1,0 +1,11 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+  {% call appPageBody({
+    heading: pageHeading
+  }) %}
+    <p class="govuk-body">The service couldn't process your request.</p>
+    <p class="govuk-body"><a href="mailto:defraforms@defra.gov.uk" class="govuk-link">Contact the Defra forms team</a> to report this error.</p>
+  {% endcall %}
+{% endblock %}

--- a/designer/server/src/views/403.njk
+++ b/designer/server/src/views/403.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}

--- a/designer/server/src/views/404.njk
+++ b/designer/server/src/views/404.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}

--- a/designer/server/src/views/500.njk
+++ b/designer/server/src/views/500.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}

--- a/designer/server/src/views/account/sign-in.njk
+++ b/designer/server/src/views/account/sign-in.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 

--- a/designer/server/src/views/account/signed-out.njk
+++ b/designer/server/src/views/account/signed-out.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}

--- a/designer/server/src/views/forms/library.njk
+++ b/designer/server/src/views/forms/library.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/designer/server/src/views/forms/question-input.njk
+++ b/designer/server/src/views/forms/question-input.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/designer/server/src/views/forms/question-inputs.njk
+++ b/designer/server/src/views/forms/question-inputs.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/designer/server/src/views/forms/question-radios.njk
+++ b/designer/server/src/views/forms/question-radios.njk
@@ -1,4 +1,4 @@
-{% extends 'layouts/page.njk' %}
+{% extends "layouts/page.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}


### PR DESCRIPTION
Supports 368034 to present a friendly error rather than JSON if the user changes the URL parameters.