### PR TITLE
Added screenreader announcement for reorder list items

### DIFF
--- a/designer/client/src/javascripts/preview/__stubs__/list.js
+++ b/designer/client/src/javascripts/preview/__stubs__/list.js
@@ -118,3 +118,63 @@ export const list1HTML = `
     </div>
   </li>
 </ol>`
+
+export const listSingleEntryDownHTML = `
+<ol class="app-reorderable-list js-enabled" id="options-container" data-module="reorderable-list">
+  <li class="app-reorderable-list__item" data-index="1" data-id="dc96bf7a-07a0-4f5b-ba6d-c5c4c9d381de" data-val="option-1" data-text="Option 1" data-hint="" style="cursor: default;">
+    <div class="app-reorderable-list__wrapper" style="cursor: default;">
+      <div class="app-reorderable-list__content" style="cursor: default;">
+        <p class="govuk-body fauxlabel option-label-display" id="option-1-label-display" style="cursor: default;">
+          Option 1
+        </p>
+      </div>
+      <div class="govuk-button-group govuk-!-margin-bottom-0">
+        <a class="govuk-button govuk-button--secondary js-reorderable-list-down govuk-!-margin-bottom-1" style="display: none" id="first-row-down">Down</a>
+      </div>
+      <div class="edit-item" style="cursor: default;">
+        <ul class="govuk-summary-list__actions-list" style="cursor: default;">
+          <li class="govuk-summary-list__actions-list-item" style="cursor: default;">
+            <a class="govuk-link govuk-link--no-visited-state edit-option-link" href="?action=edit&amp;id=dc96bf7a-07a0-4f5b-ba6d-c5c4c9d381de" style="cursor: default;">
+              Edit<span class="govuk-visually-hidden" style="cursor: default;">option 1</span>
+            </a>
+          </li>
+          <li class="govuk-summary-list__actions-list-item" style="cursor: default;">
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--destructive delete-option-link" href="?action=delete&amp;id=dc96bf7a-07a0-4f5b-ba6d-c5c4c9d381de" style="cursor: default;">
+              Delete<span class="govuk-visually-hidden" style="cursor: default;"> list item</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </li>
+</ol>`
+
+export const listSingleEntryUpHTML = `
+<ol class="app-reorderable-list js-enabled" id="options-container" data-module="reorderable-list">
+  <li class="app-reorderable-list__item" data-index="1" data-id="dc96bf7a-07a0-4f5b-ba6d-c5c4c9d381de" data-val="option-1" data-text="Option 1" data-hint="" style="cursor: default;">
+    <div class="app-reorderable-list__wrapper" style="cursor: default;">
+      <div class="app-reorderable-list__content" style="cursor: default;">
+        <p class="govuk-body fauxlabel option-label-display" id="option-1-label-display" style="cursor: default;">
+          Option 1
+        </p>
+      </div>
+      <div class="govuk-button-group govuk-!-margin-bottom-0">
+        <a class="govuk-button govuk-button--secondary js-reorderable-list-up govuk-!-margin-bottom-1" style="display: none" id="first-row-up">Up</a>
+      </div>
+      <div class="edit-item" style="cursor: default;">
+        <ul class="govuk-summary-list__actions-list" style="cursor: default;">
+          <li class="govuk-summary-list__actions-list-item" style="cursor: default;">
+            <a class="govuk-link govuk-link--no-visited-state edit-option-link" href="?action=edit&amp;id=dc96bf7a-07a0-4f5b-ba6d-c5c4c9d381de" style="cursor: default;">
+              Edit<span class="govuk-visually-hidden" style="cursor: default;">option 1</span>
+            </a>
+          </li>
+          <li class="govuk-summary-list__actions-list-item" style="cursor: default;">
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--destructive delete-option-link" href="?action=delete&amp;id=dc96bf7a-07a0-4f5b-ba6d-c5c4c9d381de" style="cursor: default;">
+              Delete<span class="govuk-visually-hidden" style="cursor: default;"> list item</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </li>
+</ol>`

--- a/designer/client/src/javascripts/preview/list-sortable.js
+++ b/designer/client/src/javascripts/preview/list-sortable.js
@@ -24,6 +24,14 @@ export class ListSortableQuestionElements extends ListQuestionElements {
   sortableContainer
   /** @type { Sortable | undefined } */
   sortableInstance
+  /** @type { HTMLElement | undefined } */
+  announcementRegion
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  announceTimeout = undefined
+  /** @type {number} */
+  announceDisplayTimeMs = 150
+  /** @type {number} */
+  announceClearTimeMs = 5000
 
   constructor() {
     super()
@@ -36,10 +44,14 @@ export class ListSortableQuestionElements extends ListQuestionElements {
     const sortableContainer = /** @type {HTMLElement} */ (
       document.getElementById('options-container')
     )
+    const announcementRegion = /** @type {HTMLElement} */ (
+      document.getElementById('reorder-announcement')
+    )
 
     this.editOptionsButton = editOptionsButton
     this.addItemButton = addItemButton
     this.sortableContainer = sortableContainer
+    this.announcementRegion = announcementRegion
   }
 
   isReordering() {
@@ -222,6 +234,48 @@ export class ListSortableQuestionElements extends ListQuestionElements {
       listenerClass._listSortableElements.setMoveFocus(target)
     }
   }
+
+  /**
+   * Announces the reorder action to screen readers via the live region.
+   * @param {HTMLElement} movedItem - The list item that was moved.
+   */
+  announceReorder(movedItem) {
+    if (!this.announcementRegion) {
+      return
+    }
+
+    const listItem = /** @type { HTMLElement | null } */ (
+      movedItem.closest('.app-reorderable-list__item')
+    )
+    const listItems = /** @type {HTMLElement[]} */ (
+      Array.from(
+        this.sortableContainer.querySelectorAll('.app-reorderable-list__item')
+      )
+    )
+    const newPositionIdx = listItems.findIndex(
+      (x) => x.dataset.id === listItem?.dataset.id
+    )
+
+    const optionTitle = listItem?.dataset.text?.trim() ?? 'Item'
+    const totalItems = listItems.length
+
+    const message = `List reordered, ${optionTitle} is now option ${newPositionIdx + 1} of ${totalItems}.`
+
+    clearTimeout(this.announceTimeout)
+    this.announceTimeout = setTimeout(() => {
+      if (this.announcementRegion) {
+        this.announcementRegion.textContent = message
+        setTimeout(() => {
+          if (
+            this.announcementRegion &&
+            this.announcementRegion.textContent === message
+          ) {
+            this.announcementRegion.textContent = ''
+          }
+        }, this.announceClearTimeMs)
+      }
+    }, this.announceDisplayTimeMs)
+  }
 }
 
 export class ListSortableEventListeners extends ListEventListeners {
@@ -250,9 +304,10 @@ export class ListSortableEventListeners extends ListEventListeners {
       () => {
         // Do nothing
       },
-      () => {
+      (e) => {
         this._listQuestion.resyncPreviewAfterReorder()
         this._listSortableElements.updateMoveButtons()
+        this._listSortableElements.announceReorder(e.item)
       }
     )
 
@@ -288,10 +343,12 @@ export class ListSortableEventListeners extends ListEventListeners {
               ? (target, e) => {
                   e.preventDefault()
                   this._listSortableElements.moveUp(this, target)
+                  this._listSortableElements.announceReorder(target)
                 }
               : (target, e) => {
                   e.preventDefault()
                   this._listSortableElements.moveDown(this, target)
+                  this._listSortableElements.announceReorder(target)
                 },
             'click'
           )

--- a/designer/client/src/javascripts/preview/list-sortable.js
+++ b/designer/client/src/javascripts/preview/list-sortable.js
@@ -11,6 +11,7 @@ import {
   ListQuestionElements
 } from '~/src/javascripts/preview/list'
 
+const APP_REORDERABLE_LIST_ITEM = '.app-reorderable-list__item'
 const REORDER_BUTTON_HIDDEN = 'reorder-button-hidden'
 
 const OK_200 = 200
@@ -207,7 +208,7 @@ export class ListSortableQuestionElements extends ListQuestionElements {
    */
   moveUp(listenerClass, target) {
     if (target.classList.contains('js-reorderable-list-up')) {
-      const item = target.closest('.app-reorderable-list__item')
+      const item = target.closest(APP_REORDERABLE_LIST_ITEM)
       const prevItem = item?.previousElementSibling
       if (prevItem && item.parentNode) {
         item.parentNode.insertBefore(item, prevItem)
@@ -224,7 +225,7 @@ export class ListSortableQuestionElements extends ListQuestionElements {
    */
   moveDown(listenerClass, target) {
     if (target.classList.contains('js-reorderable-list-down')) {
-      const item = target.closest('.app-reorderable-list__item')
+      const item = target.closest(APP_REORDERABLE_LIST_ITEM)
       const nextItem = item?.nextElementSibling
       if (nextItem && item.parentNode) {
         item.parentNode.insertBefore(nextItem, item)
@@ -245,11 +246,11 @@ export class ListSortableQuestionElements extends ListQuestionElements {
     }
 
     const listItem = /** @type { HTMLElement | null } */ (
-      movedItem.closest('.app-reorderable-list__item')
+      movedItem.closest(APP_REORDERABLE_LIST_ITEM)
     )
     const listItems = /** @type {HTMLElement[]} */ (
       Array.from(
-        this.sortableContainer.querySelectorAll('.app-reorderable-list__item')
+        this.sortableContainer.querySelectorAll(APP_REORDERABLE_LIST_ITEM)
       )
     )
     const newPositionIdx = listItems.findIndex(

--- a/designer/client/src/javascripts/preview/list-sortable.test.js
+++ b/designer/client/src/javascripts/preview/list-sortable.test.js
@@ -353,19 +353,25 @@ describe('list-sortable', () => {
     })
 
     describe('announceReorder', () => {
-      // TODO - change test for announcement
-      it('should focus button if button remains visible - move down', () => {
+      it('should focus button if button remains visible - move down', async () => {
         document.body.innerHTML =
+          '<div class="govuk-visually-hidden" id="reorder-announcement" aria-live="polite" aria-atomic="true"></div>' +
           '<button id="edit-options-button">Re-order</button>' +
           '<button id="add-option-button">Add item</button>' +
           list1HTML
         const listSortable = new ListSortableQuestionElements()
-        const downButtonFirstRow = /** @type {HTMLElement} */ (
-          document.getElementById('first-row-down')
+        const announcementRegion = /** @type {HTMLElement} */ (
+          document.getElementById('reorder-announcement')
         )
-        jest.spyOn(downButtonFirstRow, 'focus')
-        listSortable.setMoveFocus(downButtonFirstRow)
-        expect(downButtonFirstRow.focus).toHaveBeenCalled()
+        const upButtonLastRow = /** @type {HTMLElement} */ (
+          document.getElementById('last-row-up')
+        )
+        expect(announcementRegion.textContent).toBe('')
+        listSortable.announceReorder(upButtonLastRow)
+        await new Promise((_resolve) => setTimeout(_resolve, 2000))
+        expect(announcementRegion.textContent).toBe(
+          'List reordered, Option 4 is now option 4 of 4.'
+        )
       })
     })
   })

--- a/designer/client/src/javascripts/preview/list-sortable.test.js
+++ b/designer/client/src/javascripts/preview/list-sortable.test.js
@@ -353,13 +353,14 @@ describe('list-sortable', () => {
     })
 
     describe('announceReorder', () => {
-      it('should focus button if button remains visible - move down', async () => {
+      it('should announce, then clear announcement fater a timeout', async () => {
         document.body.innerHTML =
           '<div class="govuk-visually-hidden" id="reorder-announcement" aria-live="polite" aria-atomic="true"></div>' +
           '<button id="edit-options-button">Re-order</button>' +
           '<button id="add-option-button">Add item</button>' +
           list1HTML
         const listSortable = new ListSortableQuestionElements()
+        listSortable.announceClearTimeMs = 1000
         const announcementRegion = /** @type {HTMLElement} */ (
           document.getElementById('reorder-announcement')
         )
@@ -368,10 +369,28 @@ describe('list-sortable', () => {
         )
         expect(announcementRegion.textContent).toBe('')
         listSortable.announceReorder(upButtonLastRow)
-        await new Promise((_resolve) => setTimeout(_resolve, 2000))
+        await new Promise((_resolve) => setTimeout(_resolve, 500))
         expect(announcementRegion.textContent).toBe(
           'List reordered, Option 4 is now option 4 of 4.'
         )
+        await new Promise((_resolve) => setTimeout(_resolve, 1000))
+        expect(announcementRegion.textContent).toBe('')
+      })
+
+      it('should ignore if no announcement region', async () => {
+        document.body.innerHTML =
+          '<button id="edit-options-button">Re-order</button>' +
+          '<button id="add-option-button">Add item</button>' +
+          list1HTML
+        const listSortable = new ListSortableQuestionElements()
+        listSortable.announceClearTimeMs = 1000
+        listSortable.announceReorder(
+          /** @type {HTMLElement} */ (
+            document.getElementById('edit-options-button')
+          )
+        )
+        await new Promise((_resolve) => setTimeout(_resolve, 500))
+        expect(listSortable.announcementRegion).toBeNull()
       })
     })
   })

--- a/designer/client/src/javascripts/preview/list-sortable.test.js
+++ b/designer/client/src/javascripts/preview/list-sortable.test.js
@@ -351,6 +351,23 @@ describe('list-sortable', () => {
         expect(upButtonLastRow.focus).toHaveBeenCalled()
       })
     })
+
+    describe('announceReorder', () => {
+      // TODO - change test for announcement
+      it('should focus button if button remains visible - move down', () => {
+        document.body.innerHTML =
+          '<button id="edit-options-button">Re-order</button>' +
+          '<button id="add-option-button">Add item</button>' +
+          list1HTML
+        const listSortable = new ListSortableQuestionElements()
+        const downButtonFirstRow = /** @type {HTMLElement} */ (
+          document.getElementById('first-row-down')
+        )
+        jest.spyOn(downButtonFirstRow, 'focus')
+        listSortable.setMoveFocus(downButtonFirstRow)
+        expect(downButtonFirstRow.focus).toHaveBeenCalled()
+      })
+    })
   })
 
   describe('ListSortableEventListeners', () => {

--- a/designer/client/src/javascripts/preview/list-sortable.test.js
+++ b/designer/client/src/javascripts/preview/list-sortable.test.js
@@ -663,5 +663,119 @@ describe('list-sortable', () => {
         method: 'POST'
       })
     })
+
+    it('updateStateInSession should handle successful API call', async () => {
+      jest
+        .spyOn(global, 'fetch')
+        // @ts-expect-error - Response type
+        .mockImplementation(() => Promise.resolve({ status: 200 }))
+
+      // eslint-disable-next-line no-global-assign
+      window = Object.create(window)
+      const url = 'http://localhost:3000/'
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: url
+        },
+        writable: true // possibility to override
+      })
+
+      document.body.innerHTML =
+        '<button id="edit-options-button">Done</button>' +
+        '<button id="add-option-button">Add item</button>' +
+        list1HTML
+      const preview = ListSortable.setupPreview()
+      expect(preview._list.size).toBe(4)
+      preview.updateStateInSession()
+      await new Promise((_resolve) => setTimeout(_resolve, 1000))
+      expect(global.fetch).toHaveBeenCalledWith(expect.anything(), {
+        body: JSON.stringify({
+          listItems: [
+            {
+              id: 'dc96bf7a-07a0-4f5b-ba6d-c5c4c9d381de',
+              text: 'Option 1',
+              value: 'option-1'
+            },
+            {
+              id: '21e58240-5d0a-4e52-8003-3d99f318beb8',
+              text: 'Option 2',
+              value: 'option-2'
+            },
+            {
+              id: '80c4cb93-f079-4836-93f9-509e683e5004',
+              text: 'Option 3',
+              value: 'option-3'
+            },
+            {
+              id: 'ade6652f-b67e-4665-bf07-66f03877b5c6',
+              text: 'Option 4',
+              hint: { text: 'hint 4' },
+              value: 'option-4'
+            }
+          ]
+        }),
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        method: 'POST'
+      })
+    })
+
+    it('updateStateInSession should handle failed API call with error code being returned', async () => {
+      jest
+        .spyOn(global, 'fetch')
+        // @ts-expect-error - Response type
+        .mockImplementation(() => Promise.resolve({ status: 500 }))
+
+      // eslint-disable-next-line no-global-assign
+      window = Object.create(window)
+      const url = 'http://localhost:3000/'
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: url
+        },
+        writable: true // possibility to override
+      })
+
+      document.body.innerHTML =
+        '<button id="edit-options-button">Done</button>' +
+        '<button id="add-option-button">Add item</button>' +
+        list1HTML
+      const preview = ListSortable.setupPreview()
+      expect(preview._list.size).toBe(4)
+      preview.updateStateInSession()
+      await new Promise((_resolve) => setTimeout(_resolve, 1000))
+      expect(window.location.href).toBe(
+        'http://localhost:3000//editor-v2/error'
+      )
+    })
+
+    it('updateStateInSession should handle thrown API call error', async () => {
+      jest
+        .spyOn(global, 'fetch')
+        .mockImplementation(() => Promise.reject(new Error('api error')))
+
+      // eslint-disable-next-line no-global-assign
+      window = Object.create(window)
+      const url = 'http://localhost:3000/'
+      Object.defineProperty(window, 'location', {
+        value: {
+          href: url
+        },
+        writable: true // possibility to override
+      })
+
+      document.body.innerHTML =
+        '<button id="edit-options-button">Done</button>' +
+        '<button id="add-option-button">Add item</button>' +
+        list1HTML
+      const preview = ListSortable.setupPreview()
+      expect(preview._list.size).toBe(4)
+      preview.updateStateInSession()
+      await new Promise((_resolve) => setTimeout(_resolve, 1000))
+      expect(window.location.href).toBe(
+        'http://localhost:3000//editor-v2/error'
+      )
+    })
   })
 })

--- a/designer/client/src/javascripts/preview/list-sortable.test.js
+++ b/designer/client/src/javascripts/preview/list-sortable.test.js
@@ -2,7 +2,9 @@ import { ComponentType } from '@defra/forms-model'
 
 import {
   list1HTML,
-  listEmptyHTML
+  listEmptyHTML,
+  listSingleEntryDownHTML,
+  listSingleEntryUpHTML
 } from '~/src/javascripts/preview/__stubs__/list'
 import {
   questionDetailsLeftPanelHTML,
@@ -260,6 +262,27 @@ describe('list-sortable', () => {
         expect(mockResync).not.toHaveBeenCalled()
       })
 
+      it('should not error for move up if no siblings', () => {
+        document.body.innerHTML =
+          '<button id="edit-options-button">Re-order</button>' +
+          '<button id="add-option-button">Add item</button>' +
+          listSingleEntryUpHTML
+        const preview = ListSortable.setupPreview()
+        const upButtons = Array.from(
+          document.querySelectorAll('.js-reorderable-list-up')
+        )
+        const upButton = /** @type {HTMLElement} */ (
+          upButtons.find((x) => x.id === 'first-row-up')
+        )
+        expect(upButtons.findIndex((x) => x.id === 'first-row-up')).toBe(0)
+        preview._listElements.moveUp(mockListenerClass, upButton)
+        const upButtonsAfter = Array.from(
+          document.querySelectorAll('.js-reorderable-list-up')
+        )
+        expect(upButtonsAfter.findIndex((x) => x.id === 'first-row-up')).toBe(0)
+        expect(mockResync).toHaveBeenCalled()
+      })
+
       it('should move down if correct class', () => {
         document.body.innerHTML =
           '<button id="edit-options-button">Re-order</button>' +
@@ -299,6 +322,23 @@ describe('list-sortable', () => {
         downButton.classList.remove('js-reorderable-list-down')
         preview._listElements.moveDown(mockListenerClass, downButton)
         expect(mockResync).not.toHaveBeenCalled()
+      })
+
+      it('should not error if down has no siblings', () => {
+        document.body.innerHTML =
+          '<button id="edit-options-button">Re-order</button>' +
+          '<button id="add-option-button">Add item</button>' +
+          listSingleEntryDownHTML
+        const preview = ListSortable.setupPreview()
+        const downButtons = Array.from(
+          document.querySelectorAll('.js-reorderable-list-down')
+        )
+        const downButton = /** @type {HTMLElement} */ (
+          downButtons.find((x) => x.id === 'first-row-down')
+        )
+        expect(downButtons.findIndex((x) => x.id === 'first-row-down')).toBe(0)
+        preview._listElements.moveDown(mockListenerClass, downButton)
+        expect(mockResync).toHaveBeenCalled()
       })
     })
 
@@ -349,6 +389,21 @@ describe('list-sortable', () => {
         listSortable.setMoveFocus(downButtonLastRow)
         expect(downButtonLastRow.focus).not.toHaveBeenCalled()
         expect(upButtonLastRow.focus).toHaveBeenCalled()
+      })
+
+      it('should not error if no sibling', () => {
+        document.body.innerHTML =
+          '<button id="edit-options-button">Re-order</button>' +
+          '<button id="add-option-button">Add item</button>' +
+          listSingleEntryDownHTML
+        const listSortable = new ListSortableQuestionElements()
+        const downButtonFirstRow = /** @type {HTMLElement} */ (
+          document.getElementById('first-row-down')
+        )
+        jest.spyOn(downButtonFirstRow, 'focus')
+        downButtonFirstRow.classList.add('reorder-button-hidden')
+        listSortable.setMoveFocus(downButtonFirstRow)
+        expect(downButtonFirstRow.focus).not.toHaveBeenCalled()
       })
     })
 
@@ -496,6 +551,53 @@ describe('list-sortable', () => {
           document.getElementById('last-row-up')
         )
         expect(upButtonLastRow).toBeDefined()
+      })
+
+      it('should ignore if not reordering', () => {
+        document.body.innerHTML =
+          '<button id="edit-options-button">Done</button>' +
+          '<button id="add-option-button">Add item</button>' +
+          list1HTML
+        ListSortable.setupPreview()
+        const reorderButton = /** @type {HTMLElement} */ (
+          document.getElementById('edit-options-button')
+        )
+        reorderButton.click()
+        const upButtonLastRow = /** @type {HTMLElement} */ (
+          document.getElementById('last-row-up')
+        )
+        expect(upButtonLastRow.dataset.click).toBeUndefined()
+      })
+
+      it('should ignore if not an up or down button', () => {
+        document.body.innerHTML =
+          '<button id="edit-options-button">Re-order</button>' +
+          '<button id="add-option-button">Add item</button>' +
+          list1HTML
+        const upButtons = /** @type {HTMLElement[]} */ (
+          Array.from(document.getElementsByClassName('js-reorderable-list-up'))
+        )
+        const downButtons = /** @type {HTMLElement[]} */ (
+          Array.from(
+            document.getElementsByClassName('js-reorderable-list-down')
+          )
+        )
+        upButtons.forEach((x) => {
+          x.textContent = 'Not up or down'
+        })
+        downButtons.forEach((x) => {
+          x.textContent = 'Not up or down'
+        })
+
+        ListSortable.setupPreview()
+        const reorderButton = /** @type {HTMLElement} */ (
+          document.getElementById('edit-options-button')
+        )
+        reorderButton.click()
+        const upButtonLastRow = /** @type {HTMLElement} */ (
+          document.getElementById('last-row-up')
+        )
+        expect(upButtonLastRow.dataset.click).toBeUndefined()
       })
     })
   })

--- a/designer/server/src/views/forms/editor-v2/custom-templates/radios-or-checkboxes.njk
+++ b/designer/server/src/views/forms/editor-v2/custom-templates/radios-or-checkboxes.njk
@@ -7,6 +7,8 @@
 {% set radioHintIdx = 2 %}
 {% set radioValueIdx = 3 %}
 
+<div class="govuk-visually-hidden" id="reorder-announcement" aria-live="polite" aria-atomic="true"></div>
+
 <div class="govuk-form-group" id="list-items">
   <h2 class="govuk-heading-m" tabindex="-1">
     <svg class="govuk-!-margin-right-1" style="position: relative; top: -1px; vertical-align: middle;" width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -77,6 +79,7 @@
   {% else %}
     <ol class="app-reorderable-list js-enabled" id="options-container" data-module="reorderable-list">
     {% if state.listItems | length or state.editRow.expanded %}
+      {% set itemsCount = state.listItems | length %}
       {% for item in state.listItems %}
         {% set isFirst = loop.first %}
         {% set isLast = loop.last %}


### PR DESCRIPTION
Added screenreader announcements
Local test coverage shows 94.07% whereas SonarCloud is always reporting 84.2% no matter how many extra tests I add.