### PR TITLE
Avoid global scope using `new Marked()` instance

### DIFF
--- a/model/src/utils/markdown.ts
+++ b/model/src/utils/markdown.ts
@@ -1,4 +1,12 @@
-import { marked } from 'marked'
+import { Marked } from 'marked'
+
+/**
+ * Marked instance (avoids global option/extension scope)
+ */
+export const marked = new Marked({
+  breaks: true,
+  gfm: true
+})
 
 /**
  * Convert markdown to HTML
@@ -8,5 +16,5 @@ export function markdownToHtml(markdown?: string | null) {
     return ''
   }
 
-  return marked(markdown, { gfm: true, breaks: true })
+  return marked.parse(markdown)
 }

--- a/model/src/utils/markdown.ts
+++ b/model/src/utils/markdown.ts
@@ -16,5 +16,5 @@ export function markdownToHtml(markdown?: string | null) {
     return ''
   }
 
-  return marked.parse(markdown)
+  return marked.parse(markdown, { async: false })
 }


### PR DESCRIPTION
Fixes [bug #492045](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/492045) but see also:

* https://github.com/DEFRA/forms-runner/pull/652