### PR TITLE
Feature 479076:  Advanced Search

### DIFF
--- a/designer/README.md
+++ b/designer/README.md
@@ -102,3 +102,17 @@ The following attribution statement MUST be cited in your products and applicati
 The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
 
 It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.
+
+# Forms Model Changes
+
+If you make changes to the `@defra/forms-model` package (in the `model/` dir), or pull in model changes after rebasing with main, you'll need to:
+
+```sh
+npm run build --workspace=model
+```
+
+2. Restart your terminal/command prompt
+
+3. In VS Code, press `Cmd + Shift + P` (Mac) or `Ctrl + Shift + P` (Windows/Linux) and search for "Developer: Reload Window"
+
+This might be needed as the model package needs to be rebuilt to generate new TypeScript type definitions and compiled JavaScript files. Without these steps, you may see TS errors about missing types, especially after rebasing with main.

--- a/designer/client/src/javascripts/application.js
+++ b/designer/client/src/javascripts/application.js
@@ -1,5 +1,6 @@
 import { ServiceHeader } from '@defra/forms-designer/server/src/common/components/service-header/service-header.js'
 import {
+  Accordion,
   Button,
   CharacterCount,
   ErrorSummary,
@@ -8,6 +9,7 @@ import {
   createAll
 } from 'govuk-frontend'
 
+createAll(Accordion)
 createAll(Button)
 createAll(CharacterCount)
 createAll(ErrorSummary)

--- a/designer/server/src/common/components/pagination/template.njk
+++ b/designer/server/src/common/components/pagination/template.njk
@@ -5,7 +5,7 @@
   {% if params.search.title %}
     {% set queryParams = queryParams ~ "&title=" ~ (params.search.title | urlencode) %}
   {% endif %}
-  {% if params.search.author %}
+  {% if params.search.author is defined and params.search.author != "" %}
     {% set queryParams = queryParams ~ "&author=" ~ (params.search.author | urlencode) %}
   {% endif %}
   {% if params.search.organisations and params.search.organisations | length %}

--- a/designer/server/src/common/components/pagination/template.njk
+++ b/designer/server/src/common/components/pagination/template.njk
@@ -1,14 +1,27 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {% if params.pagination and params.pagination.totalPages > 1 %}
-  {% set titleQuery = "" %}
+  {% set queryParams = "" %}
   {% if params.search.title %}
-    {% set titleQuery = "&title=" ~ (params.search.title | urlencode) %}
+    {% set queryParams = queryParams ~ "&title=" ~ (params.search.title | urlencode) %}
+  {% endif %}
+  {% if params.search.author %}
+    {% set queryParams = queryParams ~ "&author=" ~ (params.search.author | urlencode) %}
+  {% endif %}
+  {% if params.search.organisations and params.search.organisations | length %}
+    {% for org in params.search.organisations %}
+      {% set queryParams = queryParams ~ "&organisations=" ~ (org | urlencode) %}
+    {% endfor %}
+  {% endif %}
+  {% if params.search.status and params.search.status | length %}
+    {% for state in params.search.status %}
+      {% set queryParams = queryParams ~ "&status=" ~ (state | urlencode) %}
+    {% endfor %}
   {% endif %}
 
   {% set previous = null %}
   {% if params.pagination.page > 1 %}
-    {% set previousHref = (params.baseUrl | default('')) ~ "?page=" ~ (params.pagination.page - 1) ~ "&perPage=" ~ params.pagination.perPage ~ titleQuery %}
+    {% set previousHref = (params.baseUrl | default('')) ~ "?page=" ~ (params.pagination.page - 1) ~ "&perPage=" ~ params.pagination.perPage ~ queryParams %}
     {% set previous = {
       href: previousHref,
       labelText: "Previous page",
@@ -18,7 +31,7 @@
 
   {% set next = null %}
   {% if params.pagination.page < params.pagination.totalPages %}
-    {% set nextHref = (params.baseUrl | default('')) ~ "?page=" ~ (params.pagination.page + 1) ~ "&perPage=" ~ params.pagination.perPage ~ titleQuery %}
+    {% set nextHref = (params.baseUrl | default('')) ~ "?page=" ~ (params.pagination.page + 1) ~ "&perPage=" ~ params.pagination.perPage ~ queryParams %}
     {% set next = {
       href: nextHref,
       labelText: "Next page",

--- a/designer/server/src/common/components/pagination/template.test.js
+++ b/designer/server/src/common/components/pagination/template.test.js
@@ -703,6 +703,308 @@ describe('Pagination Component', () => {
       })
     })
 
+    describe('With search author parameter', () => {
+      beforeEach(() => {
+        const { container } = renderMacro(
+          'appPagination',
+          'pagination/macro.njk',
+          {
+            params: {
+              baseUrl: '/library',
+              search: {
+                author: 'Enrique Chase'
+              },
+              pagination: {
+                page: 2,
+                perPage: 10,
+                totalPages: 3,
+                totalItems: 25,
+                pages: [
+                  {
+                    number: '1',
+                    href: '/library?page=1&perPage=10&author=Enrique%20Chase',
+                    current: false
+                  },
+                  {
+                    number: '2',
+                    href: '/library?page=2&perPage=10&author=Enrique%20Chase',
+                    current: true
+                  },
+                  {
+                    number: '3',
+                    href: '/library?page=3&perPage=10&author=Enrique%20Chase',
+                    current: false
+                  }
+                ]
+              }
+            }
+          }
+        )
+
+        $pagination = container.getByRole('navigation', { name: 'Pagination' })
+      })
+
+      it('should include encoded author parameter in navigation links', () => {
+        const $previousLink = within($pagination).getByRole('link', {
+          name: 'Previous'
+        })
+        const $nextLink = within($pagination).getByRole('link', {
+          name: 'Next'
+        })
+
+        expect($previousLink).toHaveAttribute(
+          'href',
+          '/library?page=1&perPage=10&author=Enrique%20Chase'
+        )
+        expect($nextLink).toHaveAttribute(
+          'href',
+          '/library?page=3&perPage=10&author=Enrique%20Chase'
+        )
+      })
+
+      it('should include encoded author parameter in page number links', () => {
+        const $pageLinks = within($pagination).getAllByRole('link', {
+          name: /Page \d+/
+        })
+
+        expect($pageLinks[0]).toHaveAttribute(
+          'href',
+          '/library?page=1&perPage=10&author=Enrique%20Chase'
+        )
+        expect($pageLinks[1]).toHaveAttribute(
+          'href',
+          '/library?page=2&perPage=10&author=Enrique%20Chase'
+        )
+        expect($pageLinks[2]).toHaveAttribute(
+          'href',
+          '/library?page=3&perPage=10&author=Enrique%20Chase'
+        )
+      })
+    })
+
+    describe('With search organisations parameter', () => {
+      beforeEach(() => {
+        const { container } = renderMacro(
+          'appPagination',
+          'pagination/macro.njk',
+          {
+            params: {
+              baseUrl: '/library',
+              search: {
+                organisations: [
+                  'Defra',
+                  'Environment Agency',
+                  'Natural England'
+                ]
+              },
+              pagination: {
+                page: 2,
+                perPage: 10,
+                totalPages: 3,
+                totalItems: 25,
+                pages: [
+                  {
+                    number: '1',
+                    href: '/library?page=1&perPage=10&organisations=Defra&organisations=Environment%20Agency&organisations=Natural%20England',
+                    current: false
+                  },
+                  {
+                    number: '2',
+                    href: '/library?page=2&perPage=10&organisations=Defra&organisations=Environment%20Agency&organisations=Natural%20England',
+                    current: true
+                  },
+                  {
+                    number: '3',
+                    href: '/library?page=3&perPage=10&organisations=Defra&organisations=Environment%20Agency&organisations=Natural%20England',
+                    current: false
+                  }
+                ]
+              }
+            }
+          }
+        )
+
+        $pagination = container.getByRole('navigation', { name: 'Pagination' })
+      })
+
+      it('should include encoded organisations parameter in navigation links', () => {
+        const $previousLink = within($pagination).getByRole('link', {
+          name: 'Previous'
+        })
+        const $nextLink = within($pagination).getByRole('link', {
+          name: 'Next'
+        })
+
+        const expectedParams =
+          'organisations=Defra&organisations=Environment%20Agency&organisations=Natural%20England'
+
+        expect($previousLink).toHaveAttribute(
+          'href',
+          `/library?page=1&perPage=10&${expectedParams}`
+        )
+        expect($nextLink).toHaveAttribute(
+          'href',
+          `/library?page=3&perPage=10&${expectedParams}`
+        )
+      })
+
+      it('should include encoded organisations parameter in page number links', () => {
+        const $pageLinks = within($pagination).getAllByRole('link', {
+          name: /Page \d+/
+        })
+
+        const expectedParams =
+          'organisations=Defra&organisations=Environment%20Agency&organisations=Natural%20England'
+
+        expect($pageLinks[0]).toHaveAttribute(
+          'href',
+          `/library?page=1&perPage=10&${expectedParams}`
+        )
+        expect($pageLinks[1]).toHaveAttribute(
+          'href',
+          `/library?page=2&perPage=10&${expectedParams}`
+        )
+        expect($pageLinks[2]).toHaveAttribute(
+          'href',
+          `/library?page=3&perPage=10&${expectedParams}`
+        )
+      })
+    })
+
+    describe('With search status parameter', () => {
+      beforeEach(() => {
+        const { container } = renderMacro(
+          'appPagination',
+          'pagination/macro.njk',
+          {
+            params: {
+              baseUrl: '/library',
+              search: {
+                status: ['draft', 'live']
+              },
+              pagination: {
+                page: 2,
+                perPage: 10,
+                totalPages: 3,
+                totalItems: 25,
+                pages: [
+                  {
+                    number: '1',
+                    href: '/library?page=1&perPage=10&status=draft&status=live',
+                    current: false
+                  },
+                  {
+                    number: '2',
+                    href: '/library?page=2&perPage=10&status=draft&status=live',
+                    current: true
+                  },
+                  {
+                    number: '3',
+                    href: '/library?page=3&perPage=10&status=draft&status=live',
+                    current: false
+                  }
+                ]
+              }
+            }
+          }
+        )
+
+        $pagination = container.getByRole('navigation', { name: 'Pagination' })
+      })
+
+      it('should include encoded status parameter in navigation links', () => {
+        const $previousLink = within($pagination).getByRole('link', {
+          name: 'Previous'
+        })
+        const $nextLink = within($pagination).getByRole('link', {
+          name: 'Next'
+        })
+
+        expect($previousLink).toHaveAttribute(
+          'href',
+          '/library?page=1&perPage=10&status=draft&status=live'
+        )
+        expect($nextLink).toHaveAttribute(
+          'href',
+          '/library?page=3&perPage=10&status=draft&status=live'
+        )
+      })
+
+      it('should include encoded status parameter in page number links', () => {
+        const $pageLinks = within($pagination).getAllByRole('link', {
+          name: /Page \d+/
+        })
+
+        expect($pageLinks[0]).toHaveAttribute(
+          'href',
+          '/library?page=1&perPage=10&status=draft&status=live'
+        )
+        expect($pageLinks[1]).toHaveAttribute(
+          'href',
+          '/library?page=2&perPage=10&status=draft&status=live'
+        )
+        expect($pageLinks[2]).toHaveAttribute(
+          'href',
+          '/library?page=3&perPage=10&status=draft&status=live'
+        )
+      })
+    })
+
+    describe('With special characters in organisation names', () => {
+      beforeEach(() => {
+        const { container } = renderMacro(
+          'appPagination',
+          'pagination/macro.njk',
+          {
+            params: {
+              baseUrl: '/library',
+              search: {
+                organisations: [
+                  'Animal and Plant Health Agency – APHA',
+                  'Centre for Environment, Fisheries and Aquaculture Science – Cefas',
+                  'Marine Management Organisation – MMO'
+                ]
+              },
+              pagination: {
+                page: 1,
+                perPage: 10,
+                totalPages: 2,
+                totalItems: 15,
+                pages: [
+                  {
+                    number: '1',
+                    href: '/library?page=1&perPage=10',
+                    current: true
+                  },
+                  {
+                    number: '2',
+                    href: '/library?page=2&perPage=10',
+                    current: false
+                  }
+                ]
+              }
+            }
+          }
+        )
+
+        $pagination = container.getByRole('navigation', { name: 'Pagination' })
+      })
+
+      it('should properly encode special characters in organisation names', () => {
+        const $nextLink = within($pagination).getByRole('link', {
+          name: 'Next'
+        })
+
+        const expectedParams =
+          'organisations=Animal%20and%20Plant%20Health%20Agency%20%E2%80%93%20APHA&organisations=Centre%20for%20Environment%2C%20Fisheries%20and%20Aquaculture%20Science%20%E2%80%93%20Cefas&organisations=Marine%20Management%20Organisation%20%E2%80%93%20MMO'
+
+        expect($nextLink).toHaveAttribute(
+          'href',
+          `/library?page=2&perPage=10&${expectedParams}`
+        )
+      })
+    })
+
     describe('With special characters in search title', () => {
       beforeEach(() => {
         const { container } = renderMacro(

--- a/designer/server/src/common/components/search/_search.scss
+++ b/designer/server/src/common/components/search/_search.scss
@@ -11,6 +11,10 @@
     margin-top: govuk-spacing(4);
   }
 
+  .govuk-accordion {
+    margin-bottom: govuk-spacing(4);
+  }
+
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(0);
 

--- a/designer/server/src/common/components/search/template.njk
+++ b/designer/server/src/common/components/search/template.njk
@@ -24,10 +24,10 @@
   }) }}
 
   {% set hasActiveSearch = (params.search.title and params.search.title != "") or
-                          (params.search.author and params.search.author != "") or
-                          (params.search.author == "all" or params.search.author == "") or
-                          (params.search.organisations and params.search.organisations | length) or
-                          (params.search.status and params.search.status | length) %}
+                        (params.search.author == "all") or
+                        (params.search.author and params.search.author != "" and params.search.author != "all") or
+                        (params.search.organisations and params.search.organisations | length) or
+                        (params.search.status and params.search.status | length) %}
 
   {% if hasActiveSearch %}
     <div class="govuk-inset-text govuk-!-margin-bottom-4" aria-labelledby="applied-filters-heading">
@@ -49,9 +49,12 @@
           {% endif %}
         </li>
         {% if params.search.organisations and params.search.organisations | length %}
-          {% for org in params.search.organisations %}
-            <li><strong>Organisation:</strong> {{ org }}</li>
-          {% endfor %}
+          <li>
+            <strong>Organisation:</strong>
+            {% for org in params.search.organisations %}
+              {{ org }}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          </li>
         {% endif %}
         {% if params.search.status and params.search.status | length %}
           {% for state in params.search.status %}

--- a/designer/server/src/common/components/search/template.njk
+++ b/designer/server/src/common/components/search/template.njk
@@ -37,7 +37,7 @@
           <li><strong>Name:</strong> {{ params.search.title }}</li>
         {% endif %}
         <li>
-          <strong>Author:</strong> 
+          <strong>Author:</strong>
           {% if params.search.author and params.search.author != "" %}
             {% if params.displayName and params.search.author == params.displayName %}
               Me ({{ params.search.author }})

--- a/designer/server/src/common/components/search/template.njk
+++ b/designer/server/src/common/components/search/template.njk
@@ -1,8 +1,8 @@
-{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
-{% set title = params.search.title %}
-{% set baseUrl = params.baseUrl %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/accordion/macro.njk" import govukAccordion %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 <form method="get" action="/library" class="app-search-form" aria-labelledby="search-form-heading">
   <h2 id="search-form-heading" class="govuk-heading-m">Search</h2>
@@ -19,17 +19,46 @@
     },
     id: "form-title",
     name: "title",
-    value: title,
+    value: params.search.title or "",
     classes: "govuk-!-width-full"
   }) }}
 
-  {% if params.search and params.search.title %}
-  <div class="govuk-inset-text govuk-!-margin-bottom-4" aria-labelledby="applied-filters-heading">
-    <h3 id="applied-filters-heading" class="govuk-heading-s">Applied filters:</h3>
-    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
-      <li><strong>Name:</strong> {{ params.search.title }}</li>
-    </ul>
-  </div>
+  {% set hasActiveSearch = (params.search.title and params.search.title != "") or 
+                          (params.search.author and params.search.author != "") or 
+                          (params.search.organisations and params.search.organisations | length) or 
+                          (params.search.status and params.search.status | length) %}
+
+  {% if hasActiveSearch %}
+    <div class="govuk-inset-text govuk-!-margin-bottom-4" aria-labelledby="applied-filters-heading">
+      <h3 id="applied-filters-heading" class="govuk-heading-s">Applied filters:</h3>
+      <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+        {% if params.search.title and params.search.title != "" %}
+          <li><strong>Name:</strong> {{ params.search.title }}</li>
+        {% endif %}
+        <li>
+          <strong>Author:</strong> 
+          {% if params.search.author and params.search.author != "" %}
+            {% if params.displayName and params.search.author == params.displayName %}
+              Me ({{ params.search.author }})
+            {% else %}
+              {{ params.search.author }}
+            {% endif %}
+          {% else %}
+            all
+          {% endif %}
+        </li>
+        {% if params.search.organisations and params.search.organisations | length %}
+          {% for org in params.search.organisations %}
+            <li><strong>Organisation:</strong> {{ org }}</li>
+          {% endfor %}
+        {% endif %}
+        {% if params.search.status and params.search.status | length %}
+          {% for state in params.search.status %}
+            <li><strong>State:</strong> {{ state | capitalize }}</li>
+          {% endfor %}
+        {% endif %}
+      </ul>
+    </div>
   {% endif %}
 
   <div class="govuk-button-group govuk-!-margin-bottom-4">
@@ -39,7 +68,124 @@
     }) }}
     {{ govukButton({
       text: "Clear filters",
-      href: baseUrl,
+      href: params.baseUrl,
+      classes: "govuk-button--secondary"
+    }) }}
+  </div>
+
+  <h3 class="govuk-heading-m govuk-!-margin-bottom-1">Advanced search</h3>
+  <p class="govuk-body">Apply additional filters</p>
+
+  {% set authors = params.filters.authors | default([]) %}
+  {% set organisations = params.filters.organisations | default([]) %}
+  {% set statuses = params.filters.statuses | default([]) %}
+
+  {% set authorsRadios = [] %}
+  {% for a in authors %}
+    {% if params.displayName and a == params.displayName %}
+      {% set authorsRadios = (authorsRadios.push({
+        text: "Me (" + a + ")",
+        value: a,
+        checked: params.search.author == a
+      }), authorsRadios) %}
+    {% else %}
+      {% set authorsRadios = (authorsRadios.push({
+        text: a,
+        value: a,
+        checked: params.search.author == a
+      }), authorsRadios) %}
+    {% endif %}
+  {% endfor %}
+  {% set authorsRadios = (authorsRadios.push({
+    text: "All authors",
+    value: "",
+    checked: not params.search.author
+  }), authorsRadios) %}
+
+  {% set orgCheckBoxes = [] %}
+  {% for org in organisations %}
+    {% set orgCheckBoxes = (orgCheckBoxes.push({
+      text: org,
+      value: org,
+      checked: params.search.organisations and (org in params.search.organisations)
+    }), orgCheckBoxes) %}
+  {% endfor %}
+
+  {% set statusCheckBoxes = [] %}
+  {% for status in statuses %}
+    {% set statusCheckBoxes = (statusCheckBoxes.push({
+      text: status | capitalize,
+      value: status,
+      checked: params.search.status and (status in params.search.status)
+    }), statusCheckBoxes) %}
+  {% endfor %}
+
+  {{ govukAccordion({
+    id: "search-filters-advanced",
+    rememberExpanded: false,
+    items: [
+      {
+        heading: { text: "Authors" },
+        expanded: params.search.author != "",
+        content: {
+          html: govukRadios({
+            name: "author",
+            classes: "govuk-radios--small",
+            fieldset: {
+              legend: {
+                text: "Select all authors that apply",
+                isPageHeading: false
+              }
+            },
+            items: authorsRadios
+          }) | safe
+        }
+      },
+      {
+        heading: { text: "Organisation" },
+        expanded: params.search.organisations and params.search.organisations.length > 0,
+        content: {
+          html: govukCheckboxes({
+            name: "organisations",
+            classes: "govuk-checkboxes--small",
+            fieldset: {
+              legend: {
+                text: "Select all organisations that apply",
+                isPageHeading: false
+              }
+            },
+            items: orgCheckBoxes
+          }) | safe
+        }
+      },
+      {
+        heading: { text: "State" },
+        expanded: params.search.status and params.search.status.length > 0,
+        content: {
+          html: govukCheckboxes({
+            name: "status",
+            classes: "govuk-checkboxes--small",
+            fieldset: {
+              legend: {
+                text: "Select all states that apply",
+                isPageHeading: false
+              }
+            },
+            items: statusCheckBoxes
+          }) | safe
+        }
+      }
+    ]
+  }) }}
+
+  <div class="govuk-button-group govuk-!-margin-bottom-4">
+    {{ govukButton({
+      text: "Apply filters",
+      classes: "app-search-form__submit"
+    }) }}
+    {{ govukButton({
+      text: "Clear filters",
+      href: params.baseUrl,
       classes: "govuk-button--secondary"
     }) }}
   </div>

--- a/designer/server/src/common/components/search/template.njk
+++ b/designer/server/src/common/components/search/template.njk
@@ -23,10 +23,10 @@
     classes: "govuk-!-width-full"
   }) }}
 
-  {% set hasActiveSearch = (params.search.title and params.search.title != "") or 
-                          (params.search.author and params.search.author != "") or 
-                          params.search.author == "all" or 
-                          (params.search.organisations and params.search.organisations | length) or 
+  {% set hasActiveSearch = (params.search.title and params.search.title != "") or
+                          (params.search.author and params.search.author != "") or
+                          (params.search.author == "all" or params.search.author == "") or
+                          (params.search.organisations and params.search.organisations | length) or
                           (params.search.status and params.search.status | length) %}
 
   {% if hasActiveSearch %}

--- a/designer/server/src/common/components/search/template.njk
+++ b/designer/server/src/common/components/search/template.njk
@@ -25,6 +25,7 @@
 
   {% set hasActiveSearch = (params.search.title and params.search.title != "") or 
                           (params.search.author and params.search.author != "") or 
+                          params.search.author == "all" or 
                           (params.search.organisations and params.search.organisations | length) or 
                           (params.search.status and params.search.status | length) %}
 
@@ -98,8 +99,8 @@
   {% endfor %}
   {% set authorsRadios = (authorsRadios.push({
     text: "All authors",
-    value: "",
-    checked: not params.search.author
+    value: "all",
+    checked: params.search.author == "all" or not params.search.author
   }), authorsRadios) %}
 
   {% set orgCheckBoxes = [] %}

--- a/designer/server/src/common/components/search/template.test.js
+++ b/designer/server/src/common/components/search/template.test.js
@@ -65,19 +65,23 @@ describe('Search Component', () => {
         expect($filterItems[0]).toHaveTextContent('Name: Some Form')
       })
 
-      it('should render the button group', () => {
-        const $applyButton = within($search).getByRole('button', {
+      it('should render the button groups', () => {
+        const $applyButtons = within($search).getAllByRole('button', {
           name: 'Apply filters'
         })
-        expect($applyButton).toBeInTheDocument()
-        expect($applyButton).toHaveClass('app-search-form__submit')
+        expect($applyButtons).toHaveLength(2)
+        $applyButtons.forEach(($button) => {
+          expect($button).toHaveClass('app-search-form__submit')
+        })
 
-        const $clearButton = within($search).getByRole('button', {
+        const $clearButtons = within($search).getAllByRole('button', {
           name: 'Clear filters'
         })
-        expect($clearButton).toBeInTheDocument()
-        expect($clearButton).toHaveClass('govuk-button--secondary')
-        expect($clearButton).toHaveAttribute('href', '/library')
+        expect($clearButtons).toHaveLength(2)
+        $clearButtons.forEach(($button) => {
+          expect($button).toHaveClass('govuk-button--secondary')
+          expect($button).toHaveAttribute('href', '/library')
+        })
       })
     })
 
@@ -126,11 +130,14 @@ describe('Search Component', () => {
         expect($search).toHaveAttribute('action', '/library')
       })
 
-      it('should use the correct base URL for clear filters button', () => {
-        const $clearButton = within($search).getByRole('button', {
+      it('should use the correct base URL for clear filters buttons', () => {
+        const $clearButtons = within($search).getAllByRole('button', {
           name: 'Clear filters'
         })
-        expect($clearButton).toHaveAttribute('href', '/different-path')
+        expect($clearButtons).toHaveLength(2)
+        $clearButtons.forEach(($button) => {
+          expect($button).toHaveAttribute('href', '/different-path')
+        })
       })
     })
 
@@ -159,13 +166,223 @@ describe('Search Component', () => {
         expect($sortInput).toHaveAttribute('name', 'sort')
       })
     })
+
+    describe('With author search', () => {
+      beforeEach(() => {
+        const { container } = renderMacro('appSearch', 'search/macro.njk', {
+          params: {
+            baseUrl: '/library',
+            displayName: 'Current User',
+            search: {
+              author: 'Current User'
+            },
+            filters: {
+              authors: ['Current User', 'Other Author']
+            }
+          }
+        })
+
+        $search = container.getByRole('form', { name: 'Search' })
+      })
+
+      it('should render the author filter in applied filters', () => {
+        const $filtersList = within($search).getByRole('list')
+        const $filterItems = within($filtersList).getAllByRole('listitem')
+        expect($filterItems).toHaveLength(1)
+        expect($filterItems[0]).toHaveTextContent('Author: Me (Current User)')
+      })
+
+      it('should render the authors radio group', () => {
+        const $authorsGroup = within($search).getByRole('group', {
+          name: 'Select all authors that apply'
+        })
+        expect($authorsGroup).toBeInTheDocument()
+
+        const $options = within($authorsGroup).getAllByRole('radio')
+        expect($options).toHaveLength(3)
+        expect($options[0]).toBeChecked()
+        expect($options[1]).not.toBeChecked()
+        expect($options[2]).not.toBeChecked()
+
+        expect($authorsGroup).toHaveFormValues({
+          author: 'Current User'
+        })
+      })
+
+      describe('when "All authors" is selected', () => {
+        beforeEach(() => {
+          const { container } = renderMacro('appSearch', 'search/macro.njk', {
+            params: {
+              baseUrl: '/library',
+              search: {
+                author: 'all'
+              },
+              filters: {
+                authors: ['Current User', 'Other Author']
+              }
+            }
+          })
+
+          $search = container.getByRole('form', { name: 'Search' })
+        })
+
+        it('should render "all" in the applied filters', () => {
+          const $filtersList = within($search).getByRole('list')
+          const $filterItems = within($filtersList).getAllByRole('listitem')
+          expect($filterItems).toHaveLength(1)
+          expect($filterItems[0]).toHaveTextContent('Author: all')
+        })
+
+        it('should have "All authors" radio option checked', () => {
+          const $authorsGroup = within($search).getByRole('group', {
+            name: 'Select all authors that apply'
+          })
+          const $options = within($authorsGroup).getAllByRole('radio')
+          expect($options[2]).toBeChecked()
+
+          expect($authorsGroup).toHaveFormValues({
+            author: 'all'
+          })
+        })
+      })
+    })
+
+    describe('With organisation search', () => {
+      beforeEach(() => {
+        const { container } = renderMacro('appSearch', 'search/macro.njk', {
+          params: {
+            baseUrl: '/library',
+            search: {
+              organisations: ['Defra', 'Environment Agency']
+            },
+            filters: {
+              organisations: ['Defra', 'Environment Agency', 'Natural England']
+            }
+          }
+        })
+
+        $search = container.getByRole('form', { name: 'Search' })
+      })
+
+      it('should render the organisation filters in applied filters', () => {
+        const $filtersList = within($search).getByRole('list')
+        const $filterItems = within($filtersList).getAllByRole('listitem')
+        expect($filterItems).toHaveLength(2)
+        expect($filterItems[0]).toHaveTextContent('Author: all')
+        expect($filterItems[1]).toHaveTextContent(
+          'Organisation: Defra, Environment Agency'
+        )
+      })
+
+      it('should render the organisations checkbox group', () => {
+        const $orgCheckboxes = within($search).getByRole('group', {
+          name: 'Select all organisations that apply'
+        })
+        expect($orgCheckboxes).toBeInTheDocument()
+
+        const $options = within($orgCheckboxes).getAllByRole('checkbox')
+        expect($options).toHaveLength(3)
+        expect($options[0]).toBeChecked()
+        expect($options[1]).toBeChecked()
+        expect($options[2]).not.toBeChecked()
+      })
+    })
+
+    describe('With status search', () => {
+      beforeEach(() => {
+        const { container } = renderMacro('appSearch', 'search/macro.njk', {
+          params: {
+            baseUrl: '/library',
+            search: {
+              status: ['draft', 'live']
+            },
+            filters: {
+              statuses: ['draft', 'live']
+            }
+          }
+        })
+
+        $search = container.getByRole('form', { name: 'Search' })
+      })
+
+      it('should render the status filters in applied filters', () => {
+        const $filtersList = within($search).getByRole('list')
+        const $filterItems = within($filtersList).getAllByRole('listitem')
+        expect($filterItems).toHaveLength(3)
+        expect($filterItems[0]).toHaveTextContent('Author: all')
+        expect($filterItems[1]).toHaveTextContent('State: Draft')
+        expect($filterItems[2]).toHaveTextContent('State: Live')
+      })
+
+      it('should render the status checkbox group', () => {
+        const $statusCheckboxes = within($search).getByRole('group', {
+          name: 'Select all states that apply'
+        })
+        expect($statusCheckboxes).toBeInTheDocument()
+
+        const $options = within($statusCheckboxes).getAllByRole('checkbox')
+        expect($options).toHaveLength(2)
+        expect($options[0]).toBeChecked()
+        expect($options[1]).toBeChecked()
+      })
+    })
+
+    describe('With all filter types', () => {
+      beforeEach(() => {
+        const { container } = renderMacro('appSearch', 'search/macro.njk', {
+          params: {
+            baseUrl: '/library',
+            displayName: 'Current User',
+            search: {
+              title: 'Test Form',
+              author: 'Current User',
+              organisations: ['Defra'],
+              status: ['draft']
+            },
+            filters: {
+              authors: ['Current User', 'Other Author'],
+              organisations: ['Defra', 'Environment Agency'],
+              statuses: ['draft', 'live']
+            }
+          }
+        })
+
+        $search = container.getByRole('form', { name: 'Search' })
+      })
+
+      it('should render all applied filters in correct order', () => {
+        const $filtersList = within($search).getByRole('list')
+        const $filterItems = within($filtersList).getAllByRole('listitem')
+        expect($filterItems).toHaveLength(4)
+        expect($filterItems[0]).toHaveTextContent('Name: Test Form')
+        expect($filterItems[1]).toHaveTextContent('Author: Me (Current User)')
+        expect($filterItems[2]).toHaveTextContent('Organisation: Defra')
+        expect($filterItems[3]).toHaveTextContent('State: Draft')
+      })
+
+      it('should expand all filter sections with active filters', () => {
+        const $accordionSections = within($search).getAllByRole('heading', {
+          level: 2,
+          name: /Authors|Organisation|State/
+        })
+
+        $accordionSections.forEach(($heading) => {
+          const $section = $heading.closest('.govuk-accordion__section')
+          expect($section).toHaveClass('govuk-accordion__section--expanded')
+        })
+      })
+    })
   })
 
   describe('Without search data', () => {
     beforeEach(() => {
       const { container } = renderMacro('appSearch', 'search/macro.njk', {
         params: {
-          baseUrl: '/library'
+          baseUrl: '/library',
+          displayName: 'Current User',
+          filters: {
+            authors: ['Current User', 'Other Author']
+          }
         }
       })
 
@@ -191,6 +408,21 @@ describe('Search Component', () => {
         name: 'Form name'
       })
       expect($input).toHaveValue('')
+    })
+
+    it('should have "All authors" radio option checked by default', () => {
+      const $authorsGroup = within($search).getByRole('group', {
+        name: 'Select all authors that apply'
+      })
+      const $options = within($authorsGroup).getAllByRole('radio')
+      expect($options).toHaveLength(3)
+      expect($options[0]).not.toBeChecked()
+      expect($options[1]).not.toBeChecked()
+      expect($options[2]).toBeChecked()
+
+      expect($authorsGroup).toHaveFormValues({
+        author: 'all'
+      })
     })
   })
 

--- a/designer/server/src/common/components/sorting/template.njk
+++ b/designer/server/src/common/components/sorting/template.njk
@@ -6,6 +6,19 @@
   {% if params.search.title %}
     <input type="hidden" name="title" value="{{ params.search.title | escape }}">
   {% endif %}
+  {% if params.search.author %}
+    <input type="hidden" name="author" value="{{ params.search.author | escape }}">
+  {% endif %}
+  {% if params.search.organisations and params.search.organisations | length %}
+    {% for org in params.search.organisations %}
+      <input type="hidden" name="organisations" value="{{ org | escape }}">
+    {% endfor %}
+  {% endif %}
+  {% if params.search.status and params.search.status | length %}
+    {% for state in params.search.status %}
+      <input type="hidden" name="status" value="{{ state | escape }}">
+    {% endfor %}
+  {% endif %}
 
   <div class="app-field-group">
     <div class="app-field-group__item">

--- a/designer/server/src/common/components/sorting/template.test.js
+++ b/designer/server/src/common/components/sorting/template.test.js
@@ -188,6 +188,88 @@ describe('Sorting Component', () => {
         })
       })
     })
+
+    describe('With author search parameter', () => {
+      beforeEach(() => {
+        const { container } = renderMacro('appSorting', 'sorting/macro.njk', {
+          params: {
+            sorting: {
+              sortBy: 'updatedAt',
+              order: 'desc'
+            },
+            search: {
+              author: 'Enrique Chase'
+            }
+          }
+        })
+
+        $sorting = container.getByRole('form', { name: 'Sorting options' })
+      })
+
+      it('should render hidden author input with correct value', () => {
+        const hiddenInput = within($sorting).getByDisplayValue('Enrique Chase')
+        expect(hiddenInput).toBeInTheDocument()
+        expect(hiddenInput).toHaveAttribute('type', 'hidden')
+        expect(hiddenInput).toHaveAttribute('name', 'author')
+      })
+    })
+
+    describe('With organisations search parameter', () => {
+      beforeEach(() => {
+        const { container } = renderMacro('appSorting', 'sorting/macro.njk', {
+          params: {
+            sorting: {
+              sortBy: 'updatedAt',
+              order: 'desc'
+            },
+            search: {
+              organisations: ['Defra', 'Environment Agency']
+            }
+          }
+        })
+
+        $sorting = container.getByRole('form', { name: 'Sorting options' })
+      })
+
+      it('should render hidden organisation inputs for each value', () => {
+        const orgInputs = within($sorting).getAllByDisplayValue(
+          /(Defra|Environment Agency)/
+        )
+        expect(orgInputs).toHaveLength(2)
+        orgInputs.forEach((input) => {
+          expect(input).toHaveAttribute('type', 'hidden')
+          expect(input).toHaveAttribute('name', 'organisations')
+        })
+      })
+    })
+
+    describe('With status search parameter', () => {
+      beforeEach(() => {
+        const { container } = renderMacro('appSorting', 'sorting/macro.njk', {
+          params: {
+            sorting: {
+              sortBy: 'updatedAt',
+              order: 'desc'
+            },
+            search: {
+              status: ['draft', 'live']
+            }
+          }
+        })
+
+        $sorting = container.getByRole('form', { name: 'Sorting options' })
+      })
+
+      it('should render hidden status inputs for each value', () => {
+        const statusInputs =
+          within($sorting).getAllByDisplayValue(/(draft|live)/)
+        expect(statusInputs).toHaveLength(2)
+        statusInputs.forEach((input) => {
+          expect(input).toHaveAttribute('type', 'hidden')
+          expect(input).toHaveAttribute('name', 'status')
+        })
+      })
+    })
   })
 
   describe('Without sorting data', () => {

--- a/designer/server/src/lib/forms.js
+++ b/designer/server/src/lib/forms.js
@@ -27,6 +27,22 @@ export async function list(token, options) {
     requestUrl.searchParams.append('title', options.title)
   }
 
+  if (options.author) {
+    requestUrl.searchParams.append('author', options.author)
+  }
+
+  if (options.organisations?.length) {
+    options.organisations.forEach((org) =>
+      requestUrl.searchParams.append('organisations', org)
+    )
+  }
+
+  if (options.status?.length) {
+    options.status.forEach((status) =>
+      requestUrl.searchParams.append('status', status)
+    )
+  }
+
   const { body } = await getJsonByType(requestUrl, getHeaders(token))
 
   return body

--- a/designer/server/src/lib/forms.test.js
+++ b/designer/server/src/lib/forms.test.js
@@ -513,11 +513,118 @@ describe('Forms library routes', () => {
 
         expect(result).toEqual(mockResponse)
       })
+
+      it('should append author parameter when provided', async () => {
+        const options = {
+          page: 1,
+          perPage: 10,
+          author: authorDisplayName
+        }
+        const mockResponse = {
+          data: [formMetadata],
+          meta: {
+            pagination: {
+              page: 1,
+              perPage: 10,
+              totalPages: 1,
+              totalItems: 1
+            }
+          }
+        }
+
+        jest.spyOn(fetch, 'getJson').mockResolvedValueOnce({
+          /** @type {any} */
+          response: {},
+          body: mockResponse
+        })
+
+        const result = await forms.list(token, options)
+
+        const fetchGetJsonMock = /** @type {jest.Mock} */ (fetch.getJson)
+        /** @type {Array<[URL, object]>} */
+        const mockCalls = fetchGetJsonMock.mock.calls
+        const calledUrl = /** @type {URL} */ (mockCalls[0][0])
+
+        expect(calledUrl.searchParams.get('author')).toBe(authorDisplayName)
+        expect(result).toEqual(mockResponse)
+      })
+
+      it('should append organisations parameters when provided', async () => {
+        const options = {
+          page: 1,
+          perPage: 10,
+          organisations: ['Defra', 'Environment Agency']
+        }
+        const mockResponse = {
+          data: [formMetadata],
+          meta: {
+            pagination: {
+              page: 1,
+              perPage: 10,
+              totalPages: 1,
+              totalItems: 1
+            }
+          }
+        }
+
+        jest.spyOn(fetch, 'getJson').mockResolvedValueOnce({
+          /** @type {any} */
+          response: {},
+          body: mockResponse
+        })
+
+        const result = await forms.list(token, options)
+
+        const fetchGetJsonMock = /** @type {jest.Mock} */ (fetch.getJson)
+        /** @type {Array<[URL, object]>} */
+        const mockCalls = fetchGetJsonMock.mock.calls
+        const calledUrl = /** @type {URL} */ (mockCalls[0][0])
+
+        const organisations = calledUrl.searchParams.getAll('organisations')
+        expect(organisations).toEqual(['Defra', 'Environment Agency'])
+        expect(result).toEqual(mockResponse)
+      })
+
+      it('should append status parameters when provided', async () => {
+        const options = {
+          page: 1,
+          perPage: 10,
+          status: /** @type {FormStatus[]} */ (['draft', 'live'])
+        }
+        const mockResponse = {
+          data: [formMetadata],
+          meta: {
+            pagination: {
+              page: 1,
+              perPage: 10,
+              totalPages: 1,
+              totalItems: 1
+            }
+          }
+        }
+
+        jest.spyOn(fetch, 'getJson').mockResolvedValueOnce({
+          /** @type {any} */
+          response: {},
+          body: mockResponse
+        })
+
+        const result = await forms.list(token, options)
+
+        const fetchGetJsonMock = /** @type {jest.Mock} */ (fetch.getJson)
+        /** @type {Array<[URL, object]>} */
+        const mockCalls = fetchGetJsonMock.mock.calls
+        const calledUrl = /** @type {URL} */ (mockCalls[0][0])
+
+        const statuses = calledUrl.searchParams.getAll('status')
+        expect(statuses).toEqual(['draft', 'live'])
+        expect(result).toEqual(mockResponse)
+      })
     })
   })
 })
 
 /**
- * @import { FormDefinition, FormMetadata, FormMetadataAuthor } from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadata, FormMetadataAuthor, FormStatus } from '@defra/forms-model'
  * @import { Server } from '@hapi/hapi'
  */

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -27,6 +27,7 @@ import {
  * @property {string} [notification] - The notification to display
  * @property {SortingOptions | undefined} sorting - The sorting options.
  * @property {SearchOptions | undefined} search - The search options.
+ * @property {{ filters: FilterOptions | undefined }} meta - The metadata containing filter options.
  */
 
 /**
@@ -44,6 +45,7 @@ export async function listViewModel(token, listOptions, notification) {
   const paginationMeta = formResponse.meta.pagination ?? undefined
   const sortingMeta = formResponse.meta.sorting ?? undefined
   const searchMeta = formResponse.meta.search ?? undefined
+  const filtersMeta = formResponse.meta.filters ?? undefined
 
   let pagination
   if (paginationMeta) {
@@ -79,7 +81,10 @@ export async function listViewModel(token, listOptions, notification) {
     pagination,
     sorting: sortingMeta,
     search: searchMeta,
-    notification
+    notification,
+    meta: {
+      filters: filtersMeta
+    }
   }
 }
 
@@ -125,6 +130,20 @@ function buildPaginationPages(
 
     if (search?.title) {
       queryParams.set('title', search.title)
+    }
+
+    if (search?.author) {
+      queryParams.set('author', search.author)
+    }
+
+    if (search?.organisations?.length) {
+      search.organisations.forEach((org) =>
+        queryParams.append('organisations', org)
+      )
+    }
+
+    if (search?.status?.length) {
+      search.status.forEach((status) => queryParams.append('status', status))
     }
 
     return {
@@ -286,5 +305,5 @@ export function getFormSpecificNavigation(formPath, metadata, activePage = '') {
 }
 
 /**
- * @import { FormDefinition, FormMetadata, PaginationResult, QueryOptions, SortingOptions, SearchOptions } from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadata, PaginationResult, QueryOptions, SortingOptions, SearchOptions, FilterOptions } from '@defra/forms-model'
  */

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -132,7 +132,9 @@ function buildPaginationPages(
       queryParams.set('title', search.title)
     }
 
-    if (search?.author) {
+    if (search?.author === '') {
+      queryParams.set('author', 'all')
+    } else if (search?.author) {
       queryParams.set('author', search.author)
     }
 

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -132,10 +132,8 @@ function buildPaginationPages(
       queryParams.set('title', search.title)
     }
 
-    if (search?.author === '') {
-      queryParams.set('author', 'all')
-    } else if (search?.author) {
-      queryParams.set('author', search.author)
+    if (search?.author !== undefined) {
+      queryParams.set('author', search.author === '' ? 'all' : search.author)
     }
 
     if (search?.organisations?.length) {

--- a/designer/server/src/models/forms/library.test.js
+++ b/designer/server/src/models/forms/library.test.js
@@ -798,7 +798,7 @@ describe('Forms Library Models', () => {
     })
 
     describe('when search options are provided', () => {
-      it('includes search parameters in pagination hrefs', async () => {
+      it('includes title search parameters in pagination hrefs', async () => {
         const mockFormResponse = {
           data: [metadataWithDraft],
           meta: {
@@ -841,7 +841,7 @@ describe('Forms Library Models', () => {
         ])
       })
 
-      it('includes search parameters with sorting in pagination hrefs', async () => {
+      it('includes title search parameters with sorting in pagination hrefs', async () => {
         const mockFormResponse = {
           data: [metadataWithDraft],
           meta: {
@@ -889,10 +889,139 @@ describe('Forms Library Models', () => {
           }
         ])
       })
+
+      it('includes author search parameter in pagination hrefs', async () => {
+        const mockFormResponse = {
+          data: [metadataWithDraft],
+          meta: {
+            pagination: {
+              page: 2,
+              perPage: 10,
+              totalPages: 3,
+              totalItems: 30
+            },
+            search: {
+              author: 'Enrique Chase'
+            }
+          }
+        }
+
+        jest.spyOn(forms, 'list').mockResolvedValue(mockFormResponse)
+        const viewModel = await listViewModel('token', {
+          page: 2,
+          perPage: 10,
+          author: 'Enrique Chase'
+        })
+
+        expect(viewModel.pagination).toBeTruthy()
+        expect(viewModel.pagination?.pages).toEqual([
+          {
+            number: '1',
+            href: `${formsLibraryPath}?page=1&perPage=10&author=Enrique+Chase`,
+            current: false
+          },
+          {
+            number: '2',
+            href: `${formsLibraryPath}?page=2&perPage=10&author=Enrique+Chase`,
+            current: true
+          },
+          {
+            number: '3',
+            href: `${formsLibraryPath}?page=3&perPage=10&author=Enrique+Chase`,
+            current: false
+          }
+        ])
+      })
+
+      it('includes multiple organisations in pagination hrefs', async () => {
+        const mockFormResponse = {
+          data: [metadataWithDraft],
+          meta: {
+            pagination: {
+              page: 2,
+              perPage: 10,
+              totalPages: 3,
+              totalItems: 30
+            },
+            search: {
+              organisations: ['Defra', 'EA']
+            }
+          }
+        }
+
+        jest.spyOn(forms, 'list').mockResolvedValue(mockFormResponse)
+        const viewModel = await listViewModel('token', {
+          page: 2,
+          perPage: 10,
+          organisations: ['Defra', 'EA']
+        })
+
+        expect(viewModel.pagination).toBeTruthy()
+        expect(viewModel.pagination?.pages).toEqual([
+          {
+            number: '1',
+            href: `${formsLibraryPath}?page=1&perPage=10&organisations=Defra&organisations=EA`,
+            current: false
+          },
+          {
+            number: '2',
+            href: `${formsLibraryPath}?page=2&perPage=10&organisations=Defra&organisations=EA`,
+            current: true
+          },
+          {
+            number: '3',
+            href: `${formsLibraryPath}?page=3&perPage=10&organisations=Defra&organisations=EA`,
+            current: false
+          }
+        ])
+      })
+
+      it('includes multiple status values in pagination hrefs', async () => {
+        const mockFormResponse = {
+          data: [metadataWithDraft],
+          meta: {
+            pagination: {
+              page: 2,
+              perPage: 10,
+              totalPages: 3,
+              totalItems: 30
+            },
+            search: {
+              status: /** @type {FormStatus[]} */ (['draft', 'live'])
+            }
+          }
+        }
+
+        jest.spyOn(forms, 'list').mockResolvedValue(mockFormResponse)
+        const viewModel = await listViewModel('token', {
+          page: 2,
+          perPage: 10,
+          status: ['draft', 'live']
+        })
+
+        expect(viewModel.pagination).toBeTruthy()
+        expect(viewModel.pagination?.pages).toEqual([
+          {
+            number: '1',
+            href: `${formsLibraryPath}?page=1&perPage=10&status=draft&status=live`,
+            current: false
+          },
+          {
+            number: '2',
+            href: `${formsLibraryPath}?page=2&perPage=10&status=draft&status=live`,
+            current: true
+          },
+          {
+            number: '3',
+            href: `${formsLibraryPath}?page=3&perPage=10&status=draft&status=live`,
+            current: false
+          }
+        ])
+      })
     })
   })
 })
 
 /**
- * @import { FormMetadata } from '@defra/forms-model'
+ * @import { FormMetadata, FormStatus } from '@defra/forms-model'
  */

--- a/designer/server/src/models/forms/library.test.js
+++ b/designer/server/src/models/forms/library.test.js
@@ -384,6 +384,117 @@ describe('Forms Library Models', () => {
         )
       })
     })
+
+    describe('when pagination with "all" author', () => {
+      it('preserves "all" author in pagination URLs', async () => {
+        const mockFormResponse = {
+          data: [metadataWithDraft],
+          meta: {
+            pagination: {
+              page: 2,
+              perPage: 10,
+              totalPages: 3,
+              totalItems: 30
+            },
+            search: {
+              author: ''
+            }
+          }
+        }
+
+        jest.spyOn(forms, 'list').mockResolvedValue(mockFormResponse)
+        const viewModel = await listViewModel('token', {
+          page: 2,
+          perPage: 10,
+          author: 'all'
+        })
+
+        expect(viewModel.pagination?.pages[0].href).toContain('author=all')
+      })
+    })
+
+    describe('when search options include author parameter', () => {
+      it('includes "all" in pagination hrefs when author is empty string', async () => {
+        const mockFormResponse = {
+          data: [metadataWithDraft],
+          meta: {
+            pagination: {
+              page: 2,
+              perPage: 10,
+              totalPages: 3,
+              totalItems: 30
+            },
+            search: {
+              author: ''
+            }
+          }
+        }
+
+        jest.spyOn(forms, 'list').mockResolvedValue(mockFormResponse)
+        const viewModel = await listViewModel('token', {
+          page: 2,
+          perPage: 10,
+          author: ''
+        })
+
+        expect(viewModel.pagination?.pages[0].href).toContain('author=all')
+        expect(viewModel.pagination?.pages[1].href).toContain('author=all')
+        expect(viewModel.pagination?.pages[2].href).toContain('author=all')
+      })
+
+      it('includes specific author name in pagination hrefs when author is provided', async () => {
+        const mockFormResponse = {
+          data: [metadataWithDraft],
+          meta: {
+            pagination: {
+              page: 2,
+              perPage: 10,
+              totalPages: 3,
+              totalItems: 30
+            },
+            search: {
+              author: 'Enrique'
+            }
+          }
+        }
+
+        jest.spyOn(forms, 'list').mockResolvedValue(mockFormResponse)
+        const viewModel = await listViewModel('token', {
+          page: 2,
+          perPage: 10,
+          author: 'Enrique'
+        })
+
+        expect(viewModel.pagination?.pages[0].href).toContain('author=Enrique')
+        expect(viewModel.pagination?.pages[1].href).toContain('author=Enrique')
+        expect(viewModel.pagination?.pages[2].href).toContain('author=Enrique')
+      })
+
+      it('omits author parameter when author is not provided in search options', async () => {
+        const mockFormResponse = {
+          data: [metadataWithDraft],
+          meta: {
+            pagination: {
+              page: 2,
+              perPage: 10,
+              totalPages: 3,
+              totalItems: 30
+            },
+            search: {}
+          }
+        }
+
+        jest.spyOn(forms, 'list').mockResolvedValue(mockFormResponse)
+        const viewModel = await listViewModel('token', {
+          page: 2,
+          perPage: 10
+        })
+
+        expect(viewModel.pagination?.pages[0].href).not.toContain('author=')
+        expect(viewModel.pagination?.pages[1].href).not.toContain('author=')
+        expect(viewModel.pagination?.pages[2].href).not.toContain('author=')
+      })
+    })
   })
 
   describe('listViewModel pagination', () => {

--- a/designer/server/src/routes/forms/library.js
+++ b/designer/server/src/routes/forms/library.js
@@ -24,19 +24,26 @@ export default [
       handler: async (request, h) => {
         const { auth, query, yar } = request
         const token = auth.credentials.token
-        const { page, perPage, sort, title } = query
+        const { page, perPage, sort, title, author, organisations, status } =
+          query
 
         const successNotification = yar
           .flash(sessionNames.successNotification)
           .at(0)
 
         const { sortBy, order } = getSortOptions(sort)
-        const listOptions = { page, perPage, sortBy, order, title }
-        const model = await library.listViewModel(
-          token,
-          listOptions,
+        const listOptions = {
+          page,
+          perPage,
+          sortBy,
+          order,
+          title,
+          author,
+          organisations,
+          status,
           successNotification
-        )
+        }
+        const model = await library.listViewModel(token, listOptions)
 
         if (model.pagination) {
           const { totalPages } = model.pagination

--- a/designer/server/src/routes/forms/library.js
+++ b/designer/server/src/routes/forms/library.js
@@ -38,12 +38,19 @@ export default [
           sortBy,
           order,
           title,
-          author,
+          author: author === 'all' ? '' : author,
           organisations,
           status,
           successNotification
         }
         const model = await library.listViewModel(token, listOptions)
+
+        if (author === 'all') {
+          if (!model.search) {
+            model.search = {}
+          }
+          model.search.author = 'all'
+        }
 
         if (model.pagination) {
           const { totalPages } = model.pagination

--- a/designer/server/src/routes/forms/library.test.js
+++ b/designer/server/src/routes/forms/library.test.js
@@ -665,6 +665,28 @@ describe('Forms library routes', () => {
           })
         )
       })
+
+      it('should initialise model.search when author is "all"', async () => {
+        jest.mocked(forms.list).mockResolvedValueOnce({
+          data: [formMetadata],
+          meta: {}
+        })
+
+        const options = {
+          method: 'GET',
+          url: '/library?author=all',
+          auth
+        }
+
+        await renderResponse(server, options)
+
+        expect(forms.list).toHaveBeenCalledWith(
+          auth.credentials.token,
+          expect.objectContaining({
+            author: ''
+          })
+        )
+      })
     })
   })
 

--- a/designer/server/src/routes/forms/library.test.js
+++ b/designer/server/src/routes/forms/library.test.js
@@ -529,7 +529,117 @@ describe('Forms library routes', () => {
         )
       })
 
-      it('should include empty string title parameter when not provided', async () => {
+      it('should handle author search parameter correctly', async () => {
+        jest.mocked(forms.list).mockResolvedValueOnce({
+          data: [formMetadata],
+          meta: {
+            search: {
+              author: 'John Smith'
+            }
+          }
+        })
+
+        const options = {
+          method: 'GET',
+          url: '/library?author=John+Smith',
+          auth
+        }
+
+        await server.inject(options)
+
+        expect(forms.list).toHaveBeenCalledWith(
+          auth.credentials.token,
+          expect.objectContaining({
+            author: 'John Smith'
+          })
+        )
+      })
+
+      it('should handle organisations search parameter correctly', async () => {
+        jest.mocked(forms.list).mockResolvedValueOnce({
+          data: [formMetadata],
+          meta: {
+            search: {
+              organisations: ['Defra', 'Marine Management Organisation – MMO']
+            }
+          }
+        })
+
+        const options = {
+          method: 'GET',
+          url: '/library?organisations=Defra&organisations=Marine Management Organisation – MMO',
+          auth
+        }
+
+        await server.inject(options)
+
+        expect(forms.list).toHaveBeenCalledWith(
+          auth.credentials.token,
+          expect.objectContaining({
+            organisations: ['Defra', 'Marine Management Organisation – MMO']
+          })
+        )
+      })
+
+      it('should handle status search parameter correctly', async () => {
+        jest.mocked(forms.list).mockResolvedValueOnce({
+          data: [formMetadata],
+          meta: {
+            search: {
+              status: /** @type {FormStatus[]} */ (['draft', 'live'])
+            }
+          }
+        })
+
+        const options = {
+          method: 'GET',
+          url: '/library?status=draft&status=live',
+          auth
+        }
+
+        await server.inject(options)
+
+        expect(forms.list).toHaveBeenCalledWith(
+          auth.credentials.token,
+          expect.objectContaining({
+            status: /** @type {FormStatus[]} */ (['draft', 'live'])
+          })
+        )
+      })
+
+      it('should handle multiple search parameters together correctly', async () => {
+        jest.mocked(forms.list).mockResolvedValueOnce({
+          data: [formMetadata],
+          meta: {
+            search: {
+              title: 'test',
+              organisations: ['Defra', 'Marine Management Organisation – MMO'],
+              status: /** @type {FormStatus[]} */ (['draft', 'live']),
+              author: 'Enrique Chase'
+            }
+          }
+        })
+
+        const options = {
+          method: 'GET',
+          url: '/library?title=test&organisations=Defra&organisations=Marine Management Organisation – MMO&status=draft&status=live&author=Enrique Chase',
+          auth
+        }
+
+        await server.inject(options)
+
+        expect(forms.list).toHaveBeenCalledWith(
+          auth.credentials.token,
+          expect.objectContaining({
+            title: 'test',
+            organisations: ['Defra', 'Marine Management Organisation – MMO'],
+            status: /** @type {FormStatus[]} */ (['draft', 'live']),
+            author: 'Enrique Chase'
+          })
+        )
+      })
+
+      it('should include empty array/string defaults for all search parameters when not provided', async () => {
         jest.mocked(forms.list).mockResolvedValueOnce({
           data: [formMetadata],
           meta: {}
@@ -548,7 +658,10 @@ describe('Forms library routes', () => {
           expect.objectContaining({
             page: 1,
             perPage: 24,
-            title: ''
+            title: '',
+            author: '',
+            organisations: [],
+            status: []
           })
         )
       })
@@ -644,6 +757,6 @@ describe('Forms library routes', () => {
 })
 
 /**
- * @import { FormDefinition, FormMetadata, FormMetadataAuthor } from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadata, FormMetadataAuthor, FormStatus} from '@defra/forms-model'
  * @import { Server } from '@hapi/hapi'
  */

--- a/designer/server/src/views/forms/library.njk
+++ b/designer/server/src/views/forms/library.njk
@@ -35,7 +35,9 @@
       {{ appSearch({
         search: search,
         sorting: sorting,
-        baseUrl: "/library"
+        baseUrl: "/library",
+        filters: meta.filters,
+        displayName: authedUser.displayName
       }) }}
     </aside>
     <div class="govuk-grid-column-two-thirds-from-desktop">


### PR DESCRIPTION
## Ticket Link
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/479076

## Description
This PR introduces the required UI changes for advanced search, effectively consuming https://github.com/DEFRA/forms-manager/pull/409. It allows users to filter on author, organisation(s) and status(es), as well as form name.

<img width="299" alt="Screenshot 2025-01-28 at 15 19 42" src="https://github.com/user-attachments/assets/5efd52c2-7174-440c-bf43-00319eaac8f2" />