### PR TITLE
Fix error message when `/status` page path is used

### DIFF
--- a/designer/client/src/PageEdit.tsx
+++ b/designer/client/src/PageEdit.tsx
@@ -255,7 +255,7 @@ export class PageEdit extends Component<Props, State> {
 
     // Path '/status' not allowed
     errors.path ??= validateCustom('page-path', path, {
-      message: 'page.errors.pathStart',
+      message: 'page.errors.pathStatus',
       schema: schema.string().disallow(ControllerPath.Status)
     })
 


### PR DESCRIPTION
Just a typo, the error message when you use the path `/status` says that `/start` is reserved