### PR TITLE
chore: update publish workflow to include schemas in cache an exclude scripts

### DIFF
--- a/.github/workflows/publish-model.yml
+++ b/.github/workflows/publish-model.yml
@@ -41,7 +41,9 @@ jobs:
         with:
           enableCrossOsArchive: true
           key: npm-build-model-${{ runner.os }}-${{ github.sha }}
-          path: model/dist
+          path: |
+            model/dist
+            model/schemas
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -85,7 +87,9 @@ jobs:
           enableCrossOsArchive: true
           fail-on-cache-miss: true
           key: npm-build-model-${{ runner.os }}-${{ github.sha }}
-          path: model/dist
+          path: |
+            model/dist
+            model/schemas
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/model/.gitignore
+++ b/model/.gitignore
@@ -2,4 +2,4 @@
 .env
 .idea
 .vscode
-schemas
+schemas/

--- a/model/.npmignore
+++ b/model/.npmignore
@@ -2,6 +2,7 @@
 *.{jest,test}?(.d).{js,ts}?(.map)
 .*
 tsconfig.*
+scripts/
 
-# schemas directory inteded to be published
+# schemas directory intended to be published
 !schemas/


### PR DESCRIPTION
Update publish workflow and ignore files for schema directory inclusion

- Modified the GitHub Actions workflow to include the 'model/schemas' directory in the build paths.
- Updated .gitignore to ensure the 'schemas/' directory is correctly ignored.
- Adjusted .npmignore to clarify the intention of including the 'schemas/' directory in the published package.