### PR TITLE
Add trace ID to headers and log unhandled errors

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -34,6 +34,7 @@
     "@babel/preset-react": "^7.26.3",
     "@dagrejs/dagre": "^1.1.4",
     "@defra/forms-model": "^3.0.393",
+    "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/basic": "^7.0.2",
     "@hapi/bell": "^13.0.2",

--- a/designer/server/src/common/helpers/logging/logger-options.js
+++ b/designer/server/src/common/helpers/logging/logger-options.js
@@ -1,3 +1,4 @@
+import { getTraceId } from '@defra/hapi-tracing'
 import { ecsFormat } from '@elastic/ecs-pino-format'
 
 import config from '~/src/config.js'
@@ -8,14 +9,10 @@ const serviceVersion = config.serviceVersion
 
 const formatters = {
   ecs: /** @type {Omit<LoggerOptions, 'mixin' | 'transport'>} */ ({
-    ...ecsFormat(),
-    base: {
-      service: {
-        name: serviceName,
-        type: 'nodeJs',
-        version: serviceVersion
-      }
-    }
+    ...ecsFormat({
+      serviceVersion,
+      serviceName
+    })
   }),
   'pino-pretty': /** @type {{ transport: TransportSingleOptions }} */ ({
     transport: {
@@ -35,7 +32,15 @@ export const loggerOptions = {
     remove: true
   },
   level: logConfig.level,
-  ...formatters[logConfig.format]
+  ...formatters[logConfig.format],
+  mixin() {
+    const mixinValues = {}
+    const traceId = getTraceId()
+    if (traceId) {
+      mixinValues.trace = { id: traceId }
+    }
+    return mixinValues
+  }
 }
 
 /**

--- a/designer/server/src/common/helpers/request-tracing.js
+++ b/designer/server/src/common/helpers/request-tracing.js
@@ -1,0 +1,8 @@
+import { tracing } from '@defra/hapi-tracing'
+
+import config from '~/src/config.js'
+
+export const requestTracing = {
+  plugin: tracing,
+  options: { tracingHeader: config.tracing.header }
+}

--- a/designer/server/src/config.ts
+++ b/designer/server/src/config.ts
@@ -45,6 +45,9 @@ export interface Config {
   redisPassword: string
   redisKeyPrefix: string
   roleEditorGroupId: string
+  tracing: {
+    header: string
+  }
 }
 
 // Define config schema
@@ -139,7 +142,10 @@ const schema = joi.object<Config>({
   redisUsername: joi.string().required(),
   redisPassword: joi.string().required(),
   redisKeyPrefix: joi.string().required(),
-  roleEditorGroupId: joi.string().required()
+  roleEditorGroupId: joi.string().required(),
+  tracing: joi.object({
+    header: joi.string().default('x-cdp-request-id')
+  })
 })
 
 // Validate config
@@ -175,7 +181,10 @@ const result = schema.validate(
     redisUsername: process.env.REDIS_USERNAME,
     redisPassword: process.env.REDIS_PASSWORD,
     redisKeyPrefix: process.env.REDIS_KEY_PREFIX,
-    roleEditorGroupId: process.env.ROLE_EDITOR_GROUP_ID
+    roleEditorGroupId: process.env.ROLE_EDITOR_GROUP_ID,
+    tracing: {
+      header: process.env.TRACING_HEADER
+    }
   },
   { abortEarly: false }
 )

--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -13,6 +13,7 @@ import {
 import { sessionCookie } from '~/src/common/helpers/auth/session-cookie.js'
 import { requestLogger } from '~/src/common/helpers/logging/request-logger.js'
 import { buildRedisClient } from '~/src/common/helpers/redis-client.js'
+import { requestTracing } from '~/src/common/helpers/request-tracing.js'
 import { sessionManager } from '~/src/common/helpers/session-manager.js'
 import * as nunjucks from '~/src/common/nunjucks/index.js'
 import config from '~/src/config.js'
@@ -106,6 +107,7 @@ export async function createServer() {
   await server.register(nunjucks.plugin)
   await server.register(router)
   await server.register(requestLogger)
+  await server.register(requestTracing)
   await server.register(errorPage)
 
   return server

--- a/designer/server/src/lib/file.js
+++ b/designer/server/src/lib/file.js
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import config from '~/src/config.js'
 import { getJson, postJson } from '~/src/lib/fetch.js'
+import { getHeaders } from '~/src/lib/utils.js'
 
 const submissionEndpoint = new URL('/file/', config.submissionUrl)
 
@@ -50,19 +51,7 @@ export async function createFileLink(fileId, retrievalKey, token) {
   )
   const { body } = await postJsonByType(requestUrl, {
     payload: { fileId, retrievalKey },
-    ...getAuthOptions(token)
+    ...getHeaders(token)
   })
   return body
 }
-
-/**
- * @param {string} token
- * @returns {Parameters<typeof Wreck.request>[2]}
- */
-function getAuthOptions(token) {
-  return { headers: { Authorization: `Bearer ${token}` } }
-}
-
-/**
- * @import Wreck from '@hapi/wreck'
- */

--- a/designer/server/src/lib/forms.js
+++ b/designer/server/src/lib/forms.js
@@ -1,5 +1,6 @@
 import config from '~/src/config.js'
 import { getJson, patchJson, postJson } from '~/src/lib/fetch.js'
+import { getHeaders } from '~/src/lib/utils.js'
 
 const formsEndpoint = new URL('/forms/', config.managerUrl)
 
@@ -26,7 +27,7 @@ export async function list(token, options) {
     requestUrl.searchParams.append('title', options.title)
   }
 
-  const { body } = await getJsonByType(requestUrl, getAuthOptions(token))
+  const { body } = await getJsonByType(requestUrl, getHeaders(token))
 
   return body
 }
@@ -40,7 +41,7 @@ export async function get(slug, token) {
   const getJsonByType = /** @type {typeof getJson<FormMetadata>} */ (getJson)
 
   const requestUrl = new URL(`./slug/${slug}`, formsEndpoint)
-  const { body } = await getJsonByType(requestUrl, getAuthOptions(token))
+  const { body } = await getJsonByType(requestUrl, getHeaders(token))
 
   return body
 }
@@ -55,7 +56,7 @@ export async function create(metadata, token) {
 
   const { body } = await postJsonByType(formsEndpoint, {
     payload: metadata,
-    ...getAuthOptions(token)
+    ...getHeaders(token)
   })
 
   return body
@@ -73,7 +74,7 @@ export async function update(id, metadata, token) {
   const requestUrl = new URL(`./${id}`, formsEndpoint)
   const { body } = await postJsonByType(requestUrl, {
     payload: metadata,
-    ...getAuthOptions(token)
+    ...getHeaders(token)
   })
 
   return body
@@ -88,7 +89,7 @@ export async function getDraftFormDefinition(id, token) {
   const getJsonByType = /** @type {typeof getJson<FormDefinition>} */ (getJson)
 
   const requestUrl = new URL(`./${id}/definition/draft`, formsEndpoint)
-  const { body } = await getJsonByType(requestUrl, getAuthOptions(token))
+  const { body } = await getJsonByType(requestUrl, getHeaders(token))
 
   return body
 }
@@ -107,7 +108,7 @@ export async function updateDraftFormDefinition(id, definition, token) {
   const requestUrl = new URL(`./${id}/definition/draft`, formsEndpoint)
   const { body } = await postJsonByType(requestUrl, {
     payload: definition,
-    ...getAuthOptions(token)
+    ...getHeaders(token)
   })
 
   return body
@@ -121,7 +122,7 @@ export async function updateDraftFormDefinition(id, definition, token) {
 export async function makeDraftFormLive(id, token) {
   const requestUrl = new URL(`./${id}/create-live`, formsEndpoint)
   const { response } = await postJson(requestUrl, {
-    ...getAuthOptions(token)
+    ...getHeaders(token)
   })
 
   return response
@@ -135,7 +136,7 @@ export async function makeDraftFormLive(id, token) {
 export async function createDraft(id, token) {
   const requestUrl = new URL(`./${id}/create-draft`, formsEndpoint)
   const { response } = await postJson(requestUrl, {
-    ...getAuthOptions(token)
+    ...getHeaders(token)
   })
 
   return response
@@ -157,18 +158,10 @@ export async function updateMetadata(id, metadata, token) {
 
   const { body } = await patchJsonByType(requestUrl, {
     payload: metadata,
-    ...getAuthOptions(token)
+    ...getHeaders(token)
   })
 
   return body
-}
-
-/**
- * @param {string} token
- * @returns {Parameters<typeof Wreck.request>[2]}
- */
-function getAuthOptions(token) {
-  return { headers: { Authorization: `Bearer ${token}` } }
 }
 
 /**

--- a/designer/server/src/lib/utils.js
+++ b/designer/server/src/lib/utils.js
@@ -1,0 +1,21 @@
+import { getTraceId } from '@defra/hapi-tracing'
+
+import config from '~/src/config.js'
+
+/**
+ * Returns a set of headers to use in a http request`
+ * @param {string} token
+ * @returns {Parameters<typeof Wreck.request>[2]}
+ */
+export function getHeaders(token) {
+  return {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(getTraceId() ? { [config.tracing.header]: getTraceId() } : {})
+    }
+  }
+}
+
+/**
+ * @import Wreck from '@hapi/wreck'
+ */

--- a/designer/server/src/lib/utils.test.js
+++ b/designer/server/src/lib/utils.test.js
@@ -1,0 +1,31 @@
+import { getTraceId } from '@defra/hapi-tracing'
+
+import config from '~/src/config.js'
+import { getHeaders } from '~/src/lib/utils.js'
+
+jest.mock('@defra/hapi-tracing')
+
+describe('Header helper functions', () => {
+  it('should include the trace id in the headers if available', () => {
+    jest.mocked(getTraceId).mockReturnValue('my-trace-id')
+
+    const result = getHeaders('token')
+    expect(result).toEqual({
+      headers: {
+        Authorization: 'Bearer token',
+        [config.tracing.header]: 'my-trace-id'
+      }
+    })
+  })
+
+  it('should exclude the trace id in the headers if missing', () => {
+    jest.mocked(getTraceId).mockReturnValue(null)
+
+    const result = getHeaders('token')
+    expect(result).toEqual({
+      headers: {
+        Authorization: 'Bearer token'
+      }
+    })
+  })
+})

--- a/designer/server/src/plugins/errorPage.ts
+++ b/designer/server/src/plugins/errorPage.ts
@@ -29,20 +29,21 @@ export default {
           const statusCode = response.output.statusCode
           const errorMessage = errorCodes.get(statusCode)
 
+          request.logger.error(
+            {
+              statusCode,
+              data: response.data,
+              message: response.message,
+              stack: response.stack
+            },
+            'Unhandled error found'
+          )
+
           if (errorMessage) {
             return h
               .view(statusCode.toString(), errorViewModel(errorMessage))
               .code(statusCode)
           }
-
-          request.log('error', {
-            statusCode,
-            data: response.data,
-            message: response.message,
-            stack: response.stack
-          })
-
-          request.logger.error(response.stack)
         }
         return h.continue
       })

--- a/designer/server/src/typings/hapi-tracing/index.d.ts
+++ b/designer/server/src/typings/hapi-tracing/index.d.ts
@@ -1,0 +1,6 @@
+declare module '@defra/hapi-tracing' {
+  import { type Plugin } from '@hapi/hapi'
+
+  export const tracing: Plugin<unknown>
+  export function getTraceId(): string | null
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,7 +45,8 @@ export const projectDefaults = {
   transformIgnorePatterns: [
     `node_modules/(?!${[
       'nanoid', // Supports ESM only
-      'slug' // Supports ESM only
+      'slug', // Supports ESM only,
+      '@defra/hapi-tracing' // Supports ESM only|
     ].join('|')}/)`
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@babel/preset-react": "^7.26.3",
         "@dagrejs/dagre": "^1.1.4",
         "@defra/forms-model": "^3.0.393",
+        "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/basic": "^7.0.2",
         "@hapi/bell": "^13.0.2",
@@ -2184,6 +2185,15 @@
     "node_modules/@defra/forms-model": {
       "resolved": "model",
       "link": true
+    },
+    "node_modules/@defra/hapi-tracing": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@defra/hapi-tracing/-/hapi-tracing-1.0.0.tgz",
+      "integrity": "sha512-FbwpcfTupC7MJzbWwgx1Lmo0UCukUSTRGpZd8vDlA9A49UOtJw/E9psqCxLq56qvgdGIRQd82Xp91c1a7haOIA==",
+      "license": "OGL-UK-3.0",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",


### PR DESCRIPTION
- Passes the request trace ID downstream so errors can be traced across multiple serviecs
- Log unhandled errors before we return a response, so we can spot what's going wrong with Andrew's access