### PR TITLE
Added screen reader for reorder buttons

### DIFF
--- a/designer/server/src/common/components/pages-reorder-panel/template.njk
+++ b/designer/server/src/common/components/pages-reorder-panel/template.njk
@@ -5,6 +5,9 @@
 {% set upAuto = "autofocus" if params.isFocus and params.prevFocusDirection == "up" else "" %}
 {% set downAuto = "autofocus" if params.isFocus and params.prevFocusDirection == "down" else "" %}
 
+{% set ariaLabelUp = "Button, move page up, Page " + params.pageNum + " of " + params.totalPages + " : " + params.pageTitle + "." %}
+{% set ariaLabelDown = "Button, move page down, Page " + params.pageNum + " of " + params.totalPages + " : " + params.pageTitle + "." %}
+
 <li>
   <div class="govuk-summary-card pages-reorder-panel{{ focusClass }}">
     <div class="govuk-summary-card__title-wrapper">
@@ -12,8 +15,8 @@
         {{ cardTitle }}
       </h2>
       <div class="govuk-button-group">
-        <button type="submit" name="movement" class="govuk-button govuk-button--secondary reorder-button{{upHidden}}" {{upAuto}} value="up|{{ params.pageId}}">Up</button>
-        <button type="submit" name="movement" class="govuk-button govuk-button--secondary reorder-button{{downHidden}}" {{downAuto}} value="down|{{ params.pageId}}">Down</button>
+        <button type="submit" name="movement" id="focus-up-{{ params.pageId }}" class="govuk-button govuk-button--secondary reorder-button{{ upHidden }}" {{ upAuto }} value="up|{{ params.pageId }}" aria-label="{{ ariaLabelUp }}">Up</button>
+        <button type="submit" name="movement" id="focus-down-{{ params.pageId }}" class="govuk-button govuk-button--secondary reorder-button{{ downHidden }}" {{ downAuto }} value="down|{{ params.pageId }}" aria-label="{{ ariaLabelDown }}">Down</button>
       </div>
     </div>
   </div>

--- a/designer/server/src/common/components/pages-reorder-panel/template.njk
+++ b/designer/server/src/common/components/pages-reorder-panel/template.njk
@@ -2,11 +2,24 @@
 {% set focusClass = " pages-reorder-panel-focus" if params.isFocus else "" %}
 {% set upHidden = "-hidden" if params.isFirstRow else "" %}
 {% set downHidden = "-hidden" if params.isLastRow else "" %}
-{% set upAuto = "autofocus" if params.isFocus and params.prevFocusDirection == "up" else "" %}
-{% set downAuto = "autofocus" if params.isFocus and params.prevFocusDirection == "down" else "" %}
+{% set upAuto = "autofocus" if params.isFocus and (params.prevFocusDirection == "up" or params.isLastRow) else "" %}
+{% set downAuto = "autofocus" if params.isFocus and (params.prevFocusDirection == "down" or params.isFirstRow) else "" %}
 
 {% set ariaLabelUp = "Button, move page up, Page " + params.pageNum + " of " + params.totalPages + " : " + params.pageTitle + "." %}
 {% set ariaLabelDown = "Button, move page down, Page " + params.pageNum + " of " + params.totalPages + " : " + params.pageTitle + "." %}
+{% set ariaAlert = "The list of pages has been reordered, " + params.pageTitle + " is now page " + params.pageNum + " of " + params.totalPages + ". " if params.isFocus else "" %}
+
+{% if params.isFocus %}
+  {% if params.prevFocusDirection == "up" or params.isLastRow %}
+    {% set ariaLabelUp = ariaAlert + ariaLabelUp %}
+  {% endif %}
+  {% if params.prevFocusDirection == "down" or params.isFirstRow %}
+    {% set ariaLabelDown = ariaAlert + ariaLabelDown %}
+  {% endif %}
+{% endif %}
+
+{% set ariaTags = "aria-live=alert" if params.isFocus else "" %}
+{% set ariaContent = "<p class='govuk-visually-hidden'>The list of pages has been reordered, " + params.pageTitle + " is now page " + params.pageNum + " of " + params.totalPages + ".</p>" if params.isFocus else "" %}
 
 <li>
   <div class="govuk-summary-card pages-reorder-panel{{ focusClass }}">

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -213,7 +213,7 @@ export function questionDetailsViewModel(
   )
 
   const extraFieldNames = extraFields.map((field) => field.name ?? 'unknown')
-  const allFieldNames = Object.keys(baseFields).concat(extraFieldNames)
+  const allFieldNames = Object.keys(baseFields.fields).concat(extraFieldNames)
   const errorList = buildErrorList(formErrors, allFieldNames)
 
   return {

--- a/designer/server/src/views/forms/editor-v2/pages-reorder.njk
+++ b/designer/server/src/views/forms/editor-v2/pages-reorder.njk
@@ -23,6 +23,7 @@
         {{ appPagesReorderPanel({
           formName: name,
           pageNum: loop.index,
+          totalPages: pages.length,
           pageId: page.id,
           pageTitle: page.title,
           actions: page.actions,


### PR DESCRIPTION
The main alert after the pages have been reordered will be done as a separate PR. This just covers the button focus screen reader voice output.