### PR TITLE
Redirect the user to the new URL if they're using the old one

### DIFF
--- a/designer/server/jest.setup.cjs
+++ b/designer/server/jest.setup.cjs
@@ -1,6 +1,8 @@
+import { hostname } from 'node:os'
+
 const { Duration } = require('luxon')
 
-process.env.APP_BASE_URL = 'http://localhost:3000'
+process.env.APP_BASE_URL = `http://${hostname()}:3000`
 process.env.AZURE_CLIENT_ID = 'dummy'
 process.env.AZURE_CLIENT_SECRET = 'dummy'
 process.env.MANAGER_URL = 'http://localhost:3001'

--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -106,9 +106,11 @@ export async function createServer() {
 
     // if the user is accessing the old URL
     if (requestDomain !== baseDomain) {
-      const redirectUrl = new URL(request.url, baseDomain).toString()
+      // create a new URL from the original as that includes the port, then override the hostname only
+      const redirectUrl = new URL(request.url)
+      redirectUrl.hostname = baseDomain
 
-      return h.redirect(redirectUrl).permanent().takeover()
+      return h.redirect(redirectUrl.toString()).permanent().takeover()
     }
 
     return h.continue

--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -106,11 +106,9 @@ export async function createServer() {
 
     // if the user is accessing the old URL
     if (requestDomain !== baseDomain) {
-      // create a new URL from the original as that includes the port, then override the hostname only
-      const redirectUrl = new URL(request.url)
-      redirectUrl.hostname = baseDomain
+      const redirectUrl = new URL(request.url, baseDomain).toString()
 
-      return h.redirect(redirectUrl.toString()).permanent().takeover()
+      return h.redirect(redirectUrl).permanent().takeover()
     }
 
     return h.continue

--- a/designer/server/src/createServer.ts
+++ b/designer/server/src/createServer.ts
@@ -110,7 +110,7 @@ export async function createServer() {
       const redirectUrl = new URL(request.url)
       redirectUrl.hostname = baseDomain
 
-      return h.redirect(redirectUrl.toString()).takeover().permanent()
+      return h.redirect(redirectUrl.toString()).permanent().takeover()
     }
 
     return h.continue

--- a/designer/server/src/routes/account/sign-out.test.js
+++ b/designer/server/src/routes/account/sign-out.test.js
@@ -1,3 +1,5 @@
+import { hostname } from 'node:os'
+
 import { StatusCodes } from 'http-status-codes'
 
 import { hasUser } from '~/src/common/helpers/auth/get-user-session.js'
@@ -73,7 +75,7 @@ describe('signOutRoute', () => {
 
     expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(response.headers.location).toBe(
-      `${wellKnownConfiguration.end_session_endpoint}?post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Faccount%2Fsigned-out&logout_hint=bar` // foo is from the query params
+      `${wellKnownConfiguration.end_session_endpoint}?post_logout_redirect_uri=http%3A%2F%2F${hostname()}%3A3000%2Faccount%2Fsigned-out&logout_hint=bar` // foo is from the query params
     )
   })
 
@@ -90,7 +92,7 @@ describe('signOutRoute', () => {
 
     expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(response.headers.location).toBe(
-      `${wellKnownConfiguration.end_session_endpoint}?post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Faccount%2Fsigned-out&logout_hint=foo` // bar is from the credentials
+      `${wellKnownConfiguration.end_session_endpoint}?post_logout_redirect_uri=http%3A%2F%2F${hostname()}%3A3000%2Faccount%2Fsigned-out&logout_hint=foo` // bar is from the credentials
     )
   })
 })


### PR DESCRIPTION
To support the new URL, redirect the users to it if they load the old URL.