### PR TITLE
Add repeat, terminal and conditional visual indicators to pages

### DIFF
--- a/designer/client/src/PagesEdit.test.tsx
+++ b/designer/client/src/PagesEdit.test.tsx
@@ -1,7 +1,9 @@
 import {
   ComponentType,
+  ConditionType,
   ControllerPath,
   ControllerType,
+  OperatorName,
   type FormDefinition
 } from '@defra/forms-model'
 import { screen } from '@testing-library/dom'
@@ -30,6 +32,19 @@ const data = {
     {
       title: 'Second page',
       path: '/second-page',
+      controller: ControllerType.Terminal,
+      next: [],
+      components: [],
+      condition: 'VHfpoC'
+    },
+    {
+      title: 'Third page',
+      path: '/third-page',
+      controller: ControllerType.Repeat,
+      repeat: {
+        options: { name: 'pizza', title: 'Pizza' },
+        schema: { min: 1, max: 4 }
+      },
       next: [],
       components: []
     },
@@ -41,7 +56,30 @@ const data = {
   ],
   lists: [],
   sections: [],
-  conditions: []
+  conditions: [
+    {
+      name: 'VHfpoC',
+      displayName: 'Do you have a UK passport?',
+      value: {
+        name: 'Do you have a UK passport?',
+        conditions: [
+          {
+            field: {
+              name: 'ukPassport',
+              type: ComponentType.YesNoField,
+              display: 'Do you have a UK passport?'
+            },
+            operator: OperatorName.Is,
+            value: {
+              type: ConditionType.Value,
+              value: 'false',
+              display: 'No'
+            }
+          }
+        ]
+      }
+    }
+  ]
 } satisfies FormDefinition
 
 describe('PagesEdit', () => {
@@ -55,6 +93,6 @@ describe('PagesEdit', () => {
     const list = screen.getByRole('list')
 
     expect(list).toBeInTheDocument()
-    expect(list.children).toHaveLength(3)
+    expect(list.children).toHaveLength(4)
   })
 })

--- a/designer/client/src/PagesEdit.tsx
+++ b/designer/client/src/PagesEdit.tsx
@@ -1,4 +1,4 @@
-import { ConditionsModel, type Page } from '@defra/forms-model'
+import { ConditionsModel, ControllerType, type Page } from '@defra/forms-model'
 import { Component, type ContextType } from 'react'
 
 import { SortUpDown } from '~/src/SortUpDown.jsx'
@@ -79,12 +79,25 @@ export class PagesEdit extends Component<Props, State> {
               <li key={key} className="app-result">
                 <div className="app-result__container govuk-body">
                   <span>{page.title}</span>
+                  {page.controller === ControllerType.Terminal && (
+                    <strong className="govuk-tag govuk-tag--red pull-right">
+                      Exit
+                    </strong>
+                  )}
+                  {page.controller === ControllerType.Repeat && (
+                    <strong className="govuk-tag govuk-tag--grey pull-right">
+                      Add another
+                    </strong>
+                  )}
                   <p className="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-body-s">
                     {page.path}
                   </p>
                   {condition && (
                     <p className="govuk-!-margin-top-1 govuk-!-margin-bottom-0 govuk-body-s">
-                      <span className="govuk-!-font-weight-bold">IF: </span>
+                      <strong className="govuk-tag govuk-tag--blue">
+                        <span className="govuk-!-font-weight-bold">IF:</span>
+                      </strong>
+                      &nbsp;
                       {ConditionsModel.from(
                         condition.value
                       ).toPresentationString()}

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -2,6 +2,7 @@
 
 import {
   ControllerType,
+  Engine,
   hasComponents,
   slugify,
   type ComponentDef,
@@ -87,14 +88,30 @@ export const Page = (
     previewUrl
   ).toString()
 
+  const isV2 = data.engine === Engine.V2
+
   return (
     <div
       className={classNames({
         page: true,
-        'page--repeat': page.controller === ControllerType.Repeat
+        'page--repeat': page.controller === ControllerType.Repeat,
+        'page--terminal': isV2 && page.controller === ControllerType.Terminal,
+        'page--conditional':
+          isV2 && page.controller !== ControllerType.Terminal && page.condition
       })}
       style={layout}
     >
+      {isV2 && page.controller === ControllerType.Repeat && (
+        <strong className="govuk-tag govuk-tag--grey">Add another</strong>
+      )}
+      {isV2 && page.controller === ControllerType.Terminal && (
+        <strong className="govuk-tag govuk-tag--red">Exit</strong>
+      )}
+      {isV2 &&
+        page.controller !== ControllerType.Terminal &&
+        page.condition && (
+          <strong className="govuk-tag govuk-tag--blue">Conditional</strong>
+        )}
       <div className="page__heading">
         <h3 className="govuk-heading-m" id={headingId}>
           {section && <span className="govuk-caption-m">{section.title}</span>}

--- a/designer/client/src/stylesheets/_helpers.scss
+++ b/designer/client/src/stylesheets/_helpers.scss
@@ -1,0 +1,3 @@
+.pull-right {
+  float: right;
+}

--- a/designer/client/src/stylesheets/application.scss
+++ b/designer/client/src/stylesheets/application.scss
@@ -13,4 +13,5 @@
 @use "partials/grid";
 @use "partials/prose";
 
+@use "helpers";
 @use "editor";

--- a/designer/client/src/stylesheets/components/_visualisation.scss
+++ b/designer/client/src/stylesheets/components/_visualisation.scss
@@ -42,8 +42,23 @@ $app-container-width: map.get($govuk-breakpoints, "wide") - 60px;
       box-shadow: 0 0 0 6px $govuk-focus-colour;
     }
 
+    .govuk-tag {
+      margin-top: auto;
+      position: absolute;
+      top: -32px;
+      left: -2px;
+    }
+
     &--repeat {
       box-shadow: 5px 10px rgba(govuk-colour("black"), 0.5);
+    }
+
+    &--terminal {
+      box-shadow: 5px 10px rgba(govuk-tint(govuk-colour("red"), 80), 0.9);
+    }
+
+    &--conditional {
+      box-shadow: 5px 10px rgba(govuk-tint(govuk-colour("blue"), 80), 0.9);
     }
 
     &__heading {


### PR DESCRIPTION
For V2 only:

Add visual indicators to the visualisation:

![image](https://github.com/user-attachments/assets/c8f96c5e-c236-43fb-a998-ddfc0ec5f344)


Add visual indicators to the Pages list:

![image](https://github.com/user-attachments/assets/81fb5ded-0eaa-490a-8d9c-7c4efff85491)
