### PR TITLE
Feat/532357 preview errors

### DIFF
--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.js
@@ -158,7 +158,7 @@ export const allBaseSettingsFields = {
       classes: GOVUK_LABEL__M
     },
     hint: {
-      text: "Enter a short description for this question like 'licence period'. Short descriptions are used in error messages and on the check your answers page."
+      text: "Enter a short description for this question like 'Licence period'. Short descriptions are used in error messages and on the check your answers page."
     }
   },
   fileTypes: {

--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.test.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.test.js
@@ -55,7 +55,7 @@ describe('editor-v2 - advanced settings fields model', () => {
             classes: GOVUK_LABEL__M
           },
           hint: {
-            text: "Enter a short description for this question like 'licence period'. Short descriptions are used in error messages and on the check your answers page."
+            text: "Enter a short description for this question like 'Licence period'. Short descriptions are used in error messages and on the check your answers page."
           },
           value: undefined
         }
@@ -112,7 +112,7 @@ describe('editor-v2 - advanced settings fields model', () => {
             classes: GOVUK_LABEL__M
           },
           hint: {
-            text: "Enter a short description for this question like 'licence period'. Short descriptions are used in error messages and on the check your answers page."
+            text: "Enter a short description for this question like 'Licence period'. Short descriptions are used in error messages and on the check your answers page."
           },
           value: undefined
         }

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -111,6 +111,13 @@ export function buildPreviewUrl(slug) {
 }
 
 /**
+ * @param {string} slug
+ */
+export function buildPreviewErrorsUrl(slug) {
+  return `${config.previewUrl}/error-preview/draft/${slug}`
+}
+
+/**
  * @param {{ text?: string, value?: string, checked?: boolean }[] | undefined } items
  * @param {string[] | undefined} selectedItems
  */

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -256,6 +256,7 @@ export function questionDetailsViewModel(
     enhancedFields: enhancedFieldList,
     ...baseModelFields(metadata.slug, pageTitle),
     name: questionFields.name || randomId(),
+    questionId,
     basePageFields,
     uploadFields,
     extraFields,

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -222,25 +222,20 @@ export function questionDetailsViewModel(
     questionNum,
     pagePath
   } = getDetails(metadata, definition, pageId, questionId, questionType)
-
   const questionFieldsOverride = /** @type {ComponentDef} */ (
     state?.questionDetails ?? questionFields
   )
-
   const basePageFields = getFieldList(
     /** @type {InputFieldsComponentsDef} */ (questionFieldsOverride),
     questionType,
     validation,
     definition
   )
-
   const uploadFields = getFileUploadFields(questionFieldsOverride, validation)
   const extraFields = /** @type {GovukField[]} */ (
     getExtraFields(questionFieldsOverride, validation)
   )
-
   validation = overrideFormValuesForEnhancedAction(validation, state)
-
   const enhancedFieldList = /** @type {GovukField[]} */ (
     getEnhancedFields(questionFieldsOverride, validation)
   )
@@ -257,10 +252,8 @@ export function questionDetailsViewModel(
     `page/${pageId}/question/${questionId}/type/${stateId}`
   )
 
-  const listDetails = getListDetails(state, questionFieldsOverride)
-
   return {
-    listDetails,
+    listDetails: getListDetails(state, questionFieldsOverride),
     state,
     enhancedFields: enhancedFieldList,
     ...baseModelFields(metadata.slug, pageTitle),

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -248,6 +248,15 @@ export function questionDetailsViewModel(
   const errorList = buildErrorList(validation?.formErrors)
   const previewPageUrl = `${buildPreviewUrl(metadata.slug)}${pagePath}?force`
   const previewErrorsUrl = `${buildPreviewErrorsUrl(metadata.slug)}${pagePath}/${questionFieldsOverride.id}`
+  const deleteUrl = editorv2Path(
+    metadata.slug,
+    `page/${pageId}/delete/${questionId}`
+  )
+  const changeTypeUrl = editorv2Path(
+    metadata.slug,
+    `page/${pageId}/question/${questionId}/type/${stateId}`
+  )
+
   const listDetails = getListDetails(state, questionFieldsOverride)
 
   return {
@@ -271,20 +280,14 @@ export function questionDetailsViewModel(
     questionTypeDesc: QuestionTypeDescriptions.find(
       (x) => x.type === questionFieldsOverride.type
     )?.description,
-    changeTypeUrl: editorv2Path(
-      metadata.slug,
-      `page/${pageId}/question/${questionId}/type/${stateId}`
-    ),
+    changeTypeUrl,
     buttonText: SAVE_AND_CONTINUE,
     previewPageUrl,
     previewErrorsUrl,
+    deleteUrl,
     isOpen: hasDataOrErrorForDisplay(extraFieldNames, errorList, extraFields),
     getFieldType: (/** @type {GovukField} */ field) =>
-      getFieldComponentType(field),
-    deleteUrl: editorv2Path(
-      metadata.slug,
-      `page/${pageId}/delete/${questionId}`
-    )
+      getFieldComponentType(field)
   }
 }
 

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -214,16 +214,17 @@ export function questionDetailsViewModel(
   state
 ) {
   const questionType = state?.questionType
-  const {
-    pageTitle,
-    navigation,
-    question: questionFields,
-    pageNum,
-    questionNum,
-    pagePath
-  } = getDetails(metadata, definition, pageId, questionId, questionType)
+
+  const details = getDetails(
+    metadata,
+    definition,
+    pageId,
+    questionId,
+    questionType
+  )
+
   const questionFieldsOverride = /** @type {ComponentDef} */ (
-    state?.questionDetails ?? questionFields
+    state?.questionDetails ?? details.question
   )
   const basePageFields = getFieldList(
     /** @type {InputFieldsComponentsDef} */ (questionFieldsOverride),
@@ -241,31 +242,26 @@ export function questionDetailsViewModel(
   )
   const extraFieldNames = extraFields.map((field) => field.name ?? 'unknown')
   const errorList = buildErrorList(validation?.formErrors)
-  const previewPageUrl = `${buildPreviewUrl(metadata.slug)}${pagePath}?force`
-  const previewErrorsUrl = `${buildPreviewErrorsUrl(metadata.slug)}${pagePath}/${questionFieldsOverride.id}`
-  const deleteUrl = editorv2Path(
-    metadata.slug,
-    `page/${pageId}/delete/${questionId}`
-  )
-  const changeTypeUrl = editorv2Path(
-    metadata.slug,
-    `page/${pageId}/question/${questionId}/type/${stateId}`
-  )
+  const previewPageUrl = `${buildPreviewUrl(metadata.slug)}${details.pagePath}?force`
+  const previewErrorsUrl = `${buildPreviewErrorsUrl(metadata.slug)}${details.pagePath}/${questionFieldsOverride.id}`
+  const urlPageBase = editorv2Path(metadata.slug, `page/${pageId}`)
+  const deleteUrl = `${urlPageBase}/delete/${questionId}`
+  const changeTypeUrl = `${urlPageBase}/question/${questionId}/type/${stateId}`
 
   return {
     listDetails: getListDetails(state, questionFieldsOverride),
     state,
     enhancedFields: enhancedFieldList,
-    ...baseModelFields(metadata.slug, pageTitle),
-    name: questionFields.name || randomId(),
+    ...baseModelFields(metadata.slug, details.pageTitle),
+    name: details.question.name || randomId(),
     questionId,
     basePageFields,
     uploadFields,
     extraFields,
-    cardTitle: `Question ${questionNum}`,
-    cardCaption: `Page ${pageNum}`,
-    cardHeading: `Edit question ${questionNum}`,
-    navigation,
+    cardTitle: `Question ${details.questionNum}`,
+    cardCaption: `Page ${details.pageNum}`,
+    cardHeading: `Edit question ${details.questionNum}`,
+    navigation: details.navigation,
     errorList,
     formErrors: validation?.formErrors,
     formValues: validation?.formValues,

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -12,6 +12,7 @@ import {
 import {
   SAVE_AND_CONTINUE,
   baseModelFields,
+  buildPreviewErrorsUrl,
   buildPreviewUrl,
   getFormSpecificNavigation,
   getPageNum,
@@ -246,6 +247,7 @@ export function questionDetailsViewModel(
   const extraFieldNames = extraFields.map((field) => field.name ?? 'unknown')
   const errorList = buildErrorList(validation?.formErrors)
   const previewPageUrl = `${buildPreviewUrl(metadata.slug)}${pagePath}?force`
+  const previewErrorsUrl = `${buildPreviewErrorsUrl(metadata.slug)}${pagePath}/${questionFieldsOverride.id}`
   const listDetails = getListDetails(state, questionFieldsOverride)
 
   return {
@@ -274,6 +276,7 @@ export function questionDetailsViewModel(
     ),
     buttonText: SAVE_AND_CONTINUE,
     previewPageUrl,
+    previewErrorsUrl,
     isOpen: hasDataOrErrorForDisplay(extraFieldNames, errorList, extraFields),
     getFieldType: (/** @type {GovukField} */ field) =>
       getFieldComponentType(field),

--- a/designer/server/src/views/forms/editor-v2/partials/question-details-base.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/question-details-base.njk
@@ -29,9 +29,8 @@
 
 {%- include "../../../../views/forms/editor-v2/partials/question-details-advanced-settings.njk" -%}
 
-{#       {{ appIconButton({
-        label: "Preview error messages",
-        href: "#",
-        id: "preview-error-messages"
-      }) }}
-#}
+{{ appIconButton({
+  label: "Preview error messages",
+  href: "#",
+  id: "preview-error-messages"
+}) }}

--- a/designer/server/src/views/forms/editor-v2/partials/question-details-base.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/question-details-base.njk
@@ -31,6 +31,6 @@
 
 {{ appIconButton({
   label: "Preview error messages",
-  href: "#",
+  href: previewErrorsUrl,
   id: "preview-error-messages"
 }) }}

--- a/designer/server/src/views/forms/editor-v2/partials/question-details-base.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/question-details-base.njk
@@ -29,8 +29,10 @@
 
 {%- include "../../../../views/forms/editor-v2/partials/question-details-advanced-settings.njk" -%}
 
-{{ appIconButton({
-  label: "Preview error messages",
-  href: previewErrorsUrl,
-  id: "preview-error-messages"
-}) }}
+{% if questionId != 'new' %}
+  {{ appIconButton({
+    label: "Preview error messages",
+    href: previewErrorsUrl,
+    id: "preview-error-messages"
+  }) }}
+{% endif %}

--- a/designer/server/src/views/forms/editor-v2/question-details.njk
+++ b/designer/server/src/views/forms/editor-v2/question-details.njk
@@ -59,19 +59,23 @@
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
       <div class="govuk-button-group govuk-!-margin-top-6">
-        {{ appIconButton({
-          label: "Preview page",
-          href: previewPageUrl,
-          id: "preview-page"
-        }) }}
+        {% if questionId != 'new' %}
+          {{ appIconButton({
+            label: "Preview page",
+            href: previewPageUrl,
+            id: "preview-page"
+          }) }}
+        {% endif %}
 
         {{ govukButton({
           text: 'Save and continue'
         }) }}
 
-        <a href="{{ deleteUrl }}" class="govuk-link govuk-link--no-visited-state">
-          Delete question
-        </a>
+        {% if questionId != 'new' %}
+          <a href="{{ deleteUrl }}" class="govuk-link govuk-link--no-visited-state">
+            Delete question
+          </a>
+        {% endif %}
       </div>
 
     </form>


### PR DESCRIPTION
Adds 'Preview error messages' buttons as appropriate
Changed hint text of short description to suggest it should start with an uppercase letter. If not, the error previews don't all have the correct case.