### PR TITLE
Feature 479076: Advanced search option schema and type changes

### DIFF
--- a/model/src/common/search/index.ts
+++ b/model/src/common/search/index.ts
@@ -8,7 +8,7 @@ import { organisations } from '~/src/form/form-metadata/index.js'
  */
 export const searchOptionFields = {
   title: Joi.string().trim().allow('').max(255).optional().default(''),
-  userId: Joi.string().guid().allow('').optional().default(''),
+  userId: Joi.string().trim().allow('').max(100).optional().default(''),
   organisations: Joi.array()
     .items(Joi.string().valid(...organisations))
     .single()

--- a/model/src/common/search/index.ts
+++ b/model/src/common/search/index.ts
@@ -8,7 +8,11 @@ import { organisations } from '~/src/form/form-metadata/index.js'
  */
 export const searchOptionFields = {
   title: Joi.string().trim().allow('').max(255).optional().default(''),
-  author: Joi.string().trim().allow('').max(100).optional().default(''),
+  userId: Joi.string()
+    .guid({ version: 'uuidv4' })
+    .allow('')
+    .optional()
+    .default(''),
   organisations: Joi.array()
     .items(Joi.string().valid(...organisations))
     .single()

--- a/model/src/common/search/index.ts
+++ b/model/src/common/search/index.ts
@@ -8,11 +8,7 @@ import { organisations } from '~/src/form/form-metadata/index.js'
  */
 export const searchOptionFields = {
   title: Joi.string().trim().allow('').max(255).optional().default(''),
-  userId: Joi.string()
-    .guid({ version: 'uuidv4' })
-    .allow('')
-    .optional()
-    .default(''),
+  userId: Joi.string().guid().allow('').optional().default(''),
   organisations: Joi.array()
     .items(Joi.string().valid(...organisations))
     .single()

--- a/model/src/common/search/types.ts
+++ b/model/src/common/search/types.ts
@@ -13,7 +13,7 @@ export interface SearchOptions {
    * Filter by author's name
    * If provided, shows only forms created by authors with matching name
    */
-  author?: string
+  userId?: string
 
   /**
    * Filter by organisations

--- a/model/src/common/types.ts
+++ b/model/src/common/types.ts
@@ -4,6 +4,7 @@ import {
 } from '~/src/common/pagination/types.js'
 import { type SearchOptions } from '~/src/common/search/types.js'
 import { type SortingOptions } from '~/src/common/sorting/types.js'
+import { type FormMetadataAuthor } from '~/src/form/form-metadata/types.js'
 
 /**
  * Options for querying results, including pagination, sorting, and searching
@@ -22,7 +23,7 @@ export interface FilterOptions {
   /**
    * List of unique authors in the response
    */
-  authors: string[]
+  authors: FormMetadataAuthor[]
 
   /**
    * List of organizations that have forms


### PR DESCRIPTION
This PR changes the search options schema to accept a `userId` as a `uuid` and adds the Joi validation for it as well.

The reason for this change is due to prevent the rare case in which a user's `given_name` and `family_name` are `undefined` in the token claims which would then prevent the filtering of forms via the `displayName` of the user which may not match the concatenated name in the forms-manager response. 
Forms-manager creates the `createdBy.displayName`  form metadata property which is taken from the token claims (`family_name` and `given_name`) and concatenates it which can result in `undefined undefined`. Using the `userId` will prevent this.