### PR TITLE
Re-order items with screenreader

### DIFF
--- a/designer/server/src/common/components/editor-card/_editor-card.scss
+++ b/designer/server/src/common/components/editor-card/_editor-card.scss
@@ -28,3 +28,121 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
 .govuk-summary-card__content .govuk-summary-list__show_final_divider .govuk-summary-list__row:last-of-type {
   border-bottom: 1px solid $govuk-border-colour;
 }
+
+// Styles for the reorderable list
+.gem-c-reorderable-list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.gem-c-reorderable-list__item {
+  margin-bottom: 15px;
+  border-left: 5px solid #008938;
+  outline: 1px solid #b1b4b6;
+  padding: 15px;
+  background-color: #ffffff;
+}
+
+.gem-c-reorderable-list__wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.gem-c-reorderable-list__content {
+  flex-grow: 1;
+}
+
+.gem-c-reorderable-list__actions {
+  display: none;
+
+  // Hide by default
+  flex-direction: column;
+  margin-left: 15px;
+}
+
+.gem-c-reorderable-list__actions .govuk-button {
+  margin-bottom: 10px;
+}
+
+.govuk-body.fauxlabel.option-label-display {
+  white-space: normal;
+
+  // Allow text to wrap
+  word-wrap: break-word;
+
+  // Break long words if necessary
+  overflow-wrap: break-word;
+
+  // Ensure wrapping for long words
+}
+
+// Styling for fauxlabel
+.fauxlabel {
+  border: 0;
+
+  margin: 0;
+}
+
+.govuk-radios__item label {
+  text-transform: capitalize;
+}
+
+.gem-c-reorderable-list .gem-c-reorderable-list__item:hover,
+.gem-c-reorderable-list__item:hover .fauxlabel {
+  background-color: #ffffff;
+  cursor: initial;
+}
+
+.gem-c-reorderable-list__item:hover .fauxlabel:focus {
+  cursor: initial;
+}
+
+// Highlighting styles
+.highlight {
+  background-color: #ffe5cc;
+  border-bottom: 2px solid #ffb266;
+}
+
+.highlight-dragging {
+  border: 2px dotted #ffb266;
+
+  // Example highlight style
+  background-color: #f0f0f0;
+}
+
+.highlight-moving {
+  border: 2px dashed #ffff00;
+}
+
+.sortable-ghost {
+  opacity: 0.4;
+}
+
+.sortable-chosen {
+  background-color: #e5f5ff;
+}
+
+// Style for hover state of the list item
+.gem-c-reorderable-list__item:hover {
+  background-color: #f0f0f0;
+  cursor: move;
+}
+
+// Style for the chosen item (when selected)
+.gem-c-reorderable-list__item.sortable-chosen {
+  background-color: #e5f5ff;
+  outline: 4px solid #ffdd00;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.border-left-container {
+  border-left: 10px solid #ffb266;
+  padding-left: 20px;
+}
+
+.reorder-panel-focus {
+  border-top: 2px solid $govuk-focus-colour;
+  border-right: 2px solid $govuk-focus-colour;
+  border-bottom: 2px solid $govuk-focus-colour;
+}

--- a/designer/server/src/common/components/editor-card/_editor-card.scss
+++ b/designer/server/src/common/components/editor-card/_editor-card.scss
@@ -30,13 +30,13 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
 }
 
 // Styles for the reorderable list
-.gem-c-reorderable-list {
+.app-reorderable-list {
   list-style-type: none;
   margin: 0;
   padding: 0;
 }
 
-.gem-c-reorderable-list__item {
+.app-reorderable-list__item {
   margin-bottom: 15px;
   border-left: 5px solid #008938;
   outline: 1px solid #b1b4b6;
@@ -44,16 +44,16 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
   background-color: #ffffff;
 }
 
-.gem-c-reorderable-list__wrapper {
+.app-reorderable-list__wrapper {
   display: flex;
   align-items: center;
 }
 
-.gem-c-reorderable-list__content {
+.app-reorderable-list__content {
   flex-grow: 1;
 }
 
-.gem-c-reorderable-list__actions {
+.app-reorderable-list__actions {
   display: none;
 
   // Hide by default
@@ -61,7 +61,7 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
   margin-left: 15px;
 }
 
-.gem-c-reorderable-list__actions .govuk-button {
+.app-reorderable-list__actions .govuk-button {
   margin-bottom: 10px;
 }
 
@@ -88,13 +88,13 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
   text-transform: capitalize;
 }
 
-.gem-c-reorderable-list .gem-c-reorderable-list__item:hover,
-.gem-c-reorderable-list__item:hover .fauxlabel {
+.app-reorderable-list .app-reorderable-list__item:hover,
+.app-reorderable-list__item:hover .fauxlabel {
   background-color: #ffffff;
   cursor: initial;
 }
 
-.gem-c-reorderable-list__item:hover .fauxlabel:focus {
+.app-reorderable-list__item:hover .fauxlabel:focus {
   cursor: initial;
 }
 
@@ -124,13 +124,13 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
 }
 
 // Style for hover state of the list item
-.gem-c-reorderable-list__item:hover {
+.app-reorderable-list__item:hover {
   background-color: #f0f0f0;
   cursor: move;
 }
 
 // Style for the chosen item (when selected)
-.gem-c-reorderable-list__item.sortable-chosen {
+.app-reorderable-list__item.sortable-chosen {
   background-color: #e5f5ff;
   outline: 4px solid #ffdd00;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);

--- a/designer/server/src/common/constants/editor.js
+++ b/designer/server/src/common/constants/editor.js
@@ -106,5 +106,40 @@ export const QuestionEnhancedFields =
   }
 
 /**
+ * @readonly
+ * @enum {string}
+ */
+export const Direction = {
+  Up: 'up',
+  Down: 'down'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ListAction = {
+  Move: 'move',
+  Reorder: 'reorder',
+  DoneReordering: 'done-reordering',
+  Delete: 'delete',
+  Edit: 'edit',
+  Cancel: 'cancel'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const EnhancedAction = {
+  AddItem: 'add-item',
+  Reorder: 're-order',
+  DoneReordering: 'done-reordering',
+  SaveItem: 'save-item',
+  Up: 'up',
+  Down: 'down'
+}
+
+/**
  * @import { FormEditorGovukField } from '@defra/forms-model'
  */

--- a/designer/server/src/routes/forms/editor-v2/question-details-extra.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-extra.test.js
@@ -78,7 +78,7 @@ describe('Editor v2 question details routes', () => {
 
     expect(statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(headers.location).toBe(
-      '/library/my-form-slug/editor-v2/page/123456/question/456/details/sessId#add-option'
+      '/library/my-form-slug/editor-v2/page/123456/question/456/details/sessId#add-option-form'
     )
   })
 })

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.js
@@ -2,6 +2,11 @@ import { randomUUID } from 'crypto'
 
 import Joi from 'joi'
 
+import {
+  Direction,
+  EnhancedAction,
+  ListAction
+} from '~/src/common/constants/editor.js'
 import { sessionNames } from '~/src/common/constants/session-names.js'
 import { addErrorsToSession } from '~/src/lib/error-helper.js'
 import {
@@ -19,7 +24,7 @@ const listUniquenessSchema = Joi.object({
 })
 
 /**
- * @param { { id?: string, text?: string, hint?: { text: string }, value?: string } | undefined } itemForEdit
+ * @param { ListItem | undefined } itemForEdit
  * @param {boolean} expanded
  */
 export function setEditRowState(itemForEdit, expanded) {
@@ -33,13 +38,45 @@ export function setEditRowState(itemForEdit, expanded) {
 }
 
 /**
+ * Repositions a list item in the array
+ * @param {{ id?: string }[]} listItems
+ * @param {string} direction
+ * @param {string} itemId
+ * @returns {{ id?: string }[]}
+ */
+export function repositionListItem(listItems, direction, itemId) {
+  if (!listItems.length) {
+    return listItems
+  }
+
+  const itemIdx = listItems.findIndex((x) => x.id === itemId)
+
+  const isValidDirection =
+    (direction === Direction.Down && itemIdx < listItems.length - 1) ||
+    (direction === Direction.Up && itemIdx > 0)
+
+  if (itemIdx === -1 || !isValidDirection) {
+    return listItems
+  }
+
+  const positionIndex = direction === Direction.Down ? itemIdx + 1 : itemIdx - 1
+
+  const newListItems = [...listItems]
+  const itemToMove = newListItems[itemIdx]
+  newListItems.splice(itemIdx, 1)
+  newListItems.splice(positionIndex, 0, itemToMove)
+
+  return newListItems
+}
+
+/**
  * @param {Yar} yar
  * @param {string} stateId
  * @param {RequestQuery} query
  * @returns { string | undefined }
  */
 export function handleEnhancedActionOnGet(yar, stateId, query) {
-  const { action, id } = query
+  const { action, id, direction } = query
   if (!action) {
     return undefined
   }
@@ -49,7 +86,7 @@ export function handleEnhancedActionOnGet(yar, stateId, query) {
     throw new Error('Invalid session contents')
   }
 
-  if (action === 'delete') {
+  if (action === ListAction.Delete) {
     const newList = state.listItems?.filter((x) => x.id !== id)
     setQuestionSessionState(yar, stateId, {
       ...state,
@@ -58,7 +95,7 @@ export function handleEnhancedActionOnGet(yar, stateId, query) {
     return radiosSectionListItemsAnchor
   }
 
-  if (action === 'edit') {
+  if (action === ListAction.Edit) {
     const itemForEdit = state.listItems?.find((x) => x.id === id)
 
     setQuestionSessionState(yar, stateId, {
@@ -68,10 +105,51 @@ export function handleEnhancedActionOnGet(yar, stateId, query) {
     return '#add-option-form'
   }
 
-  if (action === 'cancel') {
+  if (action === ListAction.Cancel) {
     setQuestionSessionState(yar, stateId, {
       ...state,
       editRow: setEditRowState(undefined, false)
+    })
+    return radiosSectionListItemsAnchor
+  }
+
+  if (action === ListAction.Reorder) {
+    setQuestionSessionState(yar, stateId, {
+      ...state,
+      isReordering: true,
+      editRow: { expanded: false },
+      lastMovedId: undefined,
+      lastMoveDirection: undefined
+    })
+    return radiosSectionListItemsAnchor
+  }
+
+  if (action === ListAction.Move) {
+    if (
+      id &&
+      direction &&
+      (direction === Direction.Up || direction === Direction.Down)
+    ) {
+      const newList = repositionListItem(
+        state.listItems ?? [],
+        String(direction),
+        String(id)
+      )
+      setQuestionSessionState(yar, stateId, {
+        ...state,
+        listItems: newList,
+        lastMovedId: String(id),
+        lastMoveDirection: String(direction)
+      })
+    }
+    return '#'
+  }
+
+  if (action === ListAction.DoneReordering) {
+    setQuestionSessionState(yar, stateId, {
+      ...state,
+      isReordering: false,
+      editRow: { expanded: false }
     })
     return radiosSectionListItemsAnchor
   }
@@ -164,27 +242,38 @@ export function handleEnhancedActionOnPost(request, stateId, questionDetails) {
       radioValue: payload.radioValue,
       expanded: true
     },
+    isReordering: preState.isReordering,
+    lastMovedId: preState.lastMovedId,
+    lastMoveDirection: preState.lastMoveDirection,
     listItems: preState.listItems ?? []
   })
 
-  if (enhancedAction === 'add-item') {
+  if (enhancedAction === EnhancedAction.AddItem) {
     setQuestionSessionState(yar, stateId, state)
-    return '#add-option'
+    return '#add-option-form'
   }
 
-  if (enhancedAction === 're-order') {
+  if (enhancedAction === EnhancedAction.Reorder) {
+    state.isReordering = true
     setQuestionSessionState(yar, stateId, state)
     return radiosSectionListItemsAnchor
   }
 
-  if (enhancedAction === 'save-item') {
+  if (enhancedAction === ListAction.DoneReordering) {
+    state.isReordering = false
+    setQuestionSessionState(yar, stateId, state)
+    return radiosSectionListItemsAnchor
+  }
+
+  if (enhancedAction === EnhancedAction.SaveItem) {
     return handleSaveItem(request, state, stateId)
   }
+
   return undefined
 }
 
 /**
- * @import { ComponentDef,  FormEditorInputQuestionDetails, QuestionSessionState, FormDefinition, ListComponentsDef } from '@defra/forms-model'
+ * @import { ComponentDef,  FormEditorInputQuestionDetails, QuestionSessionState, ListItem } from '@defra/forms-model'
  * @import { Request, RequestQuery } from '@hapi/hapi'
  * @import { Yar } from '@hapi/yar'
  */

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.js
@@ -128,13 +128,14 @@ export function handleEnhancedActionOnGet(yar, stateId, query) {
   }
 
   if (action === ListAction.Reorder) {
-    setQuestionSessionState(yar, stateId, {
-      ...state,
-      isReordering: true,
+    const newState = {
+      questionType: state.questionType,
+      questionDetails: state.questionDetails,
       editRow: { expanded: false },
-      lastMovedId: undefined,
-      lastMoveDirection: undefined
-    })
+      listItems: state.listItems,
+      isReordering: true
+    }
+    setQuestionSessionState(yar, stateId, newState)
     return radiosSectionListItemsAnchor
   }
 

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.js
@@ -70,13 +70,27 @@ export function repositionListItem(listItems, direction, itemId) {
 }
 
 /**
+ * @param { string | undefined } id
+ * @param { string | undefined } direction
+ * @returns {boolean}
+ */
+export function paramsValidForMove(id, direction) {
+  return (
+    !!id &&
+    !!direction &&
+    (direction === Direction.Up || direction === Direction.Down)
+  )
+}
+
+/**
  * @param {Yar} yar
  * @param {string} stateId
  * @param {RequestQuery} query
  * @returns { string | undefined }
  */
 export function handleEnhancedActionOnGet(yar, stateId, query) {
-  const { action, id, direction } = query
+  const { action, id, direction } =
+    /** @type {{ action?: string, id?: string, direction?: string }} */ (query)
   if (!action) {
     return undefined
   }
@@ -125,11 +139,7 @@ export function handleEnhancedActionOnGet(yar, stateId, query) {
   }
 
   if (action === ListAction.Move) {
-    if (
-      id &&
-      direction &&
-      (direction === Direction.Up || direction === Direction.Down)
-    ) {
+    if (paramsValidForMove(id, direction)) {
       const newList = repositionListItem(
         state.listItems ?? [],
         String(direction),

--- a/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details-helper.test.js
@@ -181,6 +181,121 @@ describe('Editor v2 question-details route helper', () => {
         ]
       })
     })
+
+    test('reorder should set isReordering flag', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      expect(
+        handleEnhancedActionOnGet(mockYar, '123', { action: 'reorder' })
+      ).toBe('#list-items')
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        isReordering: true,
+        editRow: { expanded: false },
+        listItems: [
+          { id: '1', text: 'text1', value: 'value1' },
+          { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' },
+          { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' }
+        ]
+      })
+    })
+
+    test('done-reordering should clear isReordering flag', () => {
+      mockGet.mockReturnValue(
+        structuredClone({
+          ...sessionWithListWithThreeItems,
+          isReordering: true
+        })
+      )
+
+      expect(
+        handleEnhancedActionOnGet(mockYar, '123', { action: 'done-reordering' })
+      ).toBe('#list-items')
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        isReordering: false,
+        listItems: [
+          { id: '1', text: 'text1', value: 'value1' },
+          { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' },
+          { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' }
+        ],
+        editRow: {
+          expanded: false
+        }
+      })
+    })
+
+    test('move up should reposition item properly', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      expect(
+        handleEnhancedActionOnGet(mockYar, '123', {
+          action: 'move',
+          id: '3',
+          direction: 'up'
+        })
+      ).toBe('#')
+
+      // up to position 2
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        listItems: [
+          { id: '1', text: 'text1', value: 'value1' },
+          { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' },
+          { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' }
+        ],
+        lastMovedId: '3',
+        lastMoveDirection: 'up'
+      })
+    })
+
+    test('move down should reposition item properly', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      expect(
+        handleEnhancedActionOnGet(mockYar, '123', {
+          action: 'move',
+          id: '1',
+          direction: 'down'
+        })
+      ).toBe('#')
+
+      // down to position 2
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        listItems: [
+          { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' },
+          { id: '1', text: 'text1', value: 'value1' },
+          { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' }
+        ],
+        lastMovedId: '1',
+        lastMoveDirection: 'down'
+      })
+    })
+
+    test('move should handle invalid moves gracefully', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      // try to move first item up (should not change list!)
+      expect(
+        handleEnhancedActionOnGet(mockYar, '123', {
+          action: 'move',
+          id: '1',
+          direction: 'up'
+        })
+      ).toBe('#')
+
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        listItems: [
+          { id: '1', text: 'text1', value: 'value1' },
+          { hint: { text: 'hint2' }, id: '2', text: 'text2', value: 'value2' },
+          { hint: { text: 'hint3' }, id: '3', text: 'text3', value: 'value3' }
+        ],
+        lastMovedId: '1',
+        lastMoveDirection: 'up'
+      })
+    })
   })
 
   describe('handleEnhancedActionOnPost', () => {
@@ -229,7 +344,7 @@ describe('Editor v2 question-details route helper', () => {
       const { mockRequest } = buildMockRequest(payload)
 
       expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
-        '#add-option'
+        '#add-option-form'
       )
       expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
         questionType: 'RadiosField',
@@ -258,160 +373,185 @@ describe('Editor v2 question-details route helper', () => {
         '#list-items'
       )
     })
+  })
 
-    describe('save-item', () => {
-      test('should handle simple no list items', () => {
-        mockGet.mockReturnValue(structuredClone(simpleSession))
+  describe('save-item', () => {
+    test('should handle simple no list items', () => {
+      mockGet.mockReturnValue(structuredClone(simpleSession))
 
-        const payload = /** @type {FormEditorInputQuestionDetails} */ ({
-          enhancedAction: 'save-item',
-          radioId: '1',
-          radioText: 'text',
+      const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+        enhancedAction: 'save-item',
+        radioId: '1',
+        radioText: 'text',
+        radioHint: '',
+        radioValue: 'value'
+      })
+      const { mockRequest } = buildMockRequest(payload)
+
+      expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
+        '#list-items'
+      )
+      const expectedList = [
+        {
+          id: expect.any(String),
+          text: 'text',
+          hint: undefined,
+          value: 'value'
+        }
+      ]
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        listItems: expectedList,
+        editRow: {
+          radioId: '',
+          radioText: '',
           radioHint: '',
-          radioValue: 'value'
-        })
-        const { mockRequest } = buildMockRequest(payload)
-
-        expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
-          '#list-items'
-        )
-        const expectedList = [
-          {
-            id: expect.any(String),
-            text: 'text',
-            hint: undefined,
-            value: 'value'
-          }
-        ]
-        expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
-          questionType: 'RadiosField',
-          listItems: expectedList,
-          editRow: {
-            radioId: '',
-            radioText: '',
-            radioHint: '',
-            radioValue: '',
-            expanded: false
-          },
-          questionDetails: {}
-        })
-      })
-      test('save-item should update existing item', () => {
-        mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
-
-        const payload = /** @type {FormEditorInputQuestionDetails} */ ({
-          enhancedAction: 'save-item',
-          radioId: '3',
-          radioText: 'text3x',
-          radioHint: 'hint3x',
-          radioValue: 'value3x'
-        })
-
-        const { mockRequest } = buildMockRequest(payload)
-
-        expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
-          '#list-items'
-        )
-        const expectedList = [
-          { id: '1', text: 'text1', value: 'value1' },
-          { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
-          {
-            id: '3',
-            text: 'text3x',
-            hint: { text: 'hint3x' },
-            value: 'value3x'
-          }
-        ]
-        expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
-          questionType: 'RadiosField',
-          listItems: expectedList,
-          editRow: {
-            radioId: '',
-            radioText: '',
-            radioHint: '',
-            radioValue: '',
-            expanded: false
-          },
-          questionDetails: {}
-        })
-      })
-
-      test('save-item should add new item', () => {
-        mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
-
-        const payload = /** @type {FormEditorInputQuestionDetails} */ ({
-          enhancedAction: 'save-item',
-          radioId: '5',
-          radioText: 'text5',
-          radioHint: '',
-          radioValue: 'value5'
-        })
-
-        const { mockRequest } = buildMockRequest(payload)
-
-        expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
-          '#list-items'
-        )
-        const expectedList = [
-          { id: '1', text: 'text1', value: 'value1' },
-          { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
-          { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' },
-          {
-            id: expect.anything(),
-            text: 'text5',
-            hint: undefined,
-            value: 'value5'
-          }
-        ]
-        expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
-          questionType: 'RadiosField',
-          listItems: expectedList,
-          editRow: {
-            radioId: '',
-            radioText: '',
-            radioHint: '',
-            radioValue: '',
-            expanded: false
-          },
-          questionDetails: {}
-        })
-      })
-
-      test('save-item should error if duplicate item', () => {
-        mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
-
-        const payload = /** @type {FormEditorInputQuestionDetails} */ ({
-          enhancedAction: 'save-item',
-          radioId: '5',
-          radioText: 'text3',
-          radioHint: 'hint5',
-          radioValue: 'value5'
-        })
-
-        const { mockRequest } = buildMockRequest(payload)
-
-        expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe('#')
-        expect(mockSet).not.toHaveBeenCalled()
-        expect(mockFlash).toHaveBeenCalledWith(
-          'questionDetailsValidationFailure',
-          {
-            formErrors: {
-              radioText: {
-                href: '#radioText',
-                text: 'Item text must be unique in the list on item 4'
-              }
-            },
-            formValues: {
-              enhancedAction: 'save-item',
-              radioHint: 'hint5',
-              radioId: '5',
-              radioText: 'text3',
-              radioValue: 'value5'
-            }
-          }
-        )
+          radioValue: '',
+          expanded: false
+        },
+        questionDetails: {}
       })
     })
+    test('save-item should update existing item', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+        enhancedAction: 'save-item',
+        radioId: '3',
+        radioText: 'text3x',
+        radioHint: 'hint3x',
+        radioValue: 'value3x'
+      })
+
+      const { mockRequest } = buildMockRequest(payload)
+
+      expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
+        '#list-items'
+      )
+      const expectedList = [
+        { id: '1', text: 'text1', value: 'value1' },
+        { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
+        {
+          id: '3',
+          text: 'text3x',
+          hint: { text: 'hint3x' },
+          value: 'value3x'
+        }
+      ]
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        listItems: expectedList,
+        editRow: {
+          radioId: '',
+          radioText: '',
+          radioHint: '',
+          radioValue: '',
+          expanded: false
+        },
+        questionDetails: {}
+      })
+    })
+
+    test('save-item should add new item', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+        enhancedAction: 'save-item',
+        radioId: '5',
+        radioText: 'text5',
+        radioHint: '',
+        radioValue: 'value5'
+      })
+
+      const { mockRequest } = buildMockRequest(payload)
+
+      expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
+        '#list-items'
+      )
+      const expectedList = [
+        { id: '1', text: 'text1', value: 'value1' },
+        { id: '2', text: 'text2', hint: { text: 'hint2' }, value: 'value2' },
+        { id: '3', text: 'text3', hint: { text: 'hint3' }, value: 'value3' },
+        {
+          id: expect.anything(),
+          text: 'text5',
+          hint: undefined,
+          value: 'value5'
+        }
+      ]
+      expect(mockSet).toHaveBeenCalledWith('questionSessionState-123', {
+        questionType: 'RadiosField',
+        listItems: expectedList,
+        editRow: {
+          radioId: '',
+          radioText: '',
+          radioHint: '',
+          radioValue: '',
+          expanded: false
+        },
+        questionDetails: {}
+      })
+    })
+
+    test('save-item should error if duplicate item', () => {
+      mockGet.mockReturnValue(structuredClone(sessionWithListWithThreeItems))
+
+      const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+        enhancedAction: 'save-item',
+        radioId: '5',
+        radioText: 'text3',
+        radioHint: 'hint5',
+        radioValue: 'value5'
+      })
+
+      const { mockRequest } = buildMockRequest(payload)
+
+      expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe('#')
+      expect(mockSet).not.toHaveBeenCalled()
+      expect(mockFlash).toHaveBeenCalledWith(
+        'questionDetailsValidationFailure',
+        {
+          formErrors: {
+            radioText: {
+              href: '#radioText',
+              text: 'Item text must be unique in the list on item 4'
+            }
+          },
+          formValues: {
+            enhancedAction: 'save-item',
+            radioHint: 'hint5',
+            radioId: '5',
+            radioText: 'text3',
+            radioValue: 'value5'
+          }
+        }
+      )
+    })
+  })
+
+  test('done-reordering post should clear isReordering flag', () => {
+    mockGet.mockReturnValue(
+      structuredClone({
+        ...sessionWithListWithThreeItems,
+        isReordering: true
+      })
+    )
+
+    const payload = /** @type {FormEditorInputQuestionDetails} */ ({
+      enhancedAction: 'done-reordering'
+    })
+
+    const { mockRequest } = buildMockRequest(payload)
+
+    expect(handleEnhancedActionOnPost(mockRequest, '123', {})).toBe(
+      '#list-items'
+    )
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        isReordering: false
+      })
+    )
   })
 })
 

--- a/designer/server/src/views/forms/editor-v2/custom-templates/radios-or-checkboxes.njk
+++ b/designer/server/src/views/forms/editor-v2/custom-templates/radios-or-checkboxes.njk
@@ -19,7 +19,7 @@
 
 
   {% if state.isReordering %}
-    <ol class="gem-c-reorderable-list" id="options-container">
+    <ol class="app-reorderable-list" id="options-container">
     {% if state.listItems | length %}
       {% set itemsCount = state.listItems | length %}
       {% for item in state.listItems %}
@@ -29,9 +29,9 @@
         {% set isFocus = state.lastMovedId == item.id %}
         {% set focusClass = " pages-reorder-panel-focus" if isFocus else "" %}
 
-        <li class="gem-c-reorderable-list__item reorder-panel{{ focusClass }}" data-index="{{ loop.index }}" data-id="{{ item.id }}">
-          <div class="gem-c-reorderable-list__wrapper">
-            <div class="gem-c-reorderable-list__content">
+        <li class="app-reorderable-list__item reorder-panel{{ focusClass }}" data-index="{{ loop.index }}" data-id="{{ item.id }}">
+          <div class="app-reorderable-list__wrapper">
+            <div class="app-reorderable-list__content">
               <p class="govuk-body fauxlabel option-label-display" id="option-{{ loop.index }}-label-display">
                 {{ item.text }}
               </p>
@@ -75,15 +75,15 @@
       <a href="?action=done-reordering" class="govuk-button">Done</a>
     </div>
   {% else %}
-    <ol class="gem-c-reorderable-list js-enabled" id="options-container" data-module="reorderable-list">
+    <ol class="app-reorderable-list js-enabled" id="options-container" data-module="reorderable-list">
     {% if state.listItems | length or state.editRow.expanded %}
       {% for item in state.listItems %}
         {% if loop.index == listDetails.rowNumBeingEdited %}
           {%- include "../../../../views/forms/editor-v2/custom-templates/radio-or-checkbox-edit.njk" -%}
         {% else %}
-          <li class="gem-c-reorderable-list__item" data-index="{{ loop.index }}" data-id="{{ item.id }}" data-val="{{ item.value }}">
-            <div class="gem-c-reorderable-list__wrapper">
-              <div class="gem-c-reorderable-list__content">
+          <li class="app-reorderable-list__item" data-index="{{ loop.index }}" data-id="{{ item.id }}" data-val="{{ item.value }}">
+            <div class="app-reorderable-list__wrapper">
+              <div class="app-reorderable-list__content">
                 <p class="govuk-body fauxlabel option-label-display" id="option-{{ loop.index }}-label-display">
                   {{ item.text }}
                 </p>

--- a/designer/server/src/views/forms/editor-v2/custom-templates/radios-or-checkboxes.njk
+++ b/designer/server/src/views/forms/editor-v2/custom-templates/radios-or-checkboxes.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "editor-card/macro.njk" import appEditorCard %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set radioIdIdx = 0 %}
 {% set radioTextIdx = 1 %}
@@ -16,68 +17,121 @@
   </h2>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" style="border-color:black; border-width: 3px;">
 
-  {% if state.listItems | length  or state.editRow.expanded %}
 
-      <ol class="gem-c-reorderable-list js-enabled" id="options-container" data-module="reorderable-list">
-        {% for item in state.listItems %}
-          {% if loop.index == listDetails.rowNumBeingEdited %}
+  {% if state.isReordering %}
+    <ol class="gem-c-reorderable-list" id="options-container">
+    {% if state.listItems | length %}
+      {% set itemsCount = state.listItems | length %}
+      {% for item in state.listItems %}
+
+        {% set isFirst = loop.first %}
+        {% set isLast = loop.last %}
+        {% set isFocus = state.lastMovedId == item.id %}
+        {% set focusClass = " pages-reorder-panel-focus" if isFocus else "" %}
+
+        <li class="gem-c-reorderable-list__item reorder-panel{{ focusClass }}" data-index="{{ loop.index }}" data-id="{{ item.id }}">
+          <div class="gem-c-reorderable-list__wrapper">
+            <div class="gem-c-reorderable-list__content">
+              <p class="govuk-body fauxlabel option-label-display" id="option-{{ loop.index }}-label-display">
+                {{ item.text }}
+              </p>
+              {% if item.hint.text %}
+              <p class="govuk-hint govuk-!-margin-top-0 govuk-!-margin-bottom-0">{{ item.hint.text }}</p>
+              {% endif %}
+            </div>
+
+            {% set upAuto = "autofocus" if isFocus and (state.lastMoveDirection == "up" or isLast) else "" %}
+            {% set downAuto = "autofocus" if isFocus and (state.lastMoveDirection == "down" or isFirst) else "" %}
+
+            {% set ariaLabelUp = "Button, Move " + item.text + ": up, " + item.text + " is currently option " + loop.index + " of " + itemsCount + " options." %}
+            {% set ariaLabelDown = "Button, Move " + item.text + ": down, " + item.text + " is currently option " + loop.index + " of " + itemsCount + " options." %}
+            {% set ariaAlert = "The list has been reordered, " + item.text + " is now option " + loop.index + " of " + itemsCount + " options." if isFocus else "" %}
+
+            {% if isFocus %}
+              {% if state.lastMoveDirection == "up" or isLast %}
+                {% set ariaLabelUp = ariaAlert + ariaLabelUp %}
+              {% endif %}
+              {% if state.lastMoveDirection == "down" or isFirst %}
+                {% set ariaLabelDown = ariaAlert + ariaLabelDown %}
+              {% endif %}
+            {% endif %}
+
+            <div class="govuk-button-group">
+              {% if not isFirst %}
+                <a href="?action=move&id={{ item.id }}&direction=up" class="govuk-button govuk-button--secondary" {{ upAuto }} aria-label="{{ ariaLabelUp }}">Up</a>
+              {% endif %}
+
+              {% if not isLast %}
+                <a href="?action=move&id={{ item.id }}&direction=down"  class="govuk-button govuk-button--secondary" {{ downAuto }} aria-label="{{ ariaLabelDown }}">Down</a>
+              {% endif %}
+            </div>
+          </div>
+        </li>
+      {% endfor %}
+    {% endif %}
+    </ol>
+
+    <div class="govuk-button-group govuk-!-margin-top-6">
+      <a href="?action=done-reordering" class="govuk-button">Done</a>
+    </div>
+  {% else %}
+    <ol class="gem-c-reorderable-list js-enabled" id="options-container" data-module="reorderable-list">
+    {% if state.listItems | length or state.editRow.expanded %}
+      {% for item in state.listItems %}
+        {% if loop.index == listDetails.rowNumBeingEdited %}
           {%- include "../../../../views/forms/editor-v2/custom-templates/radio-or-checkbox-edit.njk" -%}
-          {% else %}
-          <li class="gem-c-reorderable-list__item" draggable="true" data-index="1">
-            <div class="govuk-summary-card govuk-!-margin-top-0 govuk-!-margin-bottom-3 pages-panel-left-thin-border">
-              <div class="govuk-summary-card__content govuk-!-padding-top-1 editor-card-background-white govuk-!-padding-bottom-1">
-                <dl class="govuk-summary-list">
-                  <div class="govuk-summary-list__row">
-                    <dt class="govuk-summary-list__key">{{ item.text }}
-                    {% if item.hint.text %}
-                    <p class="govuk-hint govuk-!-margin-top-0 govuk-!-margin-bottom-0">{{ item.hint.text }}</p>
-                    {% endif %}
-                    </dt>
-                    <dd class="govuk-summary-list__actions">
-                      <ul class="govuk-summary-list__actions-list">
-                        <li class="govuk-summary-list__actions-list-item">
-                          <a class="govuk-link govuk-link--no-visited-state" href="?action=edit&id={{ item.id }}">
-                            Edit<span class="govuk-visually-hidden">option 1</span>
-                          </a>
-                        </li>
-                        <li class="govuk-summary-list__actions-list-item">
-                          <a class="govuk-link govuk-link--destructive delete-option-link" href="?action=delete&id={{ item.id }}">
-                            Delete<span class="govuk-visually-hidden"> list item</span>
-                          </a>
-                        </li>
-                      </ul>
-                    </dd>
-                  </div>
-                </dl>
+        {% else %}
+          <li class="gem-c-reorderable-list__item" data-index="{{ loop.index }}" data-id="{{ item.id }}" data-val="{{ item.value }}">
+            <div class="gem-c-reorderable-list__wrapper">
+              <div class="gem-c-reorderable-list__content">
+                <p class="govuk-body fauxlabel option-label-display" id="option-{{ loop.index }}-label-display">
+                  {{ item.text }}
+                </p>
+                {% if item.hint.text %}
+                  <p class="govuk-hint govuk-!-margin-top-0 govuk-!-margin-bottom-0">{{ item.hint.text }}</p>
+                {% endif %}
               </div>
+
+              <div class="edit-item">
+                <ul class="govuk-summary-list__actions-list">
+                  <li class="govuk-summary-list__actions-list-item">
+                    <a class="govuk-link govuk-link--no-visited-state edit-option-link" href="?action=edit&id={{ item.id }}">
+                      Edit<span class="govuk-visually-hidden">option {{ loop.index }}</span>
+                    </a>
+                  </li>
+                  <li class="govuk-summary-list__actions-list-item">
+                    <a class="govuk-link govuk-link--destructive delete-option-link" href="?action=delete&id={{ item.id }}">
+                      Delete<span class="govuk-visually-hidden"> list item</span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
             </div>
           </li>
-          {% endif %}
-        {% endfor %}
-      </ol>
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+    </ol>
 
-      {% if state.editRow.expanded %}
-
-          {% if listDetails.rowNumBeingEdited == state.listItems.length + 1 %}
-          {%- include "../../../../views/forms/editor-v2/custom-templates/radio-or-checkbox-edit.njk" -%}
-          {% endif %}
-
+    {% if state.editRow.expanded %}
+      {% if listDetails.rowNumBeingEdited == state.listItems.length + 1 %}
+      {%- include "../../../../views/forms/editor-v2/custom-templates/radio-or-checkbox-edit.njk" -%}
       {% endif %}
-
+    {% endif %}
   {% endif %}
 </div>
 
-{% if not state.editRow.expanded %}
+{% if not state.editRow.expanded and not state.isReordering %}
 <div class="govuk-button-group">
-  <!-- Add Another Option Button -->
   <button id="add-option-button" type="submit" class="govuk-button govuk-!-margin-bottom-4 govuk-!-margin-bottom-6" name="enhancedAction" value="add-item">
     Add item
   </button>
 
-  {% if (state.listItems | length > 1) %}
-  <button id="edit-options-button" type="submit" class="govuk-button govuk-button--inverse" name="enhancedAction" value="re-order">
+  {% if state.listItems.length > 1 %}
+  <a href="?action=reorder" id="edit-options-button" class="govuk-button govuk-button--inverse">
     Re-order
-  </button>
+  </a>
   {% endif %}
 </div>
 {% endif %}

--- a/model/src/form/form-editor/types.ts
+++ b/model/src/form/form-editor/types.ts
@@ -292,6 +292,15 @@ export type FormEditorInputQuestionDetails = Pick<
   | 'radioValue'
 >
 
+export interface ListItem {
+  text?: string
+  hint?: {
+    text?: string
+  }
+  value?: string
+  id?: string
+}
+
 export interface QuestionSessionState {
   questionType?: ComponentType
   questionDetails?: Partial<ComponentDef>
@@ -302,12 +311,10 @@ export interface QuestionSessionState {
     radioValue?: string
     expanded?: boolean
   }
-  listItems?: {
-    text?: string
-    hint?: { id?: string; text: string }
-    value?: string
-    id?: string
-  }[]
+  listItems?: ListItem[]
+  isReordering?: boolean
+  lastMovedId?: string
+  lastMoveDirection?: string
 }
 
 export interface GovukField {


### PR DESCRIPTION
Branched from main
Used the same 'autofocus' mechanism as for page re-ordering in order to get the screenreader to immediately read the button label
However, although it works, the screenreading didn't seem 100% reliable. Let's see how the testing goes.
