### PR TITLE
Advanced error handling

### DIFF
--- a/designer/server/src/common/components/editor-card/template.njk
+++ b/designer/server/src/common/components/editor-card/template.njk
@@ -13,7 +13,6 @@
               <div id="card-1">
                 <div class="govuk-summary-card__content">
                   {% if params.title %}<div class="editor-card-title">{{ params.title }}</div>{% endif %}
-
                   <div class="govuk-!-padding-top-3">
                     {% if params.errorList | length %}
                       {{ govukErrorSummary({
@@ -37,7 +36,7 @@
                       {% endcall %}
                     {% endif %}
 
-                      {{ caller() if caller else (params.html | safe if params.html else params.text) }}
+                    {{ caller() if caller else (params.html | safe if params.html else params.text) }}
                   </div>
                 </div>
               </div>

--- a/designer/server/src/common/helpers/build-error-details.js
+++ b/designer/server/src/common/helpers/build-error-details.js
@@ -3,10 +3,11 @@
  * @param {ValidationErrorItem} errorItem
  */
 export function buildListErrorDetail(errors, { context, message }) {
-  const position = context?.pos
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const position = /** @type {string|undefined} */ (context?.pos)
   const matchString = `[${position}]`
 
-  if (position === undefined || !context.label.includes(matchString)) {
+  if (position === undefined || !context?.label?.includes(matchString)) {
     return errors
   }
 
@@ -26,9 +27,10 @@ export function buildListErrorDetail(errors, { context, message }) {
  * @param {ValidationError} error
  */
 export function buildErrorDetails(error) {
-  return error.details.reduce((errors, { context, message }) => {
-    if (context.pos !== undefined) {
-      return buildListErrorDetail(errors, { context, message })
+  return error.details.reduce((errors, validationErrorItem) => {
+    const { context, message } = validationErrorItem
+    if (context?.pos !== undefined) {
+      return buildListErrorDetail(errors, validationErrorItem)
     }
 
     if (!context?.key) {

--- a/designer/server/src/common/helpers/build-error-details.js
+++ b/designer/server/src/common/helpers/build-error-details.js
@@ -1,10 +1,33 @@
 /**
+ * @param {ErrorDetails} errors
+ * @param {ValidationErrorItem} errorItem
+ */
+export function buildListErrorDetail(errors, { context, message }) {
+  const position = context?.pos
+  const matchString = `[${position}]`
+
+  if (position === undefined || !context.label.includes(matchString)) {
+    return errors
+  }
+
+  const key = context.label.replace(`[${position}]`, '')
+
+  return {
+    ...errors,
+    [key]: {
+      text: message,
+      href: `#${key}`
+    }
+  }
+}
+
+/**
  * @param {ValidationError} error
  */
 export function buildErrorDetails(error) {
   return error.details.reduce((errors, { context, message }) => {
     if (!context?.key) {
-      return errors
+      return buildListErrorDetail(errors, { context, message })
     }
 
     return {
@@ -42,6 +65,6 @@ export function buildErrorList(errorDetails, names) {
 }
 
 /**
- * @import { ValidationError } from 'joi'
+ * @import { ValidationError, ValidationErrorItem } from 'joi'
  * @import { ErrorDetails, ErrorDetailsItem } from '~/src/common/helpers/types.js'
  */

--- a/designer/server/src/common/helpers/build-error-details.js
+++ b/designer/server/src/common/helpers/build-error-details.js
@@ -11,11 +11,12 @@ export function buildListErrorDetail(errors, { context, message }) {
   }
 
   const key = context.label.replace(`[${position}]`, '')
+  const linePosition = parseInt(position) + 1
 
   return {
     ...errors,
     [key]: {
-      text: message,
+      text: message + ` on line ${linePosition}`,
       href: `#${key}`
     }
   }
@@ -26,8 +27,12 @@ export function buildListErrorDetail(errors, { context, message }) {
  */
 export function buildErrorDetails(error) {
   return error.details.reduce((errors, { context, message }) => {
-    if (!context?.key) {
+    if (context.pos !== undefined) {
       return buildListErrorDetail(errors, { context, message })
+    }
+
+    if (!context?.key) {
+      return errors
     }
 
     return {

--- a/designer/server/src/common/helpers/build-error-details.test.js
+++ b/designer/server/src/common/helpers/build-error-details.test.js
@@ -1,0 +1,74 @@
+import { ValidationError } from 'joi'
+
+import { buildErrorDetails } from '~/src/common/helpers/build-error-details.js'
+
+describe('build error details', () => {
+  describe('buildErrorDetails', () => {
+    it('should return errors on first array item', () => {
+      const message = 'Enter options separated by a colon'
+      const error = new ValidationError(
+        message,
+        [
+          {
+            message,
+            context: {
+              pos: 0,
+              value: { text: '', value: '' },
+              label: 'autoCompleteOptions[0]',
+              key: 0
+            }
+          }
+        ],
+        { text: '', value: '' }
+      )
+      expect(buildErrorDetails(error)).toEqual({
+        autoCompleteOptions: {
+          text: 'Enter options separated by a colon on line 1',
+          href: '#autoCompleteOptions'
+        }
+      })
+    })
+
+    it('should return errors on array items', () => {
+      const message = 'Enter options separated by a colon'
+      const error = new ValidationError(
+        message,
+        [
+          {
+            message,
+            context: {
+              pos: 0,
+              value: { text: '', value: '' },
+              label: 'unknownKey',
+              key: 0
+            }
+          },
+          {
+            message,
+            context: {
+              pos: 1,
+              value: { text: '', value: '' },
+              label: 'autoCompleteOptions[1]',
+              key: 1
+            }
+          },
+          {
+            message,
+            context: {
+              value: { text: '', value: '' },
+              label: 'unknownKey2',
+              key: 0
+            }
+          }
+        ],
+        { text: '', value: '' }
+      )
+      expect(buildErrorDetails(error)).toEqual({
+        autoCompleteOptions: {
+          text: message,
+          href: '#autoCompleteOptions'
+        }
+      })
+    })
+  })
+})

--- a/designer/server/src/common/helpers/build-error-details.test.js
+++ b/designer/server/src/common/helpers/build-error-details.test.js
@@ -65,7 +65,7 @@ describe('build error details', () => {
       )
       expect(buildErrorDetails(error)).toEqual({
         autoCompleteOptions: {
-          text: message,
+          text: 'Enter options separated by a colon on line 2',
           href: '#autoCompleteOptions'
         }
       })

--- a/designer/server/src/common/helpers/build-error-details.test.js
+++ b/designer/server/src/common/helpers/build-error-details.test.js
@@ -11,10 +11,13 @@ describe('build error details', () => {
         [
           {
             message,
+            path: [],
+            type: 'unknown',
             context: {
               pos: 0,
               value: { text: '', value: '' },
               label: 'autoCompleteOptions[0]',
+              // @ts-expect-error: Joi has incorrect typings for Context (should be string|number)
               key: 0
             }
           }
@@ -36,27 +39,36 @@ describe('build error details', () => {
         [
           {
             message,
+            path: [],
+            type: 'unknown',
             context: {
               pos: 0,
               value: { text: '', value: '' },
               label: 'unknownKey',
+              // @ts-expect-error: Joi has incorrect typings for Context (should be string|number)
               key: 0
             }
           },
           {
             message,
+            path: [],
+            type: 'unknown',
             context: {
               pos: 1,
               value: { text: '', value: '' },
               label: 'autoCompleteOptions[1]',
+              // @ts-expect-error: Joi has incorrect typings for Context (should be string|number)
               key: 1
             }
           },
           {
             message,
+            path: [],
+            type: 'unknown',
             context: {
               value: { text: '', value: '' },
               label: 'unknownKey2',
+              // @ts-expect-error: Joi has incorrect typings for Context (should be string|number)
               key: 0
             }
           }

--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.js
@@ -108,7 +108,8 @@ export const baseSchema = Joi.object().keys({
         'array.includes': 'Enter options separated by a colon',
         'dsv.invalid': 'Enter options separated by a colon',
         'string.min': 'Enter at least one character',
-        'string.empty': 'Enter at least one character'
+        'string.empty': 'Enter at least one character',
+        'array.unique': 'Duplicate option found'
       }),
       otherwise: Joi.forbidden()
     }

--- a/model/src/form/form-editor/index.test.ts
+++ b/model/src/form/form-editor/index.test.ts
@@ -64,7 +64,6 @@ describe('index', () => {
           'Polish:pl-PL\r\n' +
           'Ukrainian:uk-UA'
       )
-      expect(error).toBeUndefined()
       expect(value).toEqual([
         { text: 'English', value: 'en-gb' },
         { text: 'French', value: 'fr-FR' },
@@ -73,6 +72,7 @@ describe('index', () => {
         { text: 'Polish', value: 'pl-PL' },
         { text: 'Ukrainian', value: 'uk-UA' }
       ])
+      expect(error).toBeUndefined()
     })
 
     it('should fill in empty values', () => {

--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -440,7 +440,7 @@ export const autoCompleteOptionsSchema = customValidator
     })
   )
   .min(1)
-  .unique('name')
+  .unique('text')
   .unique('value', { ignoreUndefined: true })
   .required()
 

--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -440,6 +440,8 @@ export const autoCompleteOptionsSchema = customValidator
     })
   )
   .min(1)
+  .unique('name')
+  .unique('value', { ignoreUndefined: true })
   .required()
 
 export const questionDetailsFullSchema = {


### PR DESCRIPTION
## Advanced Error Handling

This PR solves the issue of errors on lists not showing in the error panel.  The error messages are now shown, for example:

![image](https://github.com/user-attachments/assets/9d1b9a77-cffd-4f63-888a-bd4fe92f1eaf)

Duplicate items also now throw a 400 error with error message:

![image](https://github.com/user-attachments/assets/dd00e941-3b50-4a03-8437-db40e052bf4d)

