### PR TITLE
Feat/468274 page titles

### DIFF
--- a/designer/server/src/__stubs__/form-definition.js
+++ b/designer/server/src/__stubs__/form-definition.js
@@ -131,6 +131,78 @@ export const testFormDefinitionWithTwoQuestions = {
 /**
  * @satisfies {FormDefinition}
  */
+export const testFormDefinitionWithTwoPagesAndQuestions = {
+  name: 'Test form',
+  pages: [
+    {
+      id: 'p1',
+      path: '/page-one',
+      title: 'Page one',
+      section: 'section',
+      components: [
+        {
+          id: 'q1',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your first question',
+          hint: 'Help text',
+          options: {},
+          schema: {}
+        },
+        {
+          id: 'q2',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your second question',
+          hint: 'Help text',
+          options: {},
+          schema: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      id: 'p2',
+      path: '/page-two',
+      title: 'Page two',
+      section: 'section',
+      components: [
+        {
+          id: 'q1',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your first question - page two',
+          hint: 'Help text',
+          options: {},
+          schema: {}
+        },
+        {
+          id: 'q2',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your second question - page two',
+          hint: 'Help text',
+          options: {},
+          schema: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      id: 'p3',
+      title: 'Summary',
+      path: '/summary',
+      controller: ControllerType.Summary
+    }
+  ],
+  conditions: [],
+  sections: [],
+  lists: []
+}
+
+/**
+ * @satisfies {FormDefinition}
+ */
 export const testFormDefinitionWithNoQuestions = {
   name: 'Test form',
   pages: [
@@ -149,6 +221,17 @@ export const testFormDefinitionWithNoQuestions = {
       controller: ControllerType.Summary
     }
   ],
+  conditions: [],
+  sections: [],
+  lists: []
+}
+
+/**
+ * @satisfies {FormDefinition}
+ */
+export const testFormDefinitionWithNoPages = {
+  name: 'Test form',
+  pages: [],
   conditions: [],
   sections: [],
   lists: []

--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -27,7 +27,7 @@ export async function addPageAndFirstQuestion(formId, token, questionDetails) {
 
   const { body } = await postJsonByType(requestUrl, {
     payload: {
-      title: questionDetails.title,
+      title: '',
       path: `/${slugify(questionDetails.title)}`,
       components: [questionDetails]
     },
@@ -90,18 +90,14 @@ export async function updateQuestion(
 
 /**
  * Determine page heading
- * @param {boolean} isExpanded
  * @param {Page | undefined} page
  * @param {string | undefined} pageHeading
  * @param {ComponentDef[]} components
  */
-export function resolvePageHeading(isExpanded, page, pageHeading, components) {
+export function resolvePageHeading(page, pageHeading, components) {
   const firstQuestion = components.find(
     (comp) => comp.type !== ComponentType.Html
   )
-  if (!isExpanded) {
-    return firstQuestion?.title ?? ''
-  }
 
   const pageTitle = stringHasValue(pageHeading) ? pageHeading : page?.title
   const firstQuestionFallback = stringHasValue(firstQuestion?.title)
@@ -137,12 +133,8 @@ export async function setPageHeadingAndGuidance(
 
   const isExpanded = isCheckboxSelected(payload.pageHeadingAndGuidance)
 
-  const resolvedPageHeading = resolvePageHeading(
-    isExpanded,
-    page,
-    pageHeading,
-    components
-  )
+  const pageHeadingForCall = isExpanded ? pageHeading : ''
+  const pagePathForCall = `/${slugify(resolvePageHeading(page, pageHeading, components))}`
 
   // Update page heading
   const pageHeadingRequestUrl = new URL(
@@ -151,8 +143,8 @@ export async function setPageHeadingAndGuidance(
   )
   await patchJsonByType(pageHeadingRequestUrl, {
     payload: {
-      title: resolvedPageHeading,
-      path: `/${slugify(resolvedPageHeading)}`
+      title: pageHeadingForCall,
+      path: pagePathForCall
     },
     ...getHeaders(token)
   })

--- a/designer/server/src/lib/editor.test.js
+++ b/designer/server/src/lib/editor.test.js
@@ -135,7 +135,7 @@ describe('editor.js', () => {
     const token = 'someToken'
     const expectedOptions1 = {
       payload: {
-        title: 'What is your name?',
+        title: '',
         path: '/what-is-your-name',
         components: [
           {
@@ -211,31 +211,27 @@ describe('editor.js', () => {
   }
 
   describe('resolvePageHeading', () => {
-    test('when checkbox unselected', () => {
+    test('page heading should override first question title', () => {
       expect(
-        resolvePageHeading(false, page, 'New page heading', page.components)
-      ).toBe('This is your first question')
-    })
-
-    test('when checkbox unselected and no components', () => {
-      expect(resolvePageHeading(false, page, 'New page heading', [])).toBe('')
-    })
-
-    test('when checkbox selected and page heading provided', () => {
-      expect(
-        resolvePageHeading(true, page, 'New page heading', page.components)
+        resolvePageHeading(page, 'New page heading', page.components)
       ).toBe('New page heading')
     })
 
-    test('when checkbox selected and page heading not provided', () => {
-      expect(resolvePageHeading(true, page, '', page.components)).toBe(
+    test('page heading should override even when no questions', () => {
+      expect(resolvePageHeading(page, 'New page heading', [])).toBe(
+        'New page heading'
+      )
+    })
+
+    test('should return first question title when no page heading', () => {
+      expect(resolvePageHeading(page, '', page.components)).toBe(
         'This is your first question'
       )
     })
 
-    test('when checkbox selected and page heading not provided and no questions', () => {
+    test('should return page heading from definition when form page heading not provided and no questions', () => {
       const pageCopy = { ...page, title: 'Test title' }
-      expect(resolvePageHeading(true, pageCopy, '', [])).toBe('Test title')
+      expect(resolvePageHeading(pageCopy, '', [])).toBe('Test title')
     })
   })
 
@@ -363,7 +359,7 @@ describe('editor.js', () => {
         const expectedOptionsPageHeading1 = {
           payload: {
             title: '',
-            path: '/'
+            path: '/my-new-page-title'
           },
           headers: { Authorization: `Bearer ${token}` }
         }

--- a/designer/server/src/lib/error-helper.test.js
+++ b/designer/server/src/lib/error-helper.test.js
@@ -1,6 +1,9 @@
 import Joi from 'joi'
 
-import { addErrorsToSession } from '~/src/lib/error-helper.js'
+import {
+  addErrorsToSession,
+  getValidationErrorsFromSession
+} from '~/src/lib/error-helper.js'
 
 const mockFlash = jest.fn()
 
@@ -30,7 +33,7 @@ const buildMockRequest = (payload) => {
 
 describe('Validation functions', () => {
   describe('addErrorsToSession', () => {
-    test('should return empty object', () => {
+    test('should add errors', () => {
       const sessionKey = /** @type {ValidationSessionKey} */ ('this-key')
       const error = new Joi.ValidationError(
         'dummy error',
@@ -57,6 +60,31 @@ describe('Validation functions', () => {
         },
         formValues: { field1: 'abc' }
       })
+    })
+
+    test('should handle no errors', () => {
+      const sessionKey = /** @type {ValidationSessionKey} */ ('this-key')
+      const error = undefined
+      const payload = { field1: 'abc' }
+      addErrorsToSession(buildMockRequest(payload), error, sessionKey)
+      expect(mockFlash).not.toHaveBeenCalled()
+    })
+
+    test('should handle invalid error object', () => {
+      const sessionKey = /** @type {ValidationSessionKey} */ ('this-key')
+      const error = /** @type {Joi.ValidationError} */ ({})
+      const payload = { field1: 'abc' }
+      addErrorsToSession(buildMockRequest(payload), error, sessionKey)
+      expect(mockFlash).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getValidationErrorsFromSession', () => {
+    test('should get errors', () => {
+      const sessionKey = /** @type {ValidationSessionKey} */ ('this-key')
+      const payload = { field1: 'abc' }
+      getValidationErrorsFromSession(buildMockRequest(payload).yar, sessionKey)
+      expect(mockFlash).toHaveBeenCalledWith('this-key')
     })
   })
 })

--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -1,3 +1,5 @@
+import { hasComponents } from '@defra/forms-model'
+
 import {
   buildPreviewUrl,
   getFormSpecificNavigation
@@ -7,6 +9,30 @@ import {
   formOverviewBackLink,
   formOverviewPath
 } from '~/src/models/links.js'
+
+/**
+ * @param {FormDefinition} definition
+ */
+export function setPageHeadings(definition) {
+  if (!definition.pages.length) {
+    return definition
+  }
+
+  return {
+    ...definition,
+    pages: definition.pages.map((page) => {
+      if (page.title === '') {
+        return {
+          ...page,
+          title: hasComponents(page) ? page.components[0].title : ''
+        }
+      }
+      return {
+        ...page
+      }
+    })
+  }
+}
 
 /**
  * @param {FormMetadata} metadata
@@ -44,7 +70,7 @@ export function pagesViewModel(metadata, definition) {
   }
 
   const pageListModel = {
-    ...definition,
+    ...setPageHeadings(definition),
     formSlug: metadata.slug,
     previewBaseUrl,
     navigation,

--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -1,4 +1,4 @@
-import { hasComponents } from '@defra/forms-model'
+import { ControllerType, hasComponents } from '@defra/forms-model'
 
 import {
   buildPreviewUrl,
@@ -47,26 +47,33 @@ export function pagesViewModel(metadata, definition) {
     {
       text: 'Add new page',
       href: editorv2Path(metadata.slug, 'page'),
-      classes: 'govuk-button--inverse'
+      classes: 'govuk-button--inverse',
+      attributes: /** @type {string | undefined} */ (undefined)
     }
   ]
 
-  const extraPageActions = [
-    {
-      text: 'Re-order pages',
-      href: '/reorder',
-      classes: 'govuk-button--secondary'
-    },
-    {
+  const reorderAction = {
+    text: 'Re-order pages',
+    href: '/reorder',
+    classes: 'govuk-button--secondary',
+    attributes: undefined
+  }
+
+  const numOfNonSummaryPages = definition.pages.filter(
+    (x) => x.controller !== ControllerType.Summary
+  ).length
+
+  if (numOfNonSummaryPages > 1) {
+    pageActions.push(reorderAction)
+  }
+
+  if (numOfNonSummaryPages > 0) {
+    pageActions.push({
       text: 'Preview form',
       href: previewBaseUrl,
       classes: 'govuk-link govuk-link--inverse',
       attributes: 'target="_blank"'
-    }
-  ]
-
-  if (definition.pages.length > 1) {
-    pageActions.push(...extraPageActions)
+    })
   }
 
   const pageListModel = {

--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -48,7 +48,7 @@ export function pagesViewModel(metadata, definition) {
       text: 'Add new page',
       href: editorv2Path(metadata.slug, 'page'),
       classes: 'govuk-button--inverse',
-      attributes: /** @type {string | undefined} */ (undefined)
+      attributes: /** @type {string | null} */ (null)
     }
   ]
 
@@ -56,7 +56,7 @@ export function pagesViewModel(metadata, definition) {
     text: 'Re-order pages',
     href: '/reorder',
     classes: 'govuk-button--secondary',
-    attributes: undefined
+    attributes: null
   }
 
   const numOfNonSummaryPages = definition.pages.filter(

--- a/designer/server/src/models/forms/editor-v2/pages.test.js
+++ b/designer/server/src/models/forms/editor-v2/pages.test.js
@@ -1,0 +1,37 @@
+import {
+  testFormDefinitionWithNoPages,
+  testFormDefinitionWithTwoPagesAndQuestions,
+  testFormDefinitionWithTwoQuestions
+} from '~/src/__stubs__/form-definition.js'
+import { setPageHeadings } from '~/src/models/forms/editor-v2/pages.js'
+
+describe('editor-v2 - pages model', () => {
+  describe('setPageHeadings', () => {
+    test('should return unchanged definition if no pages', () => {
+      const res = setPageHeadings(testFormDefinitionWithNoPages)
+      expect(res).toEqual(testFormDefinitionWithNoPages)
+    })
+    test('should return unchanged if page titles already set', () => {
+      const res = setPageHeadings(testFormDefinitionWithTwoQuestions)
+      expect(res).toEqual(testFormDefinitionWithTwoQuestions)
+    })
+    test('should populate page title from first question title', () => {
+      const definitionWithNoPageTitles = {
+        ...testFormDefinitionWithTwoQuestions
+      }
+      definitionWithNoPageTitles.pages[0].title = ''
+      const res = setPageHeadings(definitionWithNoPageTitles)
+      expect(res.pages[0].title).toBe('This is your first question')
+    })
+    test('should populate page titles from first question title on multiple pages', () => {
+      const definitionWithNoPageTitles = {
+        ...testFormDefinitionWithTwoPagesAndQuestions
+      }
+      definitionWithNoPageTitles.pages[0].title = ''
+      definitionWithNoPageTitles.pages[1].title = ''
+      const res = setPageHeadings(definitionWithNoPageTitles)
+      expect(res.pages[0].title).toBe('This is your first question')
+      expect(res.pages[1].title).toBe('This is your first question - page two')
+    })
+  })
+})

--- a/designer/server/src/models/forms/editor-v2/questions.js
+++ b/designer/server/src/models/forms/editor-v2/questions.js
@@ -97,15 +97,9 @@ export function questionsViewModel(
   const page = definition.pages[pageIdx]
   const components = hasComponents(page) ? page.components : []
 
-  const firstQuestion = components.find(
-    (comp) => comp.type !== ComponentType.Html
-  )
-
-  const pageHeadingFallback =
-    page.title !== firstQuestion?.title ? page.title : ''
   const pageHeadingVal = stringHasValue(formValues?.pageHeading)
     ? formValues?.pageHeading
-    : pageHeadingFallback
+    : page.title
 
   const guidanceComponent = /** @type {HtmlComponent | undefined} */ (
     components.find(

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -202,25 +202,9 @@ export const pageSchema = Joi.object<Page>().keys({
 
 /**
  * V2 engine schema - used with new editor
- * `/status` is a special route for providing a user's application status.
- *  It should not be configured via the designer.
  */
-export const pageSchemaV2 = Joi.object<Page>().keys({
-  id: Joi.string().uuid().optional(),
-  path: Joi.string().required().disallow('/status'),
-  title: Joi.string().allow('').required(),
-  section: Joi.string(),
-  controller: Joi.string().optional(),
-  components: Joi.array<ComponentDef>().items(componentSchema).unique('name'),
-  repeat: Joi.when('controller', {
-    is: Joi.string().valid('RepeatPageController').required(),
-    then: pageRepeatSchema.required(),
-    otherwise: Joi.any().strip()
-  }),
-  condition: Joi.string().allow('').optional(),
-  next: Joi.array<Link>().items(nextSchema).default([]),
-  events: eventsSchema.optional(),
-  view: Joi.string().optional()
+export const pageSchemaV2 = pageSchema.append({
+  title: Joi.string().allow('').required()
 })
 
 const baseListItemSchema = Joi.object<Item>().keys({


### PR DESCRIPTION
Reworked page title logic to simplify things
In V2 page schema, page title can be a blank string and forms-runner determines whether to display page title from 'page title' value or first question title
This PR needs to merge in tandem with the equivalent model changes for forms-manager and forms-runner