### PR TITLE
fix: Failing client side nunjucks build

### DIFF
--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -238,6 +238,10 @@ export default /** @type {Configuration} */ ({
           to: 'assets'
         },
         {
+          from: join(import.meta.dirname, 'client/src/views'),
+          to: 'views'
+        },
+        {
           from: 'i18n/translations',
           to: 'assets/translations'
         }


### PR DESCRIPTION
This should fix dev being down.  The nunjucks templates that are referenced on server were missing from the build.