### PR TITLE
Allow users to delete contact information

### DIFF
--- a/designer/server/src/models/forms/contact/email.js
+++ b/designer/server/src/models/forms/contact/email.js
@@ -40,8 +40,21 @@ export function emailViewModel(metadata, validation) {
         value: formValues?.responseTime ?? metadata.contact?.email?.responseTime
       }
     },
-    buttonText: 'Save and continue'
+    buttonText: 'Save and continue',
+    allowDelete: allowDelete(metadata)
   }
+}
+
+/**
+ * @param {FormMetadata} metadata
+ */
+export function allowDelete(metadata) {
+  const isLive = !!metadata.live
+  const hasPhone = !!metadata.contact?.phone
+  const hasEmail = !!metadata.contact?.email
+  const hasOnline = !!metadata.contact?.online
+
+  return hasEmail && (!isLive || hasPhone || hasOnline)
 }
 
 /**

--- a/designer/server/src/models/forms/contact/online.js
+++ b/designer/server/src/models/forms/contact/online.js
@@ -40,8 +40,21 @@ export function onlineViewModel(metadata, validation) {
         value: formValues?.text ?? metadata.contact?.online?.text
       }
     },
-    buttonText: 'Save and continue'
+    buttonText: 'Save and continue',
+    allowDelete: allowDelete(metadata)
   }
+}
+
+/**
+ * @param {FormMetadata} metadata
+ */
+export function allowDelete(metadata) {
+  const isLive = !!metadata.live
+  const hasPhone = !!metadata.contact?.phone
+  const hasEmail = !!metadata.contact?.email
+  const hasOnline = !!metadata.contact?.online
+
+  return hasOnline && (!isLive || hasPhone || hasEmail)
 }
 
 /**

--- a/designer/server/src/models/forms/contact/phone.js
+++ b/designer/server/src/models/forms/contact/phone.js
@@ -24,8 +24,21 @@ export function phoneViewModel(metadata, validation) {
       },
       value: formValues?.phone ?? metadata.contact?.phone
     },
-    buttonText: 'Save and continue'
+    buttonText: 'Save and continue',
+    allowDelete: allowDelete(metadata)
   }
+}
+
+/**
+ * @param {FormMetadata} metadata
+ */
+export function allowDelete(metadata) {
+  const isLive = !!metadata.live
+  const hasPhone = !!metadata.contact?.phone
+  const hasEmail = !!metadata.contact?.email
+  const hasOnline = !!metadata.contact?.online
+
+  return hasPhone && (!isLive || hasEmail || hasOnline)
 }
 
 /**

--- a/designer/server/src/routes/forms/contact/email.js
+++ b/designer/server/src/routes/forms/contact/email.js
@@ -16,14 +16,20 @@ export const ROUTE_PATH_EDIT_EMAIL_CONTACT =
   '/library/{slug}/edit/contact/email'
 
 export const emailContactSchema = Joi.object().keys({
-  address: emailAddressSchema.required().messages({
-    'string.empty': 'Enter an email address for dedicated support',
-    'string.email':
-      'Enter an email address for dedicated support in the correct format'
-  }),
-  responseTime: emailResponseTimeSchema.required().messages({
-    'string.empty': 'Enter a response time for receiving responses'
-  }),
+  address: emailAddressSchema
+    .required()
+    .when('_delete', { is: true, then: Joi.allow('') })
+    .messages({
+      'string.empty': 'Enter an email address for dedicated support',
+      'string.email':
+        'Enter an email address for dedicated support in the correct format'
+    }),
+  responseTime: emailResponseTimeSchema
+    .required()
+    .when('_delete', { is: true, then: Joi.allow('') })
+    .messages({
+      'string.empty': 'Enter a response time for receiving responses'
+    }),
   _delete: Joi.boolean()
 })
 

--- a/designer/server/src/routes/forms/contact/email.test.js
+++ b/designer/server/src/routes/forms/contact/email.test.js
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/createServer.js'
 import * as forms from '~/src/lib/forms.js'
+import { allowDelete } from '~/src/models/forms/contact/email.js'
 import { auth } from '~/test/fixtures/auth.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
@@ -152,6 +153,83 @@ describe('Forms contact email', () => {
 
     expect(statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(headers.location).toBe('/library/my-form-slug')
+  })
+
+  test('Allow delete', () => {
+    // Allow users to delete the email contact if:
+    // - the form is not live OR
+    // - the form is live but there's at least 1 other contact
+
+    const phone = '123'
+    const online = {
+      url: 'https://www.gov.uk/guidance/contact-defra',
+      text: 'Online contact form'
+    }
+
+    expect(allowDelete(formMetadata)).toBe(true)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        contact: {
+          ...formMetadata.contact,
+          phone
+        }
+      })
+    ).toBe(true)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        contact: {
+          ...formMetadata.contact,
+          online
+        }
+      })
+    ).toBe(true)
+
+    const live = {
+      createdAt: now,
+      createdBy: author,
+      updatedAt: now,
+      updatedBy: author
+    }
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        live
+      })
+    ).toBe(false)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        live
+      })
+    ).toBe(false)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        live,
+        contact: {
+          ...formMetadata.contact,
+          phone
+        }
+      })
+    ).toBe(true)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        live,
+        contact: {
+          ...formMetadata.contact,
+          online
+        }
+      })
+    ).toBe(true)
   })
 })
 

--- a/designer/server/src/routes/forms/contact/email.test.js
+++ b/designer/server/src/routes/forms/contact/email.test.js
@@ -119,6 +119,40 @@ describe('Forms contact email', () => {
     expect(statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(headers.location).toBe('/library/my-form-slug')
   })
+
+  test('POST - should redirect to overview page after removing email details', async () => {
+    jest.mocked(forms.get).mockResolvedValueOnce({
+      ...formMetadata,
+      contact: {
+        ...formMetadata.contact,
+        phone: '123'
+      }
+    })
+
+    jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
+      id: formMetadata.id,
+      slug: 'my-form-slug',
+      status: 'updated'
+    })
+
+    const options = {
+      method: 'post',
+      url: '/library/my-form-slug/edit/contact/email',
+      auth,
+      payload: {
+        address: emailAddress,
+        responseTime: responseTimeText,
+        _delete: true
+      }
+    }
+
+    const {
+      response: { headers, statusCode }
+    } = await renderResponse(server, options)
+
+    expect(statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(headers.location).toBe('/library/my-form-slug')
+  })
 })
 
 /**

--- a/designer/server/src/routes/forms/contact/email.test.js
+++ b/designer/server/src/routes/forms/contact/email.test.js
@@ -94,7 +94,7 @@ describe('Forms contact email', () => {
     expect($responseTime).toHaveValue(responseTimeText)
   })
 
-  test('POST - should redirect to overviewpage after updating email details', async () => {
+  test('POST - should redirect to overview page after updating email details', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
     jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
       id: formMetadata.id,

--- a/designer/server/src/routes/forms/contact/online.js
+++ b/designer/server/src/routes/forms/contact/online.js
@@ -16,15 +16,21 @@ export const ROUTE_PATH_EDIT_ONLINE_CONTACT =
   '/library/{slug}/edit/contact/online'
 
 export const onlineContactSchema = Joi.object().keys({
-  url: onlineUrlSchema.required().messages({
-    'string.empty': 'Enter a contact link for support',
-    'string.uri': 'Enter a contact link for support in the correct format',
-    'string.uriCustomScheme':
-      'Enter a contact link for support in the correct format'
-  }),
-  text: onlineTextSchema.required().messages({
-    'string.empty': 'Enter text to describe the contact link for support'
-  }),
+  url: onlineUrlSchema
+    .required()
+    .when('_delete', { is: true, then: Joi.allow('') })
+    .messages({
+      'string.empty': 'Enter a contact link for support',
+      'string.uri': 'Enter a contact link for support in the correct format',
+      'string.uriCustomScheme':
+        'Enter a contact link for support in the correct format'
+    }),
+  text: onlineTextSchema
+    .required()
+    .when('_delete', { is: true, then: Joi.allow('') })
+    .messages({
+      'string.empty': 'Enter text to describe the contact link for support'
+    }),
   _delete: Joi.boolean()
 })
 

--- a/designer/server/src/routes/forms/contact/online.test.js
+++ b/designer/server/src/routes/forms/contact/online.test.js
@@ -115,6 +115,43 @@ describe('Forms contact online', () => {
     expect(statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(headers.location).toBe('/library/my-form-slug')
   })
+
+  test('POST - should redirect to overview page after removing online details', async () => {
+    jest.mocked(forms.get).mockResolvedValueOnce({
+      ...formMetadata,
+      contact: {
+        ...formMetadata.contact,
+        email: {
+          address: 'support@defra.gov.uk',
+          responseTime: 'We aim to respond within 2 working days'
+        }
+      }
+    })
+
+    jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
+      id: formMetadata.id,
+      slug: 'my-form-slug',
+      status: 'updated'
+    })
+
+    const options = {
+      method: 'post',
+      url: '/library/my-form-slug/edit/contact/online',
+      auth,
+      payload: {
+        url: 'https://www.gov.uk/guidance/contact-defra',
+        text: 'Online contact form',
+        _delete: true
+      }
+    }
+
+    const {
+      response: { headers, statusCode }
+    } = await renderResponse(server, options)
+
+    expect(statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(headers.location).toBe('/library/my-form-slug')
+  })
 })
 
 /**

--- a/designer/server/src/routes/forms/contact/online.test.js
+++ b/designer/server/src/routes/forms/contact/online.test.js
@@ -90,7 +90,7 @@ describe('Forms contact online', () => {
     expect($text).toHaveValue('Online contact form')
   })
 
-  test('POST - should redirect to overviewpage after updating online details', async () => {
+  test('POST - should redirect to overview page after updating online details', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
     jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
       id: formMetadata.id,

--- a/designer/server/src/routes/forms/contact/phone.js
+++ b/designer/server/src/routes/forms/contact/phone.js
@@ -16,9 +16,13 @@ export const ROUTE_PATH_EDIT_PHONE_CONTACT =
   '/library/{slug}/edit/contact/phone'
 
 export const phoneContactSchema = Joi.object().keys({
-  phone: phoneSchema.required().messages({
-    'string.empty': 'Enter phone number and opening times for users to get help'
-  }),
+  phone: phoneSchema
+    .required()
+    .when('_delete', { is: true, then: Joi.allow('') })
+    .messages({
+      'string.empty':
+        'Enter phone number and opening times for users to get help'
+    }),
   _delete: Joi.boolean()
 })
 

--- a/designer/server/src/routes/forms/contact/phone.test.js
+++ b/designer/server/src/routes/forms/contact/phone.test.js
@@ -79,7 +79,7 @@ describe('Forms contact phone', () => {
     expect($phone).toHaveValue('123')
   })
 
-  test('POST - should redirect to overviewpage after updating phone details', async () => {
+  test('POST - should redirect to overview page after updating phone details', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
     jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
       id: formMetadata.id,

--- a/designer/server/src/routes/forms/contact/phone.test.js
+++ b/designer/server/src/routes/forms/contact/phone.test.js
@@ -101,6 +101,39 @@ describe('Forms contact phone', () => {
     expect(statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(headers.location).toBe('/library/my-form-slug')
   })
+
+  test('POST - should redirect to overview page after removing phone details', async () => {
+    jest.mocked(forms.get).mockResolvedValueOnce({
+      ...formMetadata,
+      contact: {
+        ...formMetadata.contact,
+        email: {
+          address: 'support@defra.gov.uk',
+          responseTime: 'We aim to respond within 2 working days'
+        }
+      }
+    })
+
+    jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
+      id: formMetadata.id,
+      slug: 'my-form-slug',
+      status: 'updated'
+    })
+
+    const options = {
+      method: 'post',
+      url: '/library/my-form-slug/edit/contact/phone',
+      auth,
+      payload: { phone: '1234', _delete: true }
+    }
+
+    const {
+      response: { headers, statusCode }
+    } = await renderResponse(server, options)
+
+    expect(statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(headers.location).toBe('/library/my-form-slug')
+  })
 })
 
 /**

--- a/designer/server/src/routes/forms/contact/phone.test.js
+++ b/designer/server/src/routes/forms/contact/phone.test.js
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/createServer.js'
 import * as forms from '~/src/lib/forms.js'
+import { allowDelete } from '~/src/models/forms/contact/phone.js'
 import { auth } from '~/test/fixtures/auth.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
@@ -133,6 +134,86 @@ describe('Forms contact phone', () => {
 
     expect(statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(headers.location).toBe('/library/my-form-slug')
+  })
+
+  test('Allow delete', () => {
+    // Allow users to delete the phone contact if:
+    // - the form is not live OR
+    // - the form is live but there's at least 1 other contact
+
+    const email = {
+      address: 'support@defra.gov.uk',
+      responseTime: 'We aim to respond within 2 working days'
+    }
+    const online = {
+      url: 'https://www.gov.uk/guidance/contact-defra',
+      text: 'Online contact form'
+    }
+
+    expect(allowDelete(formMetadata)).toBe(true)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        contact: {
+          ...formMetadata.contact,
+          email
+        }
+      })
+    ).toBe(true)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        contact: {
+          ...formMetadata.contact,
+          online
+        }
+      })
+    ).toBe(true)
+
+    const live = {
+      createdAt: now,
+      createdBy: author,
+      updatedAt: now,
+      updatedBy: author
+    }
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        live
+      })
+    ).toBe(false)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        live
+      })
+    ).toBe(false)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        live,
+        contact: {
+          ...formMetadata.contact,
+          email
+        }
+      })
+    ).toBe(true)
+
+    expect(
+      allowDelete({
+        ...formMetadata,
+        live,
+        contact: {
+          ...formMetadata.contact,
+          online
+        }
+      })
+    ).toBe(true)
   })
 })
 

--- a/designer/server/src/routes/forms/edit.test.js
+++ b/designer/server/src/routes/forms/edit.test.js
@@ -85,7 +85,7 @@ describe('Forms library routes', () => {
     expect($teamEmail).toHaveValue('defraforms@defra.gov.uk')
   })
 
-  test('POST - should redirect to overviewpage after updating team details', async () => {
+  test('POST - should redirect to overview page after updating team details', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
     jest
       .mocked(forms.getDraftFormDefinition)
@@ -127,7 +127,7 @@ describe('Forms library routes', () => {
     expect($title).toHaveValue('Test form')
   })
 
-  test('POST - should redirect to overviewpage after updating title', async () => {
+  test('POST - should redirect to overview page after updating title', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
     jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
       id: formMetadata.id,

--- a/designer/server/src/routes/forms/privacy-notice.test.js
+++ b/designer/server/src/routes/forms/privacy-notice.test.js
@@ -80,7 +80,7 @@ describe('Forms privacy notice', () => {
     )
   })
 
-  test('POST - should redirect to overviewpage after updating privacy notice url', async () => {
+  test('POST - should redirect to overview page after updating privacy notice url', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
     jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
       id: formMetadata.id,

--- a/designer/server/src/routes/forms/submission-guidance.test.js
+++ b/designer/server/src/routes/forms/submission-guidance.test.js
@@ -79,7 +79,7 @@ describe('Forms submission guidance', () => {
     )
   })
 
-  test('POST - should redirect to overviewpage after updating submission guidance', async () => {
+  test('POST - should redirect to overview page after updating submission guidance', async () => {
     jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
     jest.mocked(forms.updateMetadata).mockResolvedValueOnce({
       id: formMetadata.id,

--- a/designer/server/src/views/forms/contact/email.njk
+++ b/designer/server/src/views/forms/contact/email.njk
@@ -58,6 +58,15 @@
           href: backLink.href,
           classes: "govuk-button--secondary"
         }) }}
+
+        {% if allowDelete %}
+          {{ govukButton({
+            text: "Delete",
+            classes: "govuk-button--warning",
+            name: "_delete",
+            value: "true"
+          }) }}
+        {% endif %}
       </div>
     </form>
   {% endcall %}

--- a/designer/server/src/views/forms/contact/online.njk
+++ b/designer/server/src/views/forms/contact/online.njk
@@ -58,6 +58,15 @@
           href: backLink.href,
           classes: "govuk-button--secondary"
         }) }}
+
+        {% if allowDelete %}
+          {{ govukButton({
+            text: "Delete",
+            classes: "govuk-button--warning",
+            name: "_delete",
+            value: "true"
+          }) }}
+        {% endif %}
       </div>
     </form>
   {% endcall %}

--- a/designer/server/src/views/forms/contact/phone.njk
+++ b/designer/server/src/views/forms/contact/phone.njk
@@ -56,6 +56,15 @@
           href: backLink.href,
           classes: "govuk-button--secondary"
         }) }}
+
+        {% if allowDelete %}
+          {{ govukButton({
+            text: "Delete",
+            classes: "govuk-button--warning",
+            name: "_delete",
+            value: "true"
+          }) }}
+        {% endif %}
       </div>
     </form>
   {% endcall %}


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/538542

Adds a delete button to the contact forms when the contact can be deleted.
Contact info can be deleted when the form s not live, or if it is, when there's at least 1 other contact info present out of phone, online and email.

![image](https://github.com/user-attachments/assets/0a76e61c-5a43-4fc2-b7b1-e65ee60220e0)
