### PR TITLE
Fix typo “Must must end with”

### DIFF
--- a/designer/server/src/models/forms/notification-email.js
+++ b/designer/server/src/models/forms/notification-email.js
@@ -24,7 +24,7 @@ export function notificationEmailViewModel(metadata, validation) {
       },
       value: formValues?.notificationEmail ?? metadata.notificationEmail,
       hint: {
-        text: 'Used to send submitted forms for processing. Must must end with ‘.gov.uk’ or ‘.org.uk’, like name@example.gov.uk or name@example.org.uk'
+        text: 'Used to send submitted forms for processing. Emails must end with ‘.gov.uk’ or ‘.org.uk’, like name@example.gov.uk or name@example.org.uk'
       }
     },
     buttonText: 'Save and continue'


### PR DESCRIPTION
Fixes a quick typo "~Must~ Emails must end with…" in [`ad84175`](https://github.com/DEFRA/forms-designer/commit/ad84175eb52b2cb69e9622a649ec77ed4cd1b3c0#diff-241a457c1c99be4257ba168e631649ed2e54e451748b4cafa9e3d73e07357efeR27)