### PR TITLE
feat: listSchema validation messages for unique identifiers

### DIFF
--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -591,6 +591,10 @@ export const listSchema = Joi.object<List>()
         .items(stringListItemSchema)
         .unique('text')
         .unique('value')
+        .messages({
+          'array.unique':
+            'Each item must have a unique identifier - enter a different identifier for this item.'
+        })
         .description('Array of items with string values'),
       otherwise: Joi.array()
         .items(numberListItemSchema)


### PR DESCRIPTION
## Ticket
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/549452

## Description
This PR introduces a small change to the `listSchema` by introducing a new error message

<img width="609" alt="Screenshot 2025-05-09 at 10 24 31" src="https://github.com/user-attachments/assets/a33e8a0c-65ea-4c17-918f-5059b5519be8" />
