### PR TITLE
Fix/529912 duplicate page name

### DIFF
--- a/designer/server/src/lib/__stubs__/editor.js
+++ b/designer/server/src/lib/__stubs__/editor.js
@@ -1,3 +1,5 @@
+import Boom from '@hapi/boom'
+
 import config from '~/src/config.js'
 import { delJson, patchJson, postJson, putJson } from '~/src/lib/fetch.js'
 
@@ -27,6 +29,17 @@ export const formsEndpoint = new URL('/forms/', config.managerUrl)
 export const token = 'someToken'
 export const baseOptions = {
   headers: { Authorization: `Bearer ${token}` }
+}
+
+/**
+ * @param {string} message
+ */
+export function buildBoom409(message) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return Boom.boomify(new Error(message), {
+    statusCode: 409,
+    data: { message, statusCode: 409 }
+  })
 }
 
 /**

--- a/designer/server/src/lib/__stubs__/editor.js
+++ b/designer/server/src/lib/__stubs__/editor.js
@@ -35,11 +35,12 @@ export const baseOptions = {
  * @param { string | undefined } message
  */
 export function buildBoom409(message) {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return Boom.boomify(new Error(message), {
-    statusCode: 409,
-    data: { message, statusCode: 409 }
-  })
+  return /** @type {Boom.Boom<{ message: string, statusCode: number }>}} */ (
+    Boom.boomify(new Error(message), {
+      statusCode: 409,
+      data: { message, statusCode: 409 }
+    })
+  )
 }
 
 /**

--- a/designer/server/src/lib/__stubs__/editor.js
+++ b/designer/server/src/lib/__stubs__/editor.js
@@ -32,7 +32,7 @@ export const baseOptions = {
 }
 
 /**
- * @param {string} message
+ * @param { string | undefined } message
  */
 export function buildBoom409(message) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/designer/server/src/lib/error-boom-helper.js
+++ b/designer/server/src/lib/error-boom-helper.js
@@ -5,14 +5,14 @@ import { sessionNames } from '~/src/common/constants/session-names.js'
 
 const boomMappings = [
   {
-    errorCode: 4091,
+    errorCode: 409,
     errorStartsWith: 'Duplicate page path',
     errorKey: sessionNames.validationFailure.editorQuestions,
     fieldName: 'pageHeading',
     userMessage: 'This page title already exists - use a unique page title'
   },
   {
-    errorCode: 4091,
+    errorCode: 409,
     errorStartsWith: 'Duplicate page path',
     errorKey: sessionNames.validationFailure.editorQuestionDetails,
     fieldName: 'question',

--- a/designer/server/src/lib/error-boom-helper.js
+++ b/designer/server/src/lib/error-boom-helper.js
@@ -35,7 +35,7 @@ export function createJoiError(fieldName, message) {
 }
 
 /**
- * @param {Boom.Boom} boomError
+ * @param {Boom.Boom<{ message: string, statusCode: number }>} boomError
  * @param {ValidationSessionKey} errorKey
  * @param {string} [fieldName]
  */
@@ -44,7 +44,9 @@ export function checkBoomError(boomError, errorKey, fieldName = 'general') {
     return undefined
   }
 
-  const boomMessage = boomError.data?.message ?? 'An error occurred'
+  const boomMessage = /** @type {string} */ (
+    boomError.data?.message ?? 'An error occurred'
+  )
 
   const error = boomMappings.filter(
     (x) =>

--- a/designer/server/src/lib/error-boom-helper.js
+++ b/designer/server/src/lib/error-boom-helper.js
@@ -1,0 +1,81 @@
+import Boom from '@hapi/boom'
+import Joi from 'joi'
+
+const baseBoomSchema = Joi.object({
+  boomMessage: Joi.string().optional()
+})
+
+export const pageBoomSchema = Joi.object({
+  pageHeading: Joi.string()
+    .when('boomMessage', {
+      is: Joi.string().pattern(/^Duplicate page path/),
+      then: Joi.forbidden(),
+      otherwise: Joi.string().optional()
+    })
+    .messages({
+      '*': 'This page title already exists - use a unique page title'
+    })
+})
+
+export const questionsBoomSchema = Joi.object({
+  question: Joi.string()
+    .when('boomMessage', {
+      is: Joi.string().pattern(/^Duplicate page path/),
+      then: Joi.forbidden(),
+      otherwise: Joi.string().optional()
+    })
+    .messages({
+      '*': 'This question or page title already exists - use a unique question or page title'
+    })
+})
+
+const boomSchema = baseBoomSchema
+  .concat(pageBoomSchema)
+  .concat(questionsBoomSchema)
+
+/**
+ * @param {ValidationSessionKey} errorKey
+ * @param {Boom.Boom} boomError
+ * @param {string} [fieldName]
+ */
+export function mapBoomError(errorKey, boomError, fieldName = 'general') {
+  const boomMessage = boomError.data?.message ?? 'An error occurred'
+
+  const { error } = boomSchema.validate({ boomMessage, [fieldName]: errorKey })
+
+  if (!error) {
+    // Boom schema didn't find a custom message for the error
+    return new Joi.ValidationError(
+      boomMessage,
+      [
+        {
+          message: boomMessage,
+          path: [fieldName],
+          type: 'custom',
+          context: { key: fieldName }
+        }
+      ],
+      undefined
+    )
+  }
+
+  return error
+}
+
+/**
+ * @param {Boom.Boom} boomError
+ * @param {Joi.ObjectSchema} schema
+ */
+export function checkBoomError(boomError, schema) {
+  if (!Boom.isBoom(boomError) || boomError.data?.statusCode !== 409) {
+    return undefined
+  }
+
+  const boomSchema = baseBoomSchema.concat(schema)
+  const { error } = boomSchema.validate(boomError)
+  return error
+}
+
+/**
+ * @import { ValidationSessionKey } from '@hapi/yar'
+ */

--- a/designer/server/src/lib/error-boom-helper.test.js
+++ b/designer/server/src/lib/error-boom-helper.test.js
@@ -1,0 +1,19 @@
+import Joi from 'joi'
+
+import { sessionNames } from '~/src/common/constants/session-names.js'
+import { buildBoom409 } from '~/src/lib/__stubs__/editor.js'
+import { checkBoomError } from '~/src/lib/error-boom-helper.js'
+
+describe('Boom error helper', () => {
+  describe('checkBoomError', () => {
+    test('should handle if no boom message passed', () => {
+      const error = checkBoomError(
+        buildBoom409(undefined),
+        sessionNames.validationFailure.editorQuestionDetails
+      )
+      expect(error).toBeInstanceOf(Joi.ValidationError)
+      expect(error?.details[0].message).toBe('An error occurred')
+      expect(error?.details[0].path).toEqual(['general'])
+    })
+  })
+})

--- a/designer/server/src/lib/error-helper.js
+++ b/designer/server/src/lib/error-helper.js
@@ -1,10 +1,10 @@
 import Joi from 'joi'
 
-import { sessionNames } from '~/src/common/constants/session-names.js'
 import { buildErrorDetails } from '~/src/common/helpers/build-error-details.js'
 
 /**
- * @param {Request | Request<{ Payload: FormEditorInputQuestionDetails } >} request
+ * @template T
+ * @param {Request | Request<{ Payload: T }> } request
  * @param {Error} [error]
  * @param {ValidationSessionKey} [flashKey]
  */
@@ -35,33 +35,7 @@ export function getValidationErrorsFromSession(yar, errorKey) {
 }
 
 /**
- * @param {ValidationSessionKey} errorKey
- * @param {Boom.Boom} boomError
- * @param {string} [fieldName]
- */
-export function mapBoomError(errorKey, boomError, fieldName) {
-  const boomMessage = boomError.data?.message
-  let message = boomMessage ?? 'An error occurred'
-  if (boomMessage.startsWith('Duplicate page path')) {
-    if (errorKey === sessionNames.validationFailure.editorQuestionDetails) {
-      message =
-        'Page path (derived from first question text) already exists on another page'
-    } else if (errorKey === sessionNames.validationFailure.editorPage) {
-      message =
-        'Page path (derived from page heading) already exists on another page'
-    }
-  }
-
-  return {
-    [fieldName ?? 'general']: {
-      text: message,
-      href: `#${fieldName ?? 'general'}`
-    }
-  }
-}
-/**
- * @import { FormEditor, FormEditorInputQuestionDetails } from '@defra/forms-model'
- * @import Boom from '@hapi/boom'
+ * @import { FormEditor } from '@defra/forms-model'
  * @import { Request } from '@hapi/hapi'
  * @import { ValidationSessionKey, Yar } from '@hapi/yar'
  * @import { ValidationFailure } from '~/src/common/helpers/types.js'

--- a/designer/server/src/lib/error-helper.js
+++ b/designer/server/src/lib/error-helper.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 
+import { sessionNames } from '~/src/common/constants/session-names.js'
 import { buildErrorDetails } from '~/src/common/helpers/build-error-details.js'
 
 /**
@@ -34,7 +35,33 @@ export function getValidationErrorsFromSession(yar, errorKey) {
 }
 
 /**
+ * @param {ValidationSessionKey} errorKey
+ * @param {Boom.Boom} boomError
+ * @param {string} [fieldName]
+ */
+export function mapBoomError(errorKey, boomError, fieldName) {
+  const boomMessage = boomError.data?.message
+  let message = boomMessage ?? 'An error occurred'
+  if (boomMessage.startsWith('Duplicate page path')) {
+    if (errorKey === sessionNames.validationFailure.editorQuestionDetails) {
+      message =
+        'Page path (derived from first question text) already exists on another page'
+    } else if (errorKey === sessionNames.validationFailure.editorPage) {
+      message =
+        'Page path (derived from page heading) already exists on another page'
+    }
+  }
+
+  return {
+    [fieldName ?? 'general']: {
+      text: message,
+      href: `#${fieldName ?? 'general'}`
+    }
+  }
+}
+/**
  * @import { FormEditor, FormEditorInputQuestionDetails } from '@defra/forms-model'
+ * @import Boom from '@hapi/boom'
  * @import { Request } from '@hapi/hapi'
  * @import { ValidationSessionKey, Yar } from '@hapi/yar'
  * @import { ValidationFailure } from '~/src/common/helpers/types.js'

--- a/designer/server/src/lib/redirect-helper.js
+++ b/designer/server/src/lib/redirect-helper.js
@@ -1,10 +1,12 @@
 import { StatusCodes } from 'http-status-codes'
 
-import { addErrorsToSession, mapBoomError } from '~/src/lib/error-helper.js'
+import { mapBoomError } from '~/src/lib/error-boom-helper.js'
+import { addErrorsToSession } from '~/src/lib/error-helper.js'
 
 /**
- * @param {Request | Request<{ Payload: FormEditorInputQuestionDetails } >} request
- * @param {ResponseToolkit | ResponseToolkit<{ Payload: FormEditorInputQuestionDetails } >} h
+ * @template T
+ * @param { Request | Request<{ Payload: T } > } request
+ * @param { ResponseToolkit | ResponseToolkit<{ Payload: T }> } h
  * @param {Error | undefined} error
  * @param {ValidationSessionKey} errorKey
  * @param {string} [anchor]
@@ -19,11 +21,12 @@ export function redirectWithErrors(request, h, error, errorKey, anchor = '') {
 }
 
 /**
- * @param { Request | Request<{ Payload: FormEditorInputQuestionDetails }> } request
- * @param {ResponseToolkit | ResponseToolkit<{ Payload: FormEditorInputQuestionDetails }> } h
+ * @template T
+ * @param { Request | Request<{ Payload: T }> } request
+ * @param { ResponseToolkit | ResponseToolkit<{ Payload: T }> } h
  * @param {Boom.Boom} boomError
  * @param {ValidationSessionKey} errorKey
- * @param {string} fieldName
+ * @param {string} [fieldName]
  * @param {string} [anchor]
  */
 export function redirectWithBoomError(
@@ -32,24 +35,15 @@ export function redirectWithBoomError(
   boomError,
   errorKey,
   fieldName,
-  anchor
+  anchor = ''
 ) {
   const error = mapBoomError(errorKey, boomError, fieldName)
 
-  request.yar.flash(errorKey, {
-    formErrors: error,
-    formValues: request.payload
-  })
-
-  const { pathname: redirectTo } = request.url
-  return h
-    .redirect(`${redirectTo}${anchor}`)
-    .code(StatusCodes.SEE_OTHER)
-    .takeover()
+  return redirectWithErrors(request, h, error, errorKey, anchor)
 }
 
 /**
- * @import { FormEditorInputQuestionDetails } from '@defra/forms-model'
+ * @import { FormEditorInputPageSettings, FormEditorInputQuestionDetails } from '@defra/forms-model'
  * @import Boom from '@hapi/boom'
  * @import { Request, ResponseToolkit } from '@hapi/hapi'
  * @import { ValidationSessionKey } from '@hapi/yar'

--- a/designer/server/src/lib/redirect-helper.js
+++ b/designer/server/src/lib/redirect-helper.js
@@ -1,6 +1,5 @@
 import { StatusCodes } from 'http-status-codes'
 
-import { mapBoomError } from '~/src/lib/error-boom-helper.js'
 import { addErrorsToSession } from '~/src/lib/error-helper.js'
 
 /**
@@ -21,30 +20,6 @@ export function redirectWithErrors(request, h, error, errorKey, anchor = '') {
 }
 
 /**
- * @template T
- * @param { Request | Request<{ Payload: T }> } request
- * @param { ResponseToolkit | ResponseToolkit<{ Payload: T }> } h
- * @param {Boom.Boom} boomError
- * @param {ValidationSessionKey} errorKey
- * @param {string} [fieldName]
- * @param {string} [anchor]
- */
-export function redirectWithBoomError(
-  request,
-  h,
-  boomError,
-  errorKey,
-  fieldName,
-  anchor = ''
-) {
-  const error = mapBoomError(errorKey, boomError, fieldName)
-
-  return redirectWithErrors(request, h, error, errorKey, anchor)
-}
-
-/**
- * @import { FormEditorInputPageSettings, FormEditorInputQuestionDetails } from '@defra/forms-model'
- * @import Boom from '@hapi/boom'
  * @import { Request, ResponseToolkit } from '@hapi/hapi'
  * @import { ValidationSessionKey } from '@hapi/yar'
  */

--- a/designer/server/src/lib/redirect-helper.js
+++ b/designer/server/src/lib/redirect-helper.js
@@ -1,6 +1,6 @@
 import { StatusCodes } from 'http-status-codes'
 
-import { addErrorsToSession } from '~/src/lib/error-helper.js'
+import { addErrorsToSession, mapBoomError } from '~/src/lib/error-helper.js'
 
 /**
  * @param {Request | Request<{ Payload: FormEditorInputQuestionDetails } >} request
@@ -19,7 +19,38 @@ export function redirectWithErrors(request, h, error, errorKey, anchor = '') {
 }
 
 /**
+ * @param { Request | Request<{ Payload: FormEditorInputQuestionDetails }> } request
+ * @param {ResponseToolkit | ResponseToolkit<{ Payload: FormEditorInputQuestionDetails }> } h
+ * @param {Boom.Boom} boomError
+ * @param {ValidationSessionKey} errorKey
+ * @param {string} fieldName
+ * @param {string} [anchor]
+ */
+export function redirectWithBoomError(
+  request,
+  h,
+  boomError,
+  errorKey,
+  fieldName,
+  anchor
+) {
+  const error = mapBoomError(errorKey, boomError, fieldName)
+
+  request.yar.flash(errorKey, {
+    formErrors: error,
+    formValues: request.payload
+  })
+
+  const { pathname: redirectTo } = request.url
+  return h
+    .redirect(`${redirectTo}${anchor}`)
+    .code(StatusCodes.SEE_OTHER)
+    .takeover()
+}
+
+/**
  * @import { FormEditorInputQuestionDetails } from '@defra/forms-model'
+ * @import Boom from '@hapi/boom'
  * @import { Request, ResponseToolkit } from '@hapi/hapi'
  * @import { ValidationSessionKey } from '@hapi/yar'
  */

--- a/designer/server/src/routes/forms/editor-v2/question-details.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.js
@@ -9,10 +9,7 @@ import {
   addQuestion,
   updateQuestion
 } from '~/src/lib/editor.js'
-import {
-  checkBoomError,
-  questionsBoomSchema
-} from '~/src/lib/error-boom-helper.js'
+import { checkBoomError } from '~/src/lib/error-boom-helper.js'
 import { getValidationErrorsFromSession } from '~/src/lib/error-helper.js'
 import * as forms from '~/src/lib/forms.js'
 import { buildListFromDetails, upsertList } from '~/src/lib/list.js'
@@ -332,10 +329,7 @@ export default [
           .redirect(editorv2Path(slug, `page/${finalPageId}/questions`))
           .code(StatusCodes.SEE_OTHER)
       } catch (err) {
-        const error = checkBoomError(
-          /** @type {Boom.Boom} */ (err),
-          questionsBoomSchema
-        )
+        const error = checkBoomError(/** @type {Boom.Boom} */ (err), errorKey)
         if (error) {
           return redirectWithErrors(request, h, error, errorKey, '#')
         }

--- a/designer/server/src/routes/forms/editor-v2/question-details.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.test.js
@@ -30,6 +30,7 @@ import {
   createQuestionSessionState,
   getQuestionSessionState
 } from '~/src/lib/session-helper.js'
+import { handleEnhancedActionOnGet } from '~/src/routes/forms/editor-v2/question-details-helper.js'
 import { auth } from '~/test/fixtures/auth.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
@@ -344,6 +345,29 @@ describe('Editor v2 question details routes', () => {
     )
     expect(/** @type {HTMLInputElement} */ (autoCompleteField).value).toMatch(
       'Northern Ireland:northern-ireland'
+    )
+  })
+
+  test('GET - should redirect if enhanced action supplied', async () => {
+    jest.mocked(getQuestionSessionState).mockReturnValue(simpleSessionTextField)
+    jest
+      .mocked(buildQuestionSessionState)
+      .mockReturnValue(simpleSessionRadiosField)
+    jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+    jest.mocked(handleEnhancedActionOnGet).mockReturnValueOnce('#new-anchor')
+    const options = {
+      method: 'get',
+      url: '/library/my-form-slug/editor-v2/page/new/question/new/details/newSessId?action=delete&id=123',
+      auth
+    }
+
+    const {
+      response: { headers, statusCode }
+    } = await renderResponse(server, options)
+
+    expect(statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(headers.location).toBe(
+      '/library/my-form-slug/editor-v2/page/new/question/new/details/newSessId#new-anchor'
     )
   })
 

--- a/designer/server/src/routes/forms/editor-v2/question-details.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.test.js
@@ -13,7 +13,12 @@ import {
 } from '~/src/__stubs__/form-definition.js'
 import { testFormMetadata } from '~/src/__stubs__/form-metadata.js'
 import { createServer } from '~/src/createServer.js'
-import { addPageAndFirstQuestion, addQuestion } from '~/src/lib/editor.js'
+import { buildBoom409 } from '~/src/lib/__stubs__/editor.js'
+import {
+  addPageAndFirstQuestion,
+  addQuestion,
+  updateQuestion
+} from '~/src/lib/editor.js'
 import {
   addErrorsToSession,
   getValidationErrorsFromSession
@@ -477,6 +482,113 @@ describe('Editor v2 question details routes', () => {
       ),
       'questionDetailsValidationFailure'
     )
+  })
+
+  test('POST - should error if boom error from API', async () => {
+    jest.mocked(getQuestionSessionState).mockReturnValue(simpleSessionTextField)
+    jest
+      .mocked(buildQuestionSessionState)
+      .mockReturnValue(simpleSessionTextField)
+    jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+    jest.mocked(updateQuestion).mockImplementationOnce(() => {
+      throw buildBoom409('Duplicate page path')
+    })
+
+    const options = {
+      method: 'post',
+      url: '/library/my-form-slug/editor-v2/page/1/question/1/details',
+      auth,
+      payload: {
+        name: '12345',
+        question: 'Question text',
+        shortDescription: 'Short desc',
+        questionType: 'TextField'
+      }
+    }
+
+    const {
+      response: { headers, statusCode }
+    } = await renderResponse(server, options)
+
+    expect(statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(headers.location).toBe(
+      '/library/my-form-slug/editor-v2/page/1/question/1/details#'
+    )
+    expect(addErrorsToSession).toHaveBeenCalledWith(
+      expect.anything(),
+      new Joi.ValidationError(
+        'This question or page title already exists - use a unique question or page title',
+        [],
+        undefined
+      ),
+      'questionDetailsValidationFailure'
+    )
+  })
+
+  test('POST - should error if boom error from API even if not in error message lookups', async () => {
+    jest.mocked(getQuestionSessionState).mockReturnValue(simpleSessionTextField)
+    jest
+      .mocked(buildQuestionSessionState)
+      .mockReturnValue(simpleSessionTextField)
+    jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+    jest.mocked(updateQuestion).mockImplementationOnce(() => {
+      throw buildBoom409('Some other boom error')
+    })
+
+    const options = {
+      method: 'post',
+      url: '/library/my-form-slug/editor-v2/page/1/question/1/details',
+      auth,
+      payload: {
+        name: '12345',
+        question: 'Question text',
+        shortDescription: 'Short desc',
+        questionType: 'TextField'
+      }
+    }
+
+    const {
+      response: { headers, statusCode }
+    } = await renderResponse(server, options)
+
+    expect(statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(headers.location).toBe(
+      '/library/my-form-slug/editor-v2/page/1/question/1/details#'
+    )
+    expect(addErrorsToSession).toHaveBeenCalledWith(
+      expect.anything(),
+      new Joi.ValidationError('Some other boom error', [], undefined),
+      'questionDetailsValidationFailure'
+    )
+  })
+
+  test('POST - should error if not 409 boom error from API', async () => {
+    jest.mocked(getQuestionSessionState).mockReturnValue(simpleSessionTextField)
+    jest
+      .mocked(buildQuestionSessionState)
+      .mockReturnValue(simpleSessionTextField)
+    jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+    jest.mocked(updateQuestion).mockImplementationOnce(() => {
+      throw new Error('Some other API error')
+    })
+
+    const options = {
+      method: 'post',
+      url: '/library/my-form-slug/editor-v2/page/1/question/1/details',
+      auth,
+      payload: {
+        name: '12345',
+        question: 'Question text',
+        shortDescription: 'Short desc',
+        questionType: 'TextField'
+      }
+    }
+
+    const {
+      response: { statusCode }
+    } = await renderResponse(server, options)
+
+    expect(statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
   })
 
   test('POST - should redirect to next page if valid payload with new question', async () => {

--- a/designer/server/src/routes/forms/editor-v2/questions.js
+++ b/designer/server/src/routes/forms/editor-v2/questions.js
@@ -9,7 +9,7 @@ import Joi from 'joi'
 import * as scopes from '~/src/common/constants/scopes.js'
 import { sessionNames } from '~/src/common/constants/session-names.js'
 import { setPageHeadingAndGuidance } from '~/src/lib/editor.js'
-import { checkBoomError, pageBoomSchema } from '~/src/lib/error-boom-helper.js'
+import { checkBoomError } from '~/src/lib/error-boom-helper.js'
 import { getValidationErrorsFromSession } from '~/src/lib/error-helper.js'
 import * as forms from '~/src/lib/forms.js'
 import { redirectWithErrors } from '~/src/lib/redirect-helper.js'
@@ -115,10 +115,7 @@ export default [
           .redirect(editorv2Path(slug, `page/${pageId}/questions`))
           .code(StatusCodes.SEE_OTHER)
       } catch (err) {
-        const error = checkBoomError(
-          /** @type {Boom.Boom} */ (err),
-          pageBoomSchema
-        )
+        const error = checkBoomError(/** @type {Boom.Boom} */ (err), errorKey)
         if (error) {
           return redirectWithErrors(request, h, error, errorKey, '#')
         }

--- a/designer/server/src/routes/forms/editor-v2/questions.test.js
+++ b/designer/server/src/routes/forms/editor-v2/questions.test.js
@@ -22,6 +22,7 @@ jest.mock('~/src/lib/forms.js')
  * @param {string} message
  */
 function buildBoom409(message) {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return Boom.boomify(new Error(message), {
     statusCode: 409,
     data: { message, statusCode: 409 }

--- a/model/src/common/enums.ts
+++ b/model/src/common/enums.ts
@@ -2,3 +2,9 @@ export enum FormStatus {
   Draft = 'draft',
   Live = 'live'
 }
+
+export enum ApiErrorFunctionCode {
+  General = 'General',
+  DuplicatePagePathPage = 'DuplicatePagePathPage',
+  DuplicatePagePathQuestion = 'DuplicatePagePathQuestion'
+}

--- a/model/src/pages/enums.ts
+++ b/model/src/pages/enums.ts
@@ -13,9 +13,3 @@ export enum ControllerType {
   Summary = 'SummaryPageController',
   Status = 'StatusPageController'
 }
-
-export enum ApiErrorFunctionCode {
-  General = 'General',
-  DuplicatePagePathPage = 'DuplicatePagePathPage',
-  DuplicatePagePathQuestion = 'DuplicatePagePathQuestion'
-}

--- a/model/src/pages/enums.ts
+++ b/model/src/pages/enums.ts
@@ -13,3 +13,9 @@ export enum ControllerType {
   Summary = 'SummaryPageController',
   Status = 'StatusPageController'
 }
+
+export enum ApiErrorFunctionCode {
+  General = 'General',
+  DuplicatePagePathPage = 'DuplicatePagePathPage',
+  DuplicatePagePathQuestion = 'DuplicatePagePathQuestion'
+}


### PR DESCRIPTION
Handles 409 errors from forms-manager

NOTE - TODO - rather than relying on part of the forms-manager error message being a particular string, in a new PR, I will implement something like a FUNCTION_CODE being returned in the error (in addition to the message text) so the designer can match against FUNCTION_CODEs. I have added ApiErrorFunctionCode enum in the model in preparation for this.

As part of this PR, I identified that the forms-manager is not throwing a 409 when the page title is UPDATED to a duplicate - only when a new page is being added that creates a duplicate page path. This will be tackled in the a new PR.