### PR TITLE
feat: 512490 - Use correct contract for default values

### DIFF
--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -1,10 +1,43 @@
 import { ComponentType } from '~/src/components/enums.js'
-import { type ComponentDef } from '~/src/components/types.js'
-import { formDefinitionSchema } from '~/src/form/form-definition/index.js'
+import {
+  type ComponentDef,
+  type NumberFieldComponent
+} from '~/src/components/types.js'
+import {
+  formDefinitionSchema,
+  formDefinitionV2PayloadSchema
+} from '~/src/form/form-definition/index.js'
 import {
   type FormDefinition,
-  type PageQuestion
+  type PageQuestion,
+  type PageSummary
 } from '~/src/form/form-definition/types.js'
+import { ControllerPath, ControllerType } from '~/src/index.js'
+
+const buildQuestionPage = (
+  partialQuestion: Partial<PageQuestion>
+): PageQuestion => {
+  return {
+    title: 'Question Page',
+    path: '/question-page',
+    components: [],
+    next: [],
+    ...partialQuestion
+  }
+}
+
+const buildNumberFieldComponent = (
+  partialComponent: Partial<NumberFieldComponent>
+): NumberFieldComponent => {
+  return {
+    name: 'year',
+    title: 'Year',
+    options: {},
+    schema: {},
+    ...partialComponent,
+    type: ComponentType.NumberField
+  }
+}
 
 describe('Form definition schema', () => {
   let page: PageQuestion
@@ -93,6 +126,71 @@ describe('Form definition schema', () => {
         })
 
         expect(result.error).toBeUndefined()
+      })
+    })
+  })
+
+  describe('Form Definition', () => {
+    describe('formDefinitionV2PayloadSchema', () => {
+      it('should add ids to pages and components if one is missing', () => {
+        const component1 = buildNumberFieldComponent({
+          id: undefined,
+          name: 'year',
+          title: 'Year'
+        })
+        const component2 = buildNumberFieldComponent({
+          id: undefined,
+          name: 'month',
+          title: 'Month'
+        })
+
+        const page = buildQuestionPage({
+          id: undefined,
+          path: '/page-one',
+          title: 'Page One',
+          components: [component1, component2]
+        })
+
+        const page2: PageSummary = {
+          id: undefined,
+          controller: ControllerType.Summary,
+          path: ControllerPath.Summary,
+          title: 'Summary Page',
+          components: []
+        }
+        const definition: FormDefinition = {
+          conditions: [],
+          lists: [],
+          pages: [page, page2],
+          sections: []
+        }
+
+        const validated = formDefinitionV2PayloadSchema.validate(definition)
+
+        expect(validated.error).toBeUndefined()
+        expect(validated.value).toMatchObject({
+          ...definition,
+          pages: [
+            {
+              ...page,
+              id: expect.any(String),
+              components: [
+                {
+                  ...component1,
+                  id: expect.any(String)
+                },
+                {
+                  ...component2,
+                  id: expect.any(String)
+                }
+              ]
+            },
+            {
+              ...page2,
+              id: expect.any(String)
+            }
+          ]
+        })
       })
     })
   })

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -146,7 +146,9 @@ export const componentSchema = Joi.object<ComponentDef>()
   .unknown(true)
 
 export const componentSchemaV2 = componentSchema.keys({
-  id: Joi.string().uuid().default(uuidV4())
+  id: Joi.string()
+    .uuid()
+    .default(() => uuidV4())
 })
 
 const nextSchema = Joi.object<Link>().keys({
@@ -215,7 +217,9 @@ export const pageSchemaV2 = pageSchema.append({
 })
 
 export const pageSchemaPayloadV2 = pageSchemaV2.keys({
-  id: Joi.string().uuid().default(uuidV4()),
+  id: Joi.string()
+    .uuid()
+    .default(() => uuidV4()),
   components: Joi.array<ComponentDef>()
     .items(componentSchemaV2)
     .unique('name')
@@ -326,7 +330,7 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
     output: outputSchema.optional()
   })
 
-export const formDefinitionSchemaV2Payload = formDefinitionSchema.keys({
+export const formDefinitionV2PayloadSchema = formDefinitionSchema.keys({
   pages: Joi.array<Page>()
     .items(pageSchemaPayloadV2)
     .required()


### PR DESCRIPTION
## Model update

Joi.string().default has been changed to use a callback - as the other approach was setting it once.