### PR TITLE
Reverted to 'add-item' being a submit button

### DIFF
--- a/designer/server/src/routes/forms/editor-v2/question-details-extra.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-extra.test.js
@@ -14,10 +14,6 @@ jest.mock('~/src/lib/error-helper.js')
 jest.mock('~/src/lib/editor.js')
 jest.mock('~/src/lib/session-helper.js')
 
-const simpleSessionRadiosField = {
-  questionType: ComponentType.RadiosField
-}
-
 describe('Editor v2 question details routes', () => {
   /** @type {Server} */
   let server
@@ -53,19 +49,27 @@ describe('Editor v2 question details routes', () => {
     expect(headers.location?.endsWith('#list-items')).toBeFalsy()
   })
 
-  test('GET - should redirect when enhanced action is add-item', async () => {
+  test('POST - should redirect to GET if enhanced action', async () => {
+    jest
+      .mocked(getQuestionSessionState)
+      .mockReturnValue({ questionType: ComponentType.RadiosField, editRow: {} })
+
     jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
     jest
       .mocked(forms.getDraftFormDefinition)
       .mockResolvedValueOnce(testFormDefinitionWithSinglePage)
-    jest
-      .mocked(getQuestionSessionState)
-      .mockReturnValue(simpleSessionRadiosField)
 
     const options = {
-      method: 'get',
-      url: '/library/my-form-slug/editor-v2/page/p1/question/c1/details/sessId?action=add-item',
-      auth
+      method: 'post',
+      url: '/library/my-form-slug/editor-v2/page/123456/question/456/details/sessId',
+      auth,
+      payload: {
+        enhancedAction: 'add-item',
+        name: '456',
+        question: 'Question text',
+        shortDescription: 'Short desc',
+        questionType: 'RadiosField'
+      }
     }
 
     const {
@@ -74,32 +78,7 @@ describe('Editor v2 question details routes', () => {
 
     expect(statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(headers.location).toBe(
-      '/library/my-form-slug/editor-v2/page/p1/question/c1/details/sessId#add-option'
-    )
-  })
-
-  test('GET - should redirect when enhanced action is re-order', async () => {
-    jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
-    jest
-      .mocked(forms.getDraftFormDefinition)
-      .mockResolvedValueOnce(testFormDefinitionWithSinglePage)
-    jest
-      .mocked(getQuestionSessionState)
-      .mockReturnValue(simpleSessionRadiosField)
-
-    const options = {
-      method: 'get',
-      url: '/library/my-form-slug/editor-v2/page/p1/question/c1/details/sessId?action=re-order',
-      auth
-    }
-
-    const {
-      response: { headers, statusCode }
-    } = await renderResponse(server, options)
-
-    expect(statusCode).toBe(StatusCodes.SEE_OTHER)
-    expect(headers.location).toBe(
-      '/library/my-form-slug/editor-v2/page/p1/question/c1/details/sessId#list-items'
+      '/library/my-form-slug/editor-v2/page/123456/question/456/details/sessId#add-option'
     )
   })
 })

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.js
@@ -49,20 +49,6 @@ export function handleEnhancedActionOnGet(yar, stateId, query) {
     throw new Error('Invalid session contents')
   }
 
-  if (action === 'add-item') {
-    setQuestionSessionState(yar, stateId, {
-      ...state,
-      editRow: {
-        expanded: true
-      }
-    })
-    return '#add-option'
-  }
-
-  if (action === 're-order') {
-    return radiosSectionListItemsAnchor
-  }
-
   if (action === 'delete') {
     const newList = state.listItems?.filter((x) => x.id !== id)
     setQuestionSessionState(yar, stateId, {
@@ -180,6 +166,17 @@ export function handleEnhancedActionOnPost(request, stateId, questionDetails) {
     },
     listItems: preState.listItems ?? []
   })
+
+  if (enhancedAction === 'add-item') {
+    setQuestionSessionState(yar, stateId, state)
+    return '#add-option'
+  }
+
+  if (enhancedAction === 're-order') {
+    setQuestionSessionState(yar, stateId, state)
+    return radiosSectionListItemsAnchor
+  }
+
   if (enhancedAction === 'save-item') {
     return handleSaveItem(request, state, stateId)
   }

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
@@ -215,6 +215,50 @@ describe('Editor v2 question-details route helper', () => {
       )
     })
 
+    test('add-item should add item', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+        enhancedAction: 'add-item',
+        radioId: '5',
+        radioText: 'text5',
+        radioHint: 'hint5',
+        radioValue: 'value5'
+      })
+
+      const { mockRequest } = buildMockRequest(payload)
+
+      expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
+        '#add-option'
+      )
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        listItems: listWithThreeItems.listItems,
+        editRow: {
+          radioId: '5',
+          radioText: 'text5',
+          radioHint: 'hint5',
+          radioValue: 'value5',
+          expanded: true
+        },
+        questionDetails: {}
+      })
+    })
+
+    test('re-order should do nothing until implemented', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+        enhancedAction: 're-order'
+      })
+
+      const { mockRequest } = buildMockRequest(payload)
+
+      expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
+        '#list-items'
+      )
+    })
+
     describe('save-item', () => {
       test('should handle simple no list items', () => {
         mockGet.mockReturnValue(structuredClone(simpleSession))

--- a/designer/server/src/routes/forms/editor-v2/question-details.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.js
@@ -42,7 +42,7 @@ const schema = baseSchema.concat(allSpecificSchemas)
 
 const preSchema = Joi.object()
   .keys({
-    listItemCount: questionDetailsFullSchema.listItemCountSchema.when(
+    'list-items': questionDetailsFullSchema.listItemCountSchema.when(
       'questionType',
       {
         is: Joi.string().valid('CheckboxesField', 'RadiosField'),
@@ -127,7 +127,7 @@ export function validatePreSchema(request, h) {
 
   const { error } = preSchema.validate({
     ...payload,
-    listItemCount: state?.listItems?.length ?? 0
+    'list-items': state?.listItems?.length ?? 0
   })
 
   if (error) {

--- a/designer/server/src/views/forms/editor-v2/custom-templates/radios-or-checkboxes.njk
+++ b/designer/server/src/views/forms/editor-v2/custom-templates/radios-or-checkboxes.njk
@@ -70,14 +70,14 @@
 {% if not state.editRow.expanded %}
 <div class="govuk-button-group">
   <!-- Add Another Option Button -->
-  <a href="?action=add-item" id="add-option-button" class="govuk-button govuk-!-margin-bottom-4 govuk-!-margin-bottom-6">
+  <button id="add-option-button" type="submit" class="govuk-button govuk-!-margin-bottom-4 govuk-!-margin-bottom-6" name="enhancedAction" value="add-item">
     Add item
-  </a>
+  </button>
 
   {% if (state.listItems | length > 1) %}
-  <a href="?action=re-order" id="edit-options-button" class="govuk-button govuk-button--inverse">
+  <button id="edit-options-button" type="submit" class="govuk-button govuk-button--inverse" name="enhancedAction" value="re-order">
     Re-order
-  </a>
+  </button>
   {% endif %}
 </div>
 {% endif %}


### PR DESCRIPTION
A previous fix which converted 'Add item' and 'Re-order' buttons to hrefs (styled as buttons) to prevent 'enter' key causing triggering of 'Add item' instead of 'Save and continue' has caused an issue.
The question title and short description were no longer being saved in state because the operation was now a GET and not.a POST.
Have reverted so state is saved, but may perhaps revisit how we deal with a user hitting 'enter' when there are more than one default button on the page.