### PR TITLE
test: 537088 - Update hint schema

### DIFF
--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.js
@@ -8,14 +8,14 @@ import {
 const radiosSectionListItemsAnchor = '#list-items'
 
 /**
- * @param { { id?: string, text?: string, hint?: string, value?: string } | undefined } itemForEdit
+ * @param { { id?: string, text?: string, hint?: { text: string }, value?: string } | undefined } itemForEdit
  * @param {boolean} expanded
  */
 export function setEditRowState(itemForEdit, expanded) {
   return {
     radioId: itemForEdit?.id ?? '',
     radioText: itemForEdit?.text ?? '',
-    radioHint: itemForEdit?.hint ?? '',
+    radioHint: itemForEdit?.hint?.text ?? '',
     radioValue: itemForEdit?.value ?? '',
     expanded
   }
@@ -114,12 +114,20 @@ export function handleEnhancedActionOnPost(
       // Update
       foundRow.text = payload.radioText
       foundRow.hint = payload.radioHint
+        ? {
+            text: payload.radioHint
+          }
+        : undefined
       foundRow.value = payload.radioValue
     } else {
       // Insert
       state.listItems?.push({
         text: payload.radioText,
-        hint: payload.radioHint,
+        hint: payload.radioHint
+          ? {
+              text: payload.radioHint
+            }
+          : undefined,
         value: payload.radioValue,
         id: randomUUID()
       })

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
@@ -219,75 +219,117 @@ describe('Editor v2 question-details route helper', () => {
       })
     })
 
-    test('save-item should update existing item', () => {
-      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+    describe('save-item', () => {
+      test('should handle simple no list items', () => {
+        mockGet.mockReturnValue(structuredClone(simpleSession))
 
-      const payload = /** @type {FormEditorInputQuestionDetails} */ ({
-        enhancedAction: 'save-item',
-        radioId: '3',
-        radioText: 'text3x',
-        radioHint: 'hint3x',
-        radioValue: 'value3x'
-      })
-
-      expect(handleEnhancedActionOnPost(mockYar, '123', payload, {})).toBe(
-        '#list-items'
-      )
-      const expectedList = [
-        { id: '1', text: 'text1', value: 'value1' },
-        { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
-        { id: '3', text: 'text3x', hint: { text: 'hint3x' }, value: 'value3x' }
-      ]
-      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
-        questionType: 'RadiosField',
-        listItems: expectedList,
-        editRow: {
-          radioId: '',
-          radioText: '',
+        const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+          enhancedAction: 'save-item',
+          radioId: '1',
+          radioText: 'text',
           radioHint: '',
-          radioValue: '',
-          expanded: false
-        },
-        questionDetails: {}
+          radioValue: 'value'
+        })
+
+        expect(handleEnhancedActionOnPost(mockYar, '123', payload, {})).toBe(
+          '#list-items'
+        )
+        const expectedList = [
+          {
+            id: expect.any(String),
+            text: 'text',
+            hint: undefined,
+            value: 'value'
+          }
+        ]
+        expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+          questionType: 'RadiosField',
+          listItems: expectedList,
+          editRow: {
+            radioId: '',
+            radioText: '',
+            radioHint: '',
+            radioValue: '',
+            expanded: false
+          },
+          questionDetails: {}
+        })
       })
-    })
+      test('save-item should update existing item', () => {
+        mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
 
-    test('save-item should add new item', () => {
-      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+        const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+          enhancedAction: 'save-item',
+          radioId: '3',
+          radioText: 'text3x',
+          radioHint: 'hint3x',
+          radioValue: 'value3x'
+        })
 
-      const payload = /** @type {FormEditorInputQuestionDetails} */ ({
-        enhancedAction: 'save-item',
-        radioId: '5',
-        radioText: 'text5',
-        radioHint: 'hint5',
-        radioValue: 'value5'
+        expect(handleEnhancedActionOnPost(mockYar, '123', payload, {})).toBe(
+          '#list-items'
+        )
+        const expectedList = [
+          { id: '1', text: 'text1', value: 'value1' },
+          { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
+          {
+            id: '3',
+            text: 'text3x',
+            hint: { text: 'hint3x' },
+            value: 'value3x'
+          }
+        ]
+        expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+          questionType: 'RadiosField',
+          listItems: expectedList,
+          editRow: {
+            radioId: '',
+            radioText: '',
+            radioHint: '',
+            radioValue: '',
+            expanded: false
+          },
+          questionDetails: {}
+        })
       })
 
-      expect(handleEnhancedActionOnPost(mockYar, '123', payload, {})).toBe(
-        '#list-items'
-      )
-      const expectedList = [
-        { id: '1', text: 'text1', value: 'value1' },
-        { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
-        { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' },
-        {
-          id: expect.anything(),
-          text: 'text5',
-          hint: { text: 'hint5' },
-          value: 'value5'
-        }
-      ]
-      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
-        questionType: 'RadiosField',
-        listItems: expectedList,
-        editRow: {
-          radioId: '',
-          radioText: '',
+      test('save-item should add new item', () => {
+        mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+        const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+          enhancedAction: 'save-item',
+          radioId: '5',
+          radioText: 'text5',
           radioHint: '',
-          radioValue: '',
-          expanded: false
-        },
-        questionDetails: {}
+          radioValue: 'value5'
+        })
+
+        expect(handleEnhancedActionOnPost(mockYar, '123', payload, {})).toBe(
+          '#list-items'
+        )
+        const expectedList = [
+          { id: '1', text: 'text1', value: 'value1' },
+          { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
+          { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' },
+          {
+            id: expect.anything(),
+            text: 'text5',
+            hint: undefined,
+            value: 'value5'
+          }
+        ]
+        expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+          questionType: 'RadiosField',
+          listItems: expectedList,
+          editRow: {
+            radioId: '',
+            radioText: '',
+            radioHint: '',
+            radioValue: '',
+            expanded: false
+          },
+          questionDetails: {}
+        })
       })
     })
   })

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
@@ -23,9 +23,9 @@ const mockYar = /** @type {Yar}} */ ({
 
 const listWithThreeItems = {
   listItems: [
-    { id: '1', text: 'text1', hint: 'hint1', value: 'value1' },
-    { id: '2', text: 'text2', hint: 'hint2', value: 'value2' },
-    { id: '3', text: 'text3', hint: 'hint3', value: 'value3' }
+    { id: '1', text: 'text1', hint: { text: 'hint1' }, value: 'value1' },
+    { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
+    { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' }
   ]
 }
 
@@ -55,7 +55,9 @@ describe('Editor v2 question-details route helper', () => {
           {
             id: '12345',
             text: 'text1',
-            hint: 'hint1',
+            hint: {
+              text: 'hint1'
+            },
             value: 'value1'
           },
           false
@@ -109,8 +111,8 @@ describe('Editor v2 question-details route helper', () => {
       expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
         questionType: 'RadiosField',
         listItems: [
-          { id: '1', text: 'text1', hint: 'hint1', value: 'value1' },
-          { id: '3', text: 'text3', hint: 'hint3', value: 'value3' }
+          { id: '1', text: 'text1', hint: { text: 'hint1' }, value: 'value1' },
+          { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' }
         ]
       })
     })
@@ -131,9 +133,9 @@ describe('Editor v2 question-details route helper', () => {
           expanded: true
         },
         listItems: [
-          { hint: 'hint1', id: '1', text: 'text1', value: 'value1' },
-          { hint: 'hint2', id: '2', text: 'text2', value: 'value2' },
-          { hint: 'hint3', id: '3', text: 'text3', value: 'value3' }
+          { hint: { text: 'hint1' }, id: '1', text: 'text1', value: 'value1' },
+          { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' },
+          { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' }
         ]
       })
     })
@@ -154,9 +156,9 @@ describe('Editor v2 question-details route helper', () => {
           expanded: false
         },
         listItems: [
-          { hint: 'hint1', id: '1', text: 'text1', value: 'value1' },
-          { hint: 'hint2', id: '2', text: 'text2', value: 'value2' },
-          { hint: 'hint3', id: '3', text: 'text3', value: 'value3' }
+          { hint: { text: 'hint1' }, id: '1', text: 'text1', value: 'value1' },
+          { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' },
+          { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' }
         ]
       })
     })
@@ -232,9 +234,9 @@ describe('Editor v2 question-details route helper', () => {
         '#list-items'
       )
       const expectedList = [
-        { id: '1', text: 'text1', hint: 'hint1', value: 'value1' },
-        { id: '2', text: 'text2', hint: 'hint2', value: 'value2' },
-        { id: '3', text: 'text3x', hint: 'hint3x', value: 'value3x' }
+        { id: '1', text: 'text1', hint: { text: 'hint1' }, value: 'value1' },
+        { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
+        { id: '3', text: 'text3x', hint: { text: 'hint3x' }, value: 'value3x' }
       ]
       expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
         questionType: 'RadiosField',
@@ -265,13 +267,13 @@ describe('Editor v2 question-details route helper', () => {
         '#list-items'
       )
       const expectedList = [
-        { id: '1', text: 'text1', hint: 'hint1', value: 'value1' },
-        { id: '2', text: 'text2', hint: 'hint2', value: 'value2' },
-        { id: '3', text: 'text3', hint: 'hint3', value: 'value3' },
+        { id: '1', text: 'text1', hint: { text: 'hint1' }, value: 'value1' },
+        { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
+        { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' },
         {
           id: expect.anything(),
           text: 'text5',
-          hint: 'hint5',
+          hint: { text: 'hint5' },
           value: 'value5'
         }
       ]

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
@@ -23,7 +23,7 @@ const mockYar = /** @type {Yar}} */ ({
 
 const listWithThreeItems = {
   listItems: [
-    { id: '1', text: 'text1', hint: { text: 'hint1' }, value: 'value1' },
+    { id: '1', text: 'text1', value: 'value1' },
     { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
     { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' }
   ]
@@ -111,7 +111,7 @@ describe('Editor v2 question-details route helper', () => {
       expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
         questionType: 'RadiosField',
         listItems: [
-          { id: '1', text: 'text1', hint: { text: 'hint1' }, value: 'value1' },
+          { id: '1', text: 'text1', value: 'value1' },
           { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' }
         ]
       })
@@ -133,7 +133,7 @@ describe('Editor v2 question-details route helper', () => {
           expanded: true
         },
         listItems: [
-          { hint: { text: 'hint1' }, id: '1', text: 'text1', value: 'value1' },
+          { id: '1', text: 'text1', value: 'value1' },
           { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' },
           { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' }
         ]
@@ -156,7 +156,7 @@ describe('Editor v2 question-details route helper', () => {
           expanded: false
         },
         listItems: [
-          { hint: { text: 'hint1' }, id: '1', text: 'text1', value: 'value1' },
+          { id: '1', text: 'text1', value: 'value1' },
           { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' },
           { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' }
         ]
@@ -234,7 +234,7 @@ describe('Editor v2 question-details route helper', () => {
         '#list-items'
       )
       const expectedList = [
-        { id: '1', text: 'text1', hint: { text: 'hint1' }, value: 'value1' },
+        { id: '1', text: 'text1', value: 'value1' },
         { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
         { id: '3', text: 'text3x', hint: { text: 'hint3x' }, value: 'value3x' }
       ]
@@ -267,7 +267,7 @@ describe('Editor v2 question-details route helper', () => {
         '#list-items'
       )
       const expectedList = [
-        { id: '1', text: 'text1', hint: { text: 'hint1' }, value: 'value1' },
+        { id: '1', text: 'text1', value: 'value1' },
         { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
         { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' },
         {

--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -314,6 +314,11 @@ describe('Form definition schema', () => {
           {
             text: 'a string',
             value: 'string'
+          },
+          {
+            text: 'a string',
+            value: 'string',
+            hint: { text: 'a hint' }
           }
         ],
         name: 'ADxeWa',
@@ -363,7 +368,13 @@ describe('Form definition schema', () => {
           lists: [
             {
               id: expect.any(String),
-              items: [expect.objectContaining({ id: expect.any(String) })]
+              items: [
+                expect.objectContaining({ id: expect.any(String) }),
+                expect.objectContaining({
+                  id: expect.any(String),
+                  hint: { id: expect.any(String), text: 'a hint' }
+                })
+              ]
             },
             { id: expect.any(String) }
           ]

--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -312,12 +312,13 @@ describe('Form definition schema', () => {
       const list: List = {
         items: [
           {
-            text: 'a string',
-            value: 'string'
+            id: 'a9dd35af-187e-4027-b8b1-e58a4aab3a82',
+            text: 'Item 1',
+            value: 'item-1'
           },
           {
-            text: 'a string',
-            value: 'string',
+            text: 'Item 2',
+            value: 'item-2',
             hint: { text: 'a hint' }
           }
         ],

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -483,9 +483,14 @@ const baseListItemSchema = Joi.object<Item>()
       .allow('')
       .optional()
       .description('Condition that determines if this item is shown'),
-    hint: Joi.string()
-      .allow('')
+    hint: Joi.object<Item['hint']>()
       .optional()
+      .keys({
+        id: Joi.string()
+          .uuid()
+          .default(() => uuidV4()),
+        text: Joi.string()
+      })
       .description('Optional hint text to be shown on list item')
   })
 

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -125,7 +125,10 @@ export interface Item {
   description?: string
   conditional?: { components: ComponentDef[] }
   condition?: string
-  hint?: string
+  hint?: {
+    id?: string
+    text: string
+  }
 }
 
 export interface List {

--- a/model/src/form/form-editor/types.ts
+++ b/model/src/form/form-editor/types.ts
@@ -302,7 +302,12 @@ export interface QuestionSessionState {
     radioValue?: string
     expanded?: boolean
   }
-  listItems?: { text?: string; hint?: string; value?: string; id?: string }[]
+  listItems?: {
+    text?: string
+    hint?: { id?: string; text: string }
+    value?: string
+    id?: string
+  }[]
 }
 
 export interface GovukField {


### PR DESCRIPTION
## Update to schema

`forms-plugin` is using a list hint: { id: string; text: string }, so hint: string is colliding with this.  Updated now to resolve.