### PR TITLE
New designer: Remove `rel="noreferrer"` from page preview links

### DIFF
--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/jsx-no-target-blank */
+
 import {
   ControllerType,
   hasComponents,
@@ -115,7 +117,7 @@ export const Page = (
           href={href}
           className="govuk-button app-button--editor"
           target="_blank"
-          rel="noreferrer opener"
+          rel="opener"
           aria-describedby={headingId}
         >
           {i18n('page.preview')}


### PR DESCRIPTION
Slight tweak to https://github.com/DEFRA/forms-designer/pull/649/commits/f818018fec3a0cb622f3d5d8d31339508f04f3e0 to remove `rel="noreferrer"`

This makes `window.opener` available to unblock [story #475713](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/475713)