### PR TITLE
Fix 518654: Restrict component names to letters only 

### DIFF
--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -154,12 +154,19 @@ describe('Form definition schema', () => {
         expect(result.error).toBeUndefined()
       })
 
-      it('should accept names with letters and numbers', () => {
+      it('should reject names with letters and numbers', () => {
         testComponent.name = 'valid123name'
         page.components = [testComponent]
+
+        const result = formDefinitionSchema.validate(definition, {
+          abortEarly: false
+        })
+
+        expect(result.error).toBeDefined()
+        expect(result.error?.details[0].message).toMatch(/pattern/)
       })
 
-      it('should accept names with letters, numbers and underscores', () => {
+      it('should reject names with letters, numbers and underscores', () => {
         testComponent.name = 'valid_123_name'
         page.components = [testComponent]
 
@@ -167,7 +174,8 @@ describe('Form definition schema', () => {
           abortEarly: false
         })
 
-        expect(result.error).toBeUndefined()
+        expect(result.error).toBeDefined()
+        expect(result.error?.details[0].message).toMatch(/pattern/)
       })
 
       it('should reject names with dashes', () => {
@@ -194,7 +202,7 @@ describe('Form definition schema', () => {
         expect(result.error?.details[0].message).toMatch(/pattern/)
       })
 
-      it('should accept names that are only digits', () => {
+      it('should reject names that are only digits', () => {
         testComponent.name = '123'
         page.components = [testComponent]
 
@@ -202,10 +210,11 @@ describe('Form definition schema', () => {
           abortEarly: false
         })
 
-        expect(result.error).toBeUndefined()
+        expect(result.error).toBeDefined()
+        expect(result.error?.details[0].message).toMatch(/pattern/)
       })
 
-      it('should accept names that start with digits', () => {
+      it('should reject names that start with digits', () => {
         testComponent.name = '1foo'
         page.components = [testComponent]
 
@@ -213,7 +222,8 @@ describe('Form definition schema', () => {
           abortEarly: false
         })
 
-        expect(result.error).toBeUndefined()
+        expect(result.error).toBeDefined()
+        expect(result.error?.details[0].message).toMatch(/pattern/)
       })
     })
 

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -108,8 +108,10 @@ export const componentSchema = Joi.object<ComponentDef>()
         ComponentType.InsetText,
         ComponentType.Markdown
       ),
-      then: Joi.string().pattern(/^\w+$/).optional(),
-      otherwise: Joi.string().pattern(/^\w+$/)
+      then: Joi.string()
+        .pattern(/^[a-zA-Z]+$/)
+        .optional(),
+      otherwise: Joi.string().pattern(/^[a-zA-Z]+$/)
     }),
     title: Joi.when('type', {
       is: Joi.string().valid(


### PR DESCRIPTION
## Description
This PR updates the component name validation logic to restrict names strictly to uppercase and lowercase letters (^[a-zA-Z]+$). It removes support for numbers, underscores, and special characters. Corresponding tests have been updated to reflect and verify this stricter validation rule, building upon the regex validation changes introduced in the previous PR.