### PR TITLE
feat: 512490 - Use FormStatus enum rather than FormStatus and State t…

### DIFF
--- a/designer/server/src/lib/forms.test.js
+++ b/designer/server/src/lib/forms.test.js
@@ -1,3 +1,5 @@
+import { FormStatus } from '@defra/forms-model'
+
 import config from '~/src/config.js'
 import { createServer } from '~/src/createServer.js'
 import * as fetch from '~/src/lib/fetch.js'
@@ -589,7 +591,10 @@ describe('Forms library routes', () => {
         const options = {
           page: 1,
           perPage: 10,
-          status: /** @type {FormStatus[]} */ (['draft', 'live'])
+          status: /** @type {FormStatus[]} */ ([
+            FormStatus.Draft,
+            FormStatus.Live
+          ])
         }
         const mockResponse = {
           data: [formMetadata],
@@ -625,6 +630,6 @@ describe('Forms library routes', () => {
 })
 
 /**
- * @import { FormDefinition, FormMetadata, FormMetadataAuthor, FormStatus } from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadata, FormMetadataAuthor } from '@defra/forms-model'
  * @import { Server } from '@hapi/hapi'
  */

--- a/designer/server/src/models/forms/library.test.js
+++ b/designer/server/src/models/forms/library.test.js
@@ -1,3 +1,5 @@
+import { FormStatus } from '@defra/forms-model'
+
 import { buildEntry } from '~/src/common/nunjucks/context/build-navigation.js'
 import * as forms from '~/src/lib/forms.js'
 import {
@@ -1098,7 +1100,10 @@ describe('Forms Library Models', () => {
               totalItems: 30
             },
             search: {
-              status: /** @type {FormStatus[]} */ (['draft', 'live'])
+              status: /** @type {FormStatus[]} */ ([
+                FormStatus.Draft,
+                FormStatus.Live
+              ])
             }
           }
         }
@@ -1107,7 +1112,7 @@ describe('Forms Library Models', () => {
         const viewModel = await listViewModel('token', {
           page: 2,
           perPage: 10,
-          status: ['draft', 'live']
+          status: [FormStatus.Draft, FormStatus.Live]
         })
 
         expect(viewModel.pagination).toBeTruthy()
@@ -1134,5 +1139,5 @@ describe('Forms Library Models', () => {
 })
 
 /**
- * @import { FormMetadata, FormStatus } from '@defra/forms-model'
+ * @import { FormMetadata } from '@defra/forms-model'
  */

--- a/designer/server/src/routes/forms/library.test.js
+++ b/designer/server/src/routes/forms/library.test.js
@@ -793,6 +793,6 @@ describe('Forms library routes', () => {
 })
 
 /**
- * @import { FormDefinition, FormMetadata, FormMetadataAuthor} from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadata, FormMetadataAuthor } from '@defra/forms-model'
  * @import { Server } from '@hapi/hapi'
  */

--- a/designer/server/src/routes/forms/library.test.js
+++ b/designer/server/src/routes/forms/library.test.js
@@ -1,3 +1,5 @@
+import { FormStatus } from '@defra/forms-model'
+
 import config from '~/src/config.js'
 import { createServer } from '~/src/createServer.js'
 import * as forms from '~/src/lib/forms.js'
@@ -586,7 +588,10 @@ describe('Forms library routes', () => {
           data: [formMetadata],
           meta: {
             search: {
-              status: /** @type {FormStatus[]} */ (['draft', 'live'])
+              status: /** @type {FormStatus[]} */ ([
+                FormStatus.Draft,
+                FormStatus.Live
+              ])
             }
           }
         })
@@ -602,7 +607,10 @@ describe('Forms library routes', () => {
         expect(forms.list).toHaveBeenCalledWith(
           auth.credentials.token,
           expect.objectContaining({
-            status: /** @type {FormStatus[]} */ (['draft', 'live'])
+            status: /** @type {FormStatus[]} */ ([
+              FormStatus.Draft,
+              FormStatus.Live
+            ])
           })
         )
       })
@@ -614,7 +622,10 @@ describe('Forms library routes', () => {
             search: {
               title: 'test',
               organisations: ['Defra', 'Marine Management Organisation – MMO'],
-              status: /** @type {FormStatus[]} */ (['draft', 'live']),
+              status: /** @type {FormStatus[]} */ ([
+                FormStatus.Draft,
+                FormStatus.Live
+              ]),
               author: 'Enrique Chase'
             }
           }
@@ -633,7 +644,10 @@ describe('Forms library routes', () => {
           expect.objectContaining({
             title: 'test',
             organisations: ['Defra', 'Marine Management Organisation – MMO'],
-            status: /** @type {FormStatus[]} */ (['draft', 'live']),
+            status: /** @type {FormStatus[]} */ ([
+              FormStatus.Draft,
+              FormStatus.Live
+            ]),
             author: 'Enrique Chase'
           })
         )
@@ -779,6 +793,6 @@ describe('Forms library routes', () => {
 })
 
 /**
- * @import { FormDefinition, FormMetadata, FormMetadataAuthor, FormStatus} from '@defra/forms-model'
+ * @import { FormDefinition, FormMetadata, FormMetadataAuthor} from '@defra/forms-model'
  * @import { Server } from '@hapi/hapi'
  */

--- a/model/src/common/enums.ts
+++ b/model/src/common/enums.ts
@@ -1,0 +1,4 @@
+export enum FormStatus {
+  Draft = 'draft',
+  Live = 'live'
+}

--- a/model/src/common/types.ts
+++ b/model/src/common/types.ts
@@ -4,16 +4,12 @@ import {
 } from '~/src/common/pagination/types.js'
 import { type SearchOptions } from '~/src/common/search/types.js'
 import { type SortingOptions } from '~/src/common/sorting/types.js'
+import { type FormStatus } from '~/src/index.js'
 
 /**
  * Options for querying results, including pagination, sorting, and searching
  */
 export type QueryOptions = PaginationOptions & SortingOptions & SearchOptions
-
-/**
- * Available form status values
- */
-export type FormStatus = 'draft' | 'live'
 
 /**
  * Available filter options for the current result set

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,3 +1,4 @@
+export * from '~/src/common/enums.js'
 export * from '~/src/common/schema.js'
 export * from '~/src/common/pagination/index.js'
 export * from '~/src/common/search/index.js'


### PR DESCRIPTION
## FormStatus changed to enum

@mokhld this is a refactor of the FormStatus type - we are changing it to an enum and updating both Designer and Manager to come in line with that.  PR for Manager incoming.