### PR TITLE
Feat/481464  migrate on homepage

### DIFF
--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -271,5 +271,24 @@ export async function reorderPages(formId, token, payload) {
 }
 
 /**
+ * Migrates the definition to v2
+ * @param {string} formId
+ * @param {string} token
+ */
+export async function migrateDefinitionToV2(formId, token) {
+  const migrateToV2RequestUrl = new URL(
+    `./${formId}/definition/draft/migrate/v2`,
+    formsEndpoint
+  )
+
+  const { body } = await postJsonByType(migrateToV2RequestUrl, {
+    payload: {},
+    ...getHeaders(token)
+  })
+
+  return body
+}
+
+/**
  * @import { ComponentDef, Page, FormEditorInputCheckAnswersSettings, FormEditorInputPageSettings, FormDefinition } from '@defra/forms-model'
  */

--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -17,6 +17,8 @@ const formsEndpoint = new URL('/forms/', config.managerUrl)
 
 const patchJsonByType = /** @type {typeof patchJson<Page>} */ (patchJson)
 const postJsonByType = /** @type {typeof postJson<Page>} */ (postJson)
+const postJsonByDefinitionType =
+  /** @type {typeof postJson<FormDefinition>} */ (postJson)
 const putJsonByType = /** @type {typeof putJson<Page>} */ (putJson)
 const delJsonByType = /** @type {typeof delJson<ComponentDef>} */ (delJson)
 
@@ -281,7 +283,7 @@ export async function migrateDefinitionToV2(formId, token) {
     formsEndpoint
   )
 
-  const { body } = await postJsonByType(migrateToV2RequestUrl, {
+  const { body } = await postJsonByDefinitionType(migrateToV2RequestUrl, {
     payload: {},
     ...getHeaders(token)
   })

--- a/designer/server/src/routes/forms/editor-v2/pages.js
+++ b/designer/server/src/routes/forms/editor-v2/pages.js
@@ -1,5 +1,8 @@
+import { Engine } from '@defra/forms-model'
+
 import * as scopes from '~/src/common/constants/scopes.js'
 import { sessionNames } from '~/src/common/constants/session-names.js'
+import * as editor from '~/src/lib/editor.js'
 import * as forms from '~/src/lib/forms.js'
 import * as viewModel from '~/src/models/forms/editor-v2/pages.js'
 
@@ -21,7 +24,13 @@ export default [
       const { slug } = params
 
       const metadata = await forms.get(slug, token)
-      const definition = await forms.getDraftFormDefinition(metadata.id, token)
+      const formId = metadata.id
+
+      let definition = await forms.getDraftFormDefinition(formId, token)
+
+      if (definition.engine === Engine.V1) {
+        definition = await editor.migrateDefinitionToV2(formId, token)
+      }
 
       // Saved banner
       const notification = /** @type {string[] | undefined} */ (

--- a/designer/server/src/routes/forms/editor-v2/pages.test.js
+++ b/designer/server/src/routes/forms/editor-v2/pages.test.js
@@ -1,16 +1,20 @@
-import { ComponentType, ControllerType } from '@defra/forms-model'
+import { ComponentType, ControllerType, Engine } from '@defra/forms-model'
+import { StatusCodes } from 'http-status-codes'
 
 import {
+  buildDefinition,
   testFormDefinitionWithSinglePage,
   testFormDefinitionWithSummaryOnly
 } from '~/src/__stubs__/form-definition.js'
 import { testFormMetadata } from '~/src/__stubs__/form-metadata.js'
 import { createServer } from '~/src/createServer.js'
+import * as editor from '~/src/lib/editor.js'
 import * as forms from '~/src/lib/forms.js'
 import { auth } from '~/test/fixtures/auth.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 jest.mock('~/src/lib/forms.js')
+jest.mock('~/src/lib/editor.js')
 
 describe('Editor v2 pages routes', () => {
   /** @type {Server} */
@@ -21,11 +25,14 @@ describe('Editor v2 pages routes', () => {
     await server.initialize()
   })
 
+  const testForm = buildDefinition({
+    ...testFormDefinitionWithSummaryOnly,
+    engine: Engine.V2
+  })
+
   test('GET - should check correct formData is rendered in the view with summary page only', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
-    jest
-      .mocked(forms.getDraftFormDefinition)
-      .mockResolvedValueOnce(testFormDefinitionWithSummaryOnly)
+    jest.mocked(forms.getDraftFormDefinition).mockResolvedValueOnce(testForm)
 
     const options = {
       method: 'get',
@@ -49,56 +56,60 @@ describe('Editor v2 pages routes', () => {
   })
 
   test('GET - should check correct formData is rendered in the view with multiple pages', async () => {
-    const formDefinitionMultiplePages = { ...testFormDefinitionWithSinglePage }
-    formDefinitionMultiplePages.pages = [
-      {
-        id: 'p1',
-        path: '/page-one',
-        title: 'Page one',
-        section: 'section',
-        components: [
-          {
-            id: 'c1',
-            type: ComponentType.TextField,
-            name: 'textField',
-            title: 'This is your first field',
-            hint: 'Help text',
-            options: {},
-            schema: {}
-          }
-        ],
-        next: [{ path: '/page-two' }]
-      },
-      {
-        id: 'p1',
-        path: '/page-two',
-        title: 'Page two',
-        section: 'section',
-        components: [
-          {
-            id: 'c1',
-            type: ComponentType.TextField,
-            name: 'textField',
-            title: 'This is your second field',
-            hint: 'Help text',
-            options: {},
-            schema: {}
-          }
-        ],
-        next: [{ path: '/summary' }]
-      },
-      {
-        id: 'c2',
-        title: 'Summary',
-        path: '/summary',
-        controller: ControllerType.Summary
-      }
-    ]
+    const formDefinitionMultiplePages = buildDefinition({
+      ...testFormDefinitionWithSinglePage,
+      pages: [
+        {
+          id: 'p1',
+          path: '/page-one',
+          title: 'Page one',
+          section: 'section',
+          components: [
+            {
+              id: 'c1',
+              type: ComponentType.TextField,
+              name: 'textField',
+              title: 'This is your first field',
+              hint: 'Help text',
+              options: {},
+              schema: {}
+            }
+          ],
+          next: [{ path: '/page-two' }]
+        },
+        {
+          id: 'p1',
+          path: '/page-two',
+          title: 'Page two',
+          section: 'section',
+          components: [
+            {
+              id: 'c1',
+              type: ComponentType.TextField,
+              name: 'textField',
+              title: 'This is your second field',
+              hint: 'Help text',
+              options: {},
+              schema: {}
+            }
+          ],
+          next: [{ path: '/summary' }]
+        },
+        {
+          id: 'c2',
+          title: 'Summary',
+          path: '/summary',
+          controller: ControllerType.Summary
+        }
+      ],
+      engine: Engine.V2
+    })
 
     jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
     jest
       .mocked(forms.getDraftFormDefinition)
       .mockResolvedValueOnce(formDefinitionMultiplePages)
+    const migrateToV2 = jest.mocked(editor.migrateDefinitionToV2)
 
     const options = {
       method: 'get',
@@ -107,6 +118,8 @@ describe('Editor v2 pages routes', () => {
     }
 
     const { container } = await renderResponse(server, options)
+
+    expect(migrateToV2).not.toHaveBeenCalled()
 
     const $mainHeading = container.getByRole('heading', { level: 1 })
 
@@ -122,6 +135,38 @@ describe('Editor v2 pages routes', () => {
     expect($actions).toHaveLength(4)
     expect($actions[2]).toHaveTextContent('Add new page')
     expect($actions[3]).toHaveTextContent('Re-order pages')
+  })
+
+  test('GET - should migrate to v2 if draft definition is v1', async () => {
+    const formId = '661e4ca5039739ef2902b214'
+    const v1Definition = buildDefinition({
+      ...testFormDefinitionWithSinglePage,
+      engine: Engine.V1
+    })
+    const v2Definition = buildDefinition({
+      ...testFormDefinitionWithSinglePage,
+      engine: Engine.V2
+    })
+
+    const migrateToV2 = jest.mocked(editor.migrateDefinitionToV2)
+
+    jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+    jest
+      .mocked(forms.getDraftFormDefinition)
+      .mockResolvedValueOnce(v1Definition)
+    migrateToV2.mockResolvedValueOnce(v2Definition)
+
+    const options = {
+      method: 'get',
+      url: '/library/my-form-slug/editor-v2/pages',
+      auth
+    }
+
+    const {
+      response: { statusCode }
+    } = await renderResponse(server, options)
+    expect(statusCode).toBe(StatusCodes.OK)
+    expect(migrateToV2).toHaveBeenCalledWith(formId, expect.anything())
   })
 })
 


### PR DESCRIPTION
## Migrate v1 definition to v2 

When a user calls the v2 homepage (/library/v2-form/editor-v2/pages) on a v1 draft form -  a call is sent through to migrate the form to v2.  The page is then opened with the updated definition.