### PR TITLE
Fix/529909 change file upload

### DIFF
--- a/designer/server/src/__stubs__/form-definition.js
+++ b/designer/server/src/__stubs__/form-definition.js
@@ -441,6 +441,72 @@ export const testFormDefinitionWithAGuidancePage = {
 }
 
 /**
+ * @satisfies {FormDefinition}
+ */
+export const testFormDefinitionWithFileUploadPage = {
+  name: 'Test form',
+  pages: [
+    {
+      id: 'p1',
+      path: '/file-upload',
+      title: 'Upload a file',
+      controller: ControllerType.FileUpload,
+      section: 'section',
+      components: [
+        {
+          id: 'q1',
+          type: ComponentType.FileUploadField,
+          name: 'fileUpload',
+          title: 'Upload a file',
+          options: {},
+          schema: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      id: 'p2',
+      path: '/page-two',
+      title: 'Page two',
+      section: 'section',
+      components: [
+        {
+          id: 'q1',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your first question - page two',
+          hint: 'Help text',
+          options: {},
+          schema: {}
+        },
+        {
+          id: 'q2',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your second question - page two',
+          hint: 'Help text',
+          options: {
+            required: false
+          },
+          schema: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      id: 'p3',
+      title: 'Summary',
+      path: '/summary',
+      controller: ControllerType.Summary,
+      components: []
+    }
+  ],
+  conditions: [],
+  sections: [],
+  lists: []
+}
+
+/**
  * @param {Partial<PageQuestion>} [partialPage]
  * @returns {PageQuestion}
  */

--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -104,10 +104,8 @@ export async function updateQuestion(
   // Determine if page controller should change
   const page = getPageFromDefinition(definition, pageId)
   const origControllerType = page?.controller
-    ? { controller: page.controller }
-    : {}
-  const newControllerType = getControllerType(questionDetails)
-  if (origControllerType.controller !== newControllerType.controller) {
+  const { controller: newControllerType } = getControllerType(questionDetails)
+  if (origControllerType !== newControllerType) {
     // Update page controller
     const pageHeadingRequestUrl = new URL(
       `./${formId}/definition/draft/pages/${pageId}`,
@@ -115,7 +113,7 @@ export async function updateQuestion(
     )
     await patchJsonByType(pageHeadingRequestUrl, {
       payload: {
-        controller: newControllerType.controller ?? null
+        controller: newControllerType ?? null
       },
       ...getHeaders(token)
     })

--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -9,6 +9,7 @@ import config from '~/src/config.js'
 import { delJson, patchJson, postJson, putJson } from '~/src/lib/fetch.js'
 import {
   getHeaders,
+  getPageFromDefinition,
   isCheckboxSelected,
   slugify,
   stringHasValue
@@ -87,6 +88,7 @@ export async function addQuestion(formId, token, pageId, questionDetails) {
  * Add a question to an existing page
  * @param {string} formId
  * @param {string} token
+ * @param {FormDefinition} definition
  * @param {string} pageId
  * @param {string} questionId
  * @param {Partial<ComponentDef>} questionDetails
@@ -94,10 +96,31 @@ export async function addQuestion(formId, token, pageId, questionDetails) {
 export async function updateQuestion(
   formId,
   token,
+  definition,
   pageId,
   questionId,
   questionDetails
 ) {
+  // Determine if page controller should change
+  const page = getPageFromDefinition(definition, pageId)
+  const origControllerType = page?.controller
+    ? { controller: page.controller }
+    : {}
+  const newControllerType = getControllerType(questionDetails)
+  if (origControllerType !== newControllerType) {
+    // Update page controller
+    const pageHeadingRequestUrl = new URL(
+      `./${formId}/definition/draft/pages/${pageId}`,
+      formsEndpoint
+    )
+    await patchJsonByType(pageHeadingRequestUrl, {
+      payload: {
+        controller: newControllerType.controller ?? null
+      },
+      ...getHeaders(token)
+    })
+  }
+
   const requestUrl = new URL(
     `./${formId}/definition/draft/pages/${pageId}/components/${questionId}`,
     formsEndpoint
@@ -206,7 +229,7 @@ export async function setPageHeadingAndGuidance(
 ) {
   const { pageHeading, guidanceText } = payload
 
-  const page = definition.pages.find((x) => x.id === pageId)
+  const page = getPageFromDefinition(definition, pageId)
   const components = hasComponents(page) ? page.components : []
 
   const isExpanded = isCheckboxSelected(payload.pageHeadingAndGuidance)
@@ -254,7 +277,7 @@ export async function setCheckAnswersDeclaration(
 ) {
   const { declarationText } = payload
 
-  const page = definition.pages.find((x) => x.id === pageId)
+  const page = getPageFromDefinition(definition, pageId)
   // Unable to use hasComponents() method since Summary page does not contain 'next' property
   const components = hasComponentsEvenIfNoNext(page) ? page.components : []
 

--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -107,7 +107,7 @@ export async function updateQuestion(
     ? { controller: page.controller }
     : {}
   const newControllerType = getControllerType(questionDetails)
-  if (origControllerType !== newControllerType) {
+  if (origControllerType.controller !== newControllerType.controller) {
     // Update page controller
     const pageHeadingRequestUrl = new URL(
       `./${formId}/definition/draft/pages/${pageId}`,

--- a/designer/server/src/lib/editor.test.js
+++ b/designer/server/src/lib/editor.test.js
@@ -3,6 +3,7 @@ import { ComponentType, ControllerType, Engine } from '@defra/forms-model'
 import {
   buildDefinition,
   testFormDefinitionWithExistingGuidance,
+  testFormDefinitionWithFileUploadPage,
   testFormDefinitionWithTwoPagesAndQuestions,
   testFormDefinitionWithTwoQuestions
 } from '~/src/__stubs__/form-definition.js'
@@ -271,7 +272,7 @@ describe('editor.js', () => {
     }
 
     describe('when putJson succeeds', () => {
-      test('returns response body', async () => {
+      test('returns response body when no controller defined', async () => {
         mockedPutJson.mockResolvedValueOnce({
           response: createMockResponse(),
           body: { id: '456' }
@@ -287,6 +288,109 @@ describe('editor.js', () => {
         )
 
         expect(mockedPutJson).toHaveBeenCalledWith(requestUrl, expectedOptions2)
+        expect(result).toEqual({ id: '456' })
+      })
+
+      test('returns response body when controller to change to null', async () => {
+        mockedPutJson.mockResolvedValueOnce({
+          response: createMockResponse(),
+          body: { id: '456' }
+        })
+
+        const expectedPatch = {
+          payload: {
+            controller: null
+          },
+          headers: { Authorization: `Bearer ${token}` }
+        }
+
+        const result = await updateQuestion(
+          formId,
+          token,
+          testFormDefinitionWithFileUploadPage,
+          'p1',
+          'q1',
+          questionDetails
+        )
+
+        expect(mockedPutJson).toHaveBeenCalledWith(requestUrl, expectedOptions2)
+        expect(mockedPatchJson).toHaveBeenCalledWith(requestUrl, expectedPatch)
+        expect(result).toEqual({ id: '456' })
+      })
+
+      test('returns response body when controller to change to File Upload controller', async () => {
+        mockedPutJson.mockResolvedValueOnce({
+          response: createMockResponse(),
+          body: { id: '456' }
+        })
+
+        const questionDetailsFileUpload = {
+          type: ComponentType.FileUploadField
+        }
+
+        const expectedPut = {
+          payload: {
+            type: ComponentType.FileUploadField
+          },
+          headers: { Authorization: `Bearer ${token}` }
+        }
+
+        const expectedPatch = {
+          payload: {
+            controller: ControllerType.FileUpload
+          },
+          headers: { Authorization: `Bearer ${token}` }
+        }
+
+        const result = await updateQuestion(
+          formId,
+          token,
+          testFormDefinitionWithTwoPagesAndQuestions,
+          'p1',
+          'q1',
+          questionDetailsFileUpload
+        )
+
+        expect(mockedPutJson).toHaveBeenCalledWith(requestUrl, expectedPut)
+        expect(mockedPatchJson).toHaveBeenCalledWith(requestUrl, expectedPatch)
+        expect(result).toEqual({ id: '456' })
+      })
+
+      test('returns response body when controller is not to change', async () => {
+        mockedPutJson.mockResolvedValueOnce({
+          response: createMockResponse(),
+          body: { id: '456' }
+        })
+
+        const questionDetailsFileUpload = {
+          type: ComponentType.FileUploadField
+        }
+
+        const expectedPut = {
+          payload: {
+            type: ComponentType.FileUploadField
+          },
+          headers: { Authorization: `Bearer ${token}` }
+        }
+
+        const expectedPatch = {
+          payload: {
+            controller: ControllerType.FileUpload
+          },
+          headers: { Authorization: `Bearer ${token}` }
+        }
+
+        const result = await updateQuestion(
+          formId,
+          token,
+          testFormDefinitionWithFileUploadPage,
+          'p1',
+          'q1',
+          questionDetailsFileUpload
+        )
+
+        expect(mockedPutJson).toHaveBeenCalledWith(requestUrl, expectedPut)
+        expect(mockedPatchJson).toHaveBeenCalledWith(requestUrl, expectedPatch)
         expect(result).toEqual({ id: '456' })
       })
     })

--- a/designer/server/src/lib/editor.test.js
+++ b/designer/server/src/lib/editor.test.js
@@ -373,13 +373,6 @@ describe('editor.js', () => {
           headers: { Authorization: `Bearer ${token}` }
         }
 
-        const expectedPatch = {
-          payload: {
-            controller: ControllerType.FileUpload
-          },
-          headers: { Authorization: `Bearer ${token}` }
-        }
-
         const result = await updateQuestion(
           formId,
           token,
@@ -390,7 +383,7 @@ describe('editor.js', () => {
         )
 
         expect(mockedPutJson).toHaveBeenCalledWith(requestUrl, expectedPut)
-        expect(mockedPatchJson).toHaveBeenCalledWith(requestUrl, expectedPatch)
+        expect(mockedPatchJson).not.toHaveBeenCalled()
         expect(result).toEqual({ id: '456' })
       })
     })

--- a/designer/server/src/lib/editor.test.js
+++ b/designer/server/src/lib/editor.test.js
@@ -2,7 +2,9 @@ import { ComponentType, ControllerType, Engine } from '@defra/forms-model'
 
 import {
   buildDefinition,
-  testFormDefinitionWithExistingGuidance
+  testFormDefinitionWithExistingGuidance,
+  testFormDefinitionWithTwoPagesAndQuestions,
+  testFormDefinitionWithTwoQuestions
 } from '~/src/__stubs__/form-definition.js'
 import config from '~/src/config.js'
 import {
@@ -278,6 +280,7 @@ describe('editor.js', () => {
         const result = await updateQuestion(
           formId,
           token,
+          testFormDefinitionWithTwoPagesAndQuestions,
           '12345',
           '456',
           questionDetails
@@ -294,7 +297,14 @@ describe('editor.js', () => {
         mockedPutJson.mockRejectedValueOnce(testError)
 
         await expect(
-          updateQuestion(formId, token, '12345', '456', questionDetails)
+          updateQuestion(
+            formId,
+            token,
+            testFormDefinitionWithTwoQuestions,
+            '12345',
+            '456',
+            questionDetails
+          )
         ).rejects.toThrow(testError)
       })
     })

--- a/designer/server/src/lib/utils.js
+++ b/designer/server/src/lib/utils.js
@@ -68,6 +68,17 @@ export function insertValidationErrors(formField) {
 }
 
 /**
+ *
+ * @param {FormDefinition} definition
+ * @param {string} pageId
+ * @returns { Page | undefined }
+ */
+export function getPageFromDefinition(definition, pageId) {
+  return definition.pages.find((x) => x.id === pageId)
+}
+
+/**
  * @import { ErrorDetailsItem } from '~/src/common/helpers/types.js'
+ * @import { FormDefinition, Page } from '@defra/forms-model'
  * @import Wreck from '@hapi/wreck'
  */

--- a/designer/server/src/models/forms/editor-v2/check-answers-settings.js
+++ b/designer/server/src/models/forms/editor-v2/check-answers-settings.js
@@ -1,7 +1,11 @@
 import { ComponentType, hasComponentsEvenIfNoNext } from '@defra/forms-model'
 
 import { buildErrorList } from '~/src/common/helpers/build-error-details.js'
-import { insertValidationErrors, stringHasValue } from '~/src/lib/utils.js'
+import {
+  getPageFromDefinition,
+  insertValidationErrors,
+  stringHasValue
+} from '~/src/lib/utils.js'
 import {
   GOVUK_LABEL__M,
   SAVE_AND_CONTINUE,
@@ -72,8 +76,7 @@ export function checkAnswersSettingsViewModel(
   const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
   const { formValues, formErrors } = validation ?? {}
 
-  const pageIdx = definition.pages.findIndex((x) => x.id === pageId)
-  const page = definition.pages[pageIdx]
+  const page = getPageFromDefinition(definition, pageId)
   const components = hasComponentsEvenIfNoNext(page) ? page.components : []
 
   const guidanceComponent = /** @type { MarkdownComponent | undefined } */ (

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -2,6 +2,7 @@ import { ControllerType, hasComponents } from '@defra/forms-model'
 
 import { buildEntry } from '~/src/common/nunjucks/context/build-navigation.js'
 import config from '~/src/config.js'
+import { getPageFromDefinition } from '~/src/lib/utils.js'
 import { editorv2Path, formsLibraryPath } from '~/src/models/links.js'
 
 export const BACK_TO_ADD_AND_EDIT_PAGES = 'Back to add and edit pages'
@@ -31,7 +32,7 @@ export function getPageNum(definition, pageId) {
  * @param {string} pageId
  */
 export function getQuestionsOnPage(definition, pageId) {
-  const page = definition.pages.find((x) => x.id === pageId)
+  const page = getPageFromDefinition(definition, pageId)
   return hasComponents(page) ? page.components : []
 }
 

--- a/designer/server/src/models/forms/editor-v2/guidance.js
+++ b/designer/server/src/models/forms/editor-v2/guidance.js
@@ -1,7 +1,10 @@
 import { ComponentType, hasComponents } from '@defra/forms-model'
 
 import { buildErrorList } from '~/src/common/helpers/build-error-details.js'
-import { insertValidationErrors } from '~/src/lib/utils.js'
+import {
+  getPageFromDefinition,
+  insertValidationErrors
+} from '~/src/lib/utils.js'
 import {
   GOVUK_LABEL__M,
   SAVE,
@@ -71,8 +74,7 @@ export function guidanceViewModel(
 
   const pageNum = getPageNum(definition, pageId)
 
-  const pageIdx = definition.pages.findIndex((x) => x.id === pageId)
-  const page = /** @type { Page | undefined } */ (definition.pages[pageIdx])
+  const page = getPageFromDefinition(definition, pageId)
   const components = hasComponents(page) ? page.components : []
 
   const pageHeadingVal = formValues?.pageHeading ?? page?.title

--- a/designer/server/src/models/forms/editor-v2/question-delete.js
+++ b/designer/server/src/models/forms/editor-v2/question-delete.js
@@ -1,6 +1,6 @@
 import { ComponentType, hasComponents } from '@defra/forms-model'
 
-import { stringHasValue } from '~/src/lib/utils.js'
+import { getPageFromDefinition, stringHasValue } from '~/src/lib/utils.js'
 import {
   baseModelFields,
   getFormSpecificNavigation
@@ -91,7 +91,7 @@ export function deleteQuestionConfirmationPageViewModel(
   const formPath = formOverviewPath(metadata.slug)
   const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
 
-  const page = definition.pages.find((x) => x.id === pageId)
+  const page = getPageFromDefinition(definition, pageId)
   const components = hasComponents(page) ? page.components : []
 
   const { bodyText, buttonText, cancelPath, captionText, pageTitle } =

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -2,6 +2,7 @@ import { randomId } from '@defra/forms-model'
 
 import { QuestionTypeDescriptions } from '~/src/common/constants/editor.js'
 import { buildErrorList } from '~/src/common/helpers/build-error-details.js'
+import { getPageFromDefinition } from '~/src/lib/utils.js'
 import { advancedSettingsPerComponentType } from '~/src/models/forms/editor-v2/advanced-settings-fields.js'
 import {
   getFieldList,
@@ -98,7 +99,7 @@ export function getDetails(
 ) {
   const formPath = formOverviewPath(metadata.slug)
   const pageNum = getPageNum(definition, pageId)
-  const page = definition.pages.find((x) => x.id === pageId)
+  const page = getPageFromDefinition(definition, pageId)
   const questionNum = getQuestionNum(definition, pageId, questionId)
   const question = getQuestion(definition, pageId, questionId)
 

--- a/designer/server/src/models/forms/editor-v2/question-type.js
+++ b/designer/server/src/models/forms/editor-v2/question-type.js
@@ -113,16 +113,22 @@ const listSubItems = [
 ]
 
 /**
+ * @param {string} questionId
  * @param {FormEditorCheckbox[]} questionTypes
  * @param {ComponentDef[]} componentsSoFar
  */
-export function filterQuestionTypes(questionTypes, componentsSoFar) {
-  const hasFormComponent = componentsSoFar.some(
+export function filterQuestionTypes(
+  questionId,
+  questionTypes,
+  componentsSoFar
+) {
+  const formComponentCount = componentsSoFar.filter(
     (x) => x.type !== ComponentType.Markdown
-  )
+  ).length
   const preventFileUpload =
     componentsSoFar.some((x) => x.type === ComponentType.FileUploadField) ||
-    hasFormComponent
+    formComponentCount > 1 ||
+    (formComponentCount === 1 && questionId === 'new')
   return preventFileUpload
     ? questionTypes.filter((q) => q.value !== ComponentType.FileUploadField)
     : questionTypes
@@ -215,6 +221,7 @@ export function questionTypeViewModel(
         name: 'questionType',
         value: formValues?.questionType,
         items: filterQuestionTypes(
+          questionId,
           questionTypeRadioItems,
           getQuestionsOnPage(definition, pageId)
         ),

--- a/designer/server/src/models/forms/editor-v2/question-type.test.js
+++ b/designer/server/src/models/forms/editor-v2/question-type.test.js
@@ -35,14 +35,14 @@ const testQuestionTypeItems = /** @type {FormEditorCheckbox[]} */ ([
 
 describe('editor-v2 - question type model', () => {
   describe('filterQuestionTypes', () => {
-    test('should return full list if no components', () => {
-      const res = filterQuestionTypes(testQuestionTypeItems, [])
+    test('should return full list if no components and new question', () => {
+      const res = filterQuestionTypes('new', testQuestionTypeItems, [])
       expect(res).toHaveLength(4)
       expect(res[2].text).toBe('Supporting evidence')
     })
 
-    test('should omit file upload if some components', () => {
-      const res = filterQuestionTypes(testQuestionTypeItems, [
+    test('should omit file upload if some components and new question', () => {
+      const res = filterQuestionTypes('new', testQuestionTypeItems, [
         {
           name: '',
           title: '',
@@ -55,12 +55,33 @@ describe('editor-v2 - question type model', () => {
       expect(res[2].text).toBe('Email address')
     })
 
-    test('should omit file upload if already a file upload component', () => {
-      const res = filterQuestionTypes(testQuestionTypeItems, [
+    test('should omit file upload if already a file upload component and new question', () => {
+      const res = filterQuestionTypes('new', testQuestionTypeItems, [
         {
           name: '',
           title: '',
           type: ComponentType.FileUploadField,
+          schema: {},
+          options: {}
+        }
+      ])
+      expect(res).toHaveLength(3)
+      expect(res[2].text).toBe('Email address')
+    })
+
+    test('should omit file upload if some components and existing question', () => {
+      const res = filterQuestionTypes('123', testQuestionTypeItems, [
+        {
+          name: '',
+          title: '',
+          type: ComponentType.TextField,
+          schema: {},
+          options: {}
+        },
+        {
+          name: '',
+          title: '',
+          type: ComponentType.MultilineTextField,
           schema: {},
           options: {}
         }

--- a/designer/server/src/routes/forms/editor-v2/question-details.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.js
@@ -94,6 +94,7 @@ export default [
 
       // Save page and first question
       const metadata = await forms.get(slug, token)
+      const definition = await forms.getDraftFormDefinition(metadata.id, token)
       let finalPageId = pageId
 
       if (pageId === 'new') {
@@ -109,6 +110,7 @@ export default [
         await updateQuestion(
           metadata.id,
           token,
+          definition,
           pageId,
           questionId,
           questionDetails

--- a/designer/server/src/routes/forms/editor-v2/question-type.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-type.test.js
@@ -55,7 +55,7 @@ describe('Editor v2 question routes', () => {
     expect($actions).toHaveLength(3)
     expect($actions[2]).toHaveTextContent('Save and continue')
 
-    expect($radios).toHaveLength(15)
+    expect($radios).toHaveLength(16)
     expect($radios[0]).toHaveAccessibleName('Written answer')
     expect($radios[1]).toHaveAccessibleName('Short answer (a single line)')
     expect($radios[2]).toHaveAccessibleName(
@@ -67,14 +67,15 @@ describe('Editor v2 question routes', () => {
     expect($radios[6]).toHaveAccessibleName('Month and year')
     expect($radios[7]).toHaveAccessibleName('UK address')
     expect($radios[8]).toHaveAccessibleName('Phone number')
-    expect($radios[9]).toHaveAccessibleName('Email address')
-    expect($radios[10]).toHaveAccessibleName(
+    expect($radios[9]).toHaveAccessibleName('Supporting evidence')
+    expect($radios[10]).toHaveAccessibleName('Email address')
+    expect($radios[11]).toHaveAccessibleName(
       'A list of options that users can choose from'
     )
-    expect($radios[11]).toHaveAccessibleName('Yes or No')
-    expect($radios[12]).toHaveAccessibleName('Checkboxes')
-    expect($radios[13]).toHaveAccessibleName('Radios')
-    expect($radios[14]).toHaveAccessibleName('Autocomplete')
+    expect($radios[12]).toHaveAccessibleName('Yes or No')
+    expect($radios[13]).toHaveAccessibleName('Checkboxes')
+    expect($radios[14]).toHaveAccessibleName('Radios')
+    expect($radios[15]).toHaveAccessibleName('Autocomplete')
   })
 
   test('POST - should error if missing mandatory fields', async () => {

--- a/model/src/form/form-manager/types.ts
+++ b/model/src/form/form-manager/types.ts
@@ -1,6 +1,8 @@
 import { type Page } from '~/src/index.js'
 
-export type PatchPageFields = Partial<Pick<Page, 'title' | 'path'>>
+export type PatchPageFields = Partial<
+  Pick<Page, 'title' | 'path' | 'controller'>
+>
 
 export interface AddComponentQueryOptions {
   prepend?: boolean


### PR DESCRIPTION
Allows File Upload question to be change to a differnet type of question, or from say a TextField to a FileUpload question - and handles the controller property on the page in the JSON