### PR TITLE
Add repeater text to the pages overview

### DIFF
--- a/designer/server/src/__stubs__/form-definition.js
+++ b/designer/server/src/__stubs__/form-definition.js
@@ -769,5 +769,75 @@ export const testFormDefinitionWithOneQuestionNoPageTitle = {
 }
 
 /**
+ * @satisfies {FormDefinition}
+ */
+export const testFormDefinitionWithRepeater = {
+  name: 'Test form',
+  pages: [
+    {
+      id: 'p1',
+      path: '/pizza',
+      title: 'Pizza',
+      controller: ControllerType.Repeat,
+      repeat: {
+        schema: { min: 1, max: 5 },
+        options: { title: 'Pizza', name: 'xdGhbu' }
+      },
+      section: 'section',
+      components: [
+        {
+          id: 'q1',
+          type: ComponentType.TextField,
+          name: 'toppings',
+          title: 'Toppings',
+          options: {},
+          schema: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      id: 'p2',
+      path: '/page-two',
+      title: 'Page two',
+      section: 'section',
+      components: [
+        {
+          id: 'q1',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your first question - page two',
+          hint: 'Help text',
+          options: {},
+          schema: {}
+        },
+        {
+          id: 'q2',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your second question - page two',
+          hint: 'Help text',
+          options: {
+            required: false
+          },
+          schema: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      id: 'p3',
+      title: 'Summary',
+      path: '/summary',
+      controller: ControllerType.Summary,
+      components: []
+    }
+  ],
+  conditions: [],
+  sections: [],
+  lists: []
+}
+
+/**
  * @import { FormDefinition, PageQuestion, PageSummary, TextFieldComponent, FileUploadFieldComponent, AutocompleteFieldComponent, List, Item, RadiosFieldComponent, CheckboxesFieldComponent } from '@defra/forms-model'
  */

--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -79,11 +79,20 @@ export function mapQuestionRows(page) {
 
   const isSummary = page.controller === ControllerType.Summary
 
-  return components.map((comp, idx) =>
+  const rows = components.map((comp, idx) =>
     comp.type === ComponentType.Markdown
       ? mapMarkdown(comp, isSummary)
       : mapQuestion(comp, idx)
   )
+
+  if (page.controller === ControllerType.Repeat) {
+    rows.push({
+      key: { text: 'People can answer' },
+      value: { text: 'More than once' }
+    })
+  }
+
+  return rows
 }
 
 /**

--- a/designer/server/src/models/forms/editor-v2/pages.test.js
+++ b/designer/server/src/models/forms/editor-v2/pages.test.js
@@ -5,6 +5,7 @@ import {
   testFormDefinitionWithExistingSummaryDeclaration,
   testFormDefinitionWithNoPages,
   testFormDefinitionWithNoQuestions,
+  testFormDefinitionWithRepeater,
   testFormDefinitionWithTwoPagesAndQuestions,
   testFormDefinitionWithTwoQuestions
 } from '~/src/__stubs__/form-definition.js'
@@ -71,9 +72,11 @@ describe('editor-v2 - pages model', () => {
       const resPageSummaryQuestions = mapQuestionRows(
         testFormDefinitionWithTwoPagesAndQuestions.pages[2]
       )
-
       const resPageSummaryExistingMarkdown = mapQuestionRows(
         testFormDefinitionWithExistingSummaryDeclaration.pages[1]
+      )
+      const resPageSummaryRepeater = mapQuestionRows(
+        testFormDefinitionWithRepeater.pages[0]
       )
 
       expect(resPageOneQuestions).toHaveLength(2)
@@ -121,6 +124,17 @@ describe('editor-v2 - pages model', () => {
         value: {
           html: '<pre class="break-on-newlines"><p class="govuk-body">Declaration text</p></pre>',
           classes: 'with-ellipsis'
+        }
+      })
+
+      expect(resPageSummaryRepeater).toHaveLength(2)
+
+      expect(resPageSummaryRepeater[1]).toEqual({
+        key: {
+          text: 'People can answer'
+        },
+        value: {
+          text: 'More than once'
         }
       })
     })


### PR DESCRIPTION
Add missing flow 5:

Flow 5 – Display Question Listing Page

GIVEN I can see the Question overview page

AND I have finished configuring all the question pages I need

WHEN I select the back to all pages button

THEN the question listing page is displayed as per link whereby there is a row at the bottom of the summary list of said page called:

**People can answer More than once**

https://www.figma.com/design/1A9Tthy0CJeqp2rGNSKRjH/Defra-Form-Builder-flows?node-id=13384-96824&t=SkztKcLLhVb3YlXQ-4

![image](https://github.com/user-attachments/assets/6870d9a0-f6b0-41e3-bf0b-a423d3102b3b)
