### PR TITLE
Add forms prefix to preview URLs

### DIFF
--- a/designer/client/src/components/Menu/SubMenu.tsx
+++ b/designer/client/src/components/Menu/SubMenu.tsx
@@ -15,7 +15,7 @@ export function SubMenu({ overview }: Readonly<Props>) {
   const fileInput = useRef<HTMLInputElement>(null)
 
   const { href: formPreviewLink } = new URL(
-    `/preview/draft/${meta.slug}`,
+    `/form/preview/draft/${meta.slug}`,
     previewUrl
   )
 

--- a/designer/client/src/components/Page/Page.tsx
+++ b/designer/client/src/components/Page/Page.tsx
@@ -84,7 +84,7 @@ export const Page = (
   const headingId = `${pageId}-heading`
 
   const href = new URL(
-    `/preview/draft/${meta.slug}${page.path}?force`,
+    `/form/preview/draft/${meta.slug}${page.path}?force`,
     previewUrl
   ).toString()
 

--- a/designer/client/src/javascripts/preview/__stubs__/question.js
+++ b/designer/client/src/javascripts/preview/__stubs__/question.js
@@ -280,7 +280,7 @@ export function questionDetailsLeftPanelBuilder(listItemsHTML) {
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
       <div class="govuk-button-group govuk-!-margin-top-6">
-        <a class="govuk-button govuk-button--inverse" data-module="govuk-button" href="/preview/draft/form-to-go-live/pick-your-quest?force" id="preview-page" role="button" target="_blank">
+        <a class="govuk-button govuk-button--inverse" data-module="govuk-button" href="/form/preview/draft/form-to-go-live/pick-your-quest?force" id="preview-page" role="button" target="_blank">
           <span class="icon-wrapper">
             <!-- Your SVG icon -->
             <svg width="24" height="17" viewBox="0 0 24 17" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -6,6 +6,7 @@ import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
 import { createLogger } from '~/src/common/helpers/logging/logger.js'
 import { buildNavigation } from '~/src/common/nunjucks/context/build-navigation.js'
 import config from '~/src/config.js'
+import { buildPreviewUrl } from '~/src/models/forms/editor-v2/common.js'
 
 const logger = createLogger()
 const { cdpEnvironment, phase, serviceName, serviceVersion } = config
@@ -44,7 +45,10 @@ export async function context(request) {
     isAuthenticated: request?.auth?.isAuthenticated ?? false,
     isAuthorized: request?.auth?.isAuthorized ?? false,
     isFormsUser: credentials?.scope?.includes(SCOPE_READ) ?? false, // isAuthorized may be true if no scopes are required for the route
-    authedUser: credentials?.user
+    authedUser: credentials?.user,
+    helpers: {
+      buildPreviewUrl
+    }
   }
 }
 

--- a/designer/server/src/common/nunjucks/context/index.js
+++ b/designer/server/src/common/nunjucks/context/index.js
@@ -6,7 +6,10 @@ import { getUserSession } from '~/src/common/helpers/auth/get-user-session.js'
 import { createLogger } from '~/src/common/helpers/logging/logger.js'
 import { buildNavigation } from '~/src/common/nunjucks/context/build-navigation.js'
 import config from '~/src/config.js'
-import { buildPreviewUrl } from '~/src/models/forms/editor-v2/common.js'
+import {
+  buildFormUrl,
+  buildPreviewUrl
+} from '~/src/models/forms/editor-v2/common.js'
 
 const logger = createLogger()
 const { cdpEnvironment, phase, serviceName, serviceVersion } = config
@@ -47,6 +50,7 @@ export async function context(request) {
     isFormsUser: credentials?.scope?.includes(SCOPE_READ) ?? false, // isAuthorized may be true if no scopes are required for the route
     authedUser: credentials?.user,
     helpers: {
+      buildFormUrl,
       buildPreviewUrl
     }
   }

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -118,10 +118,13 @@ export function buildPreviewUrl(slug, status) {
 }
 
 /**
- * @param {string} slug
+ * Builds a URL for previewing error messages for a question based on its slug.
+ * @param {string} slug - The unique identifier for the form.
  */
 export function buildPreviewErrorsUrl(slug) {
-  return `${config.previewUrl}/error-preview/draft/${slug}`
+  const encodedSlug = encodeURIComponent(slug)
+
+  return `${config.previewUrl}/error-preview/draft/${encodedSlug}`
 }
 
 /**

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -106,6 +106,16 @@ export function baseModelFields(slug, pageTitle, pageHeading) {
 }
 
 /**
+ * Builds a live form URL based on its slug.
+ * @param {string} slug - The unique identifier for the form.
+ */
+export function buildFormUrl(slug) {
+  const encodedSlug = encodeURIComponent(slug)
+
+  return `${config.previewUrl}/form/${encodedSlug}`
+}
+
+/**
  * Builds a URL for previewing a form based on its slug and status.
  * @param {string} slug - The unique identifier for the form.
  * @param {FormStatus} status - The current status of the form.

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -106,10 +106,15 @@ export function baseModelFields(slug, pageTitle, pageHeading) {
 }
 
 /**
- * @param {string} slug
+ * Builds a URL for previewing a form based on its slug and status.
+ * @param {string} slug - The unique identifier for the form.
+ * @param {FormStatus} status - The current status of the form.
  */
-export function buildPreviewUrl(slug) {
-  return `${config.previewUrl}/preview/draft/${slug}`
+export function buildPreviewUrl(slug, status) {
+  const encodedSlug = encodeURIComponent(slug)
+  const encodedStatus = encodeURIComponent(status)
+
+  return `${config.previewUrl}/form/preview/${encodedStatus}/${encodedSlug}`
 }
 
 /**
@@ -141,5 +146,5 @@ export function tickBoxes(items, selectedItems) {
 }
 
 /**
- * @import { ComponentDef, FormMetadata, FormDefinition } from '@defra/forms-model'
+ * @import { ComponentDef, FormMetadata, FormDefinition, FormStatus } from '@defra/forms-model'
  */

--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -1,6 +1,7 @@
 import {
   ComponentType,
   ControllerType,
+  FormStatus,
   hasComponents,
   hasComponentsEvenIfNoNext,
   isFormType
@@ -163,7 +164,7 @@ export function hideFirstGuidance(page) {
 export function pagesViewModel(metadata, definition, notification) {
   const formPath = formOverviewPath(metadata.slug)
   const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
-  const previewBaseUrl = buildPreviewUrl(metadata.slug)
+  const previewBaseUrl = buildPreviewUrl(metadata.slug, FormStatus.Draft)
 
   const pageActions = [
     {

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -1,4 +1,4 @@
-import { randomId } from '@defra/forms-model'
+import { FormStatus, randomId } from '@defra/forms-model'
 
 import { QuestionTypeDescriptions } from '~/src/common/constants/editor.js'
 import { buildErrorList } from '~/src/common/helpers/build-error-details.js'
@@ -237,7 +237,7 @@ export function questionDetailsViewModel(
   )
   const extraFieldNames = extraFields.map((field) => field.name ?? 'unknown')
   const errorList = buildErrorList(validation?.formErrors)
-  const previewPageUrl = `${buildPreviewUrl(metadata.slug)}${details.pagePath}?force`
+  const previewPageUrl = `${buildPreviewUrl(metadata.slug, FormStatus.Draft)}${details.pagePath}?force`
   const previewErrorsUrl = `${buildPreviewErrorsUrl(metadata.slug)}${details.pagePath}/${questionFieldsOverride.id}`
   const urlPageBase = editorv2Path(metadata.slug, `page/${pageId}`)
   const deleteUrl = `${urlPageBase}/delete/${questionId}`

--- a/designer/server/src/models/forms/editor-v2/questions.js
+++ b/designer/server/src/models/forms/editor-v2/questions.js
@@ -1,6 +1,7 @@
 import {
   ComponentType,
   ControllerType,
+  FormStatus,
   hasComponents,
   isFormType
 } from '@defra/forms-model'
@@ -283,7 +284,7 @@ export function questionsViewModel(
       (comp) => comp.type === ComponentType.FileUploadField
     ),
     notification,
-    previewPageUrl: `${buildPreviewUrl(metadata.slug)}${page.path}?force`
+    previewPageUrl: `${buildPreviewUrl(metadata.slug, FormStatus.Draft)}${page.path}?force`
   }
 }
 

--- a/designer/server/src/views/forms/partials/overview-draft.njk
+++ b/designer/server/src/views/forms/partials/overview-draft.njk
@@ -13,7 +13,7 @@
 {% endset %}
 
 {% set formPreviewLink %}
-  {% set linkHref = previewUrl + "/preview/draft/" + form.slug | urlencode %}
+  {% set linkHref = helpers.buildPreviewUrl(form.slug, "draft") %}
   <a href="{{ linkHref }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noreferrer noopener">
     {{ linkHref }} (opens in a new tab)
   </a>

--- a/designer/server/src/views/forms/partials/overview-live.njk
+++ b/designer/server/src/views/forms/partials/overview-live.njk
@@ -13,7 +13,7 @@
 {% endset %}
 
 {% set formPreviewLink %}
-  {% set linkHref = previewUrl + "/preview/live/" + form.slug | urlencode %}
+  {% set linkHref = helpers.buildPreviewUrl(form.slug, "live") %}
   <a href="{{ linkHref }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noreferrer noopener">
     {{ linkHref }} (opens in a new tab)
   </a>

--- a/designer/server/src/views/forms/partials/overview-live.njk
+++ b/designer/server/src/views/forms/partials/overview-live.njk
@@ -20,7 +20,7 @@
 {% endset %}
 
 {% set formLink %}
-  {% set linkHref = previewUrl + "/" + form.slug | urlencode %}
+  {% set linkHref = helpers.buildFormUrl(form.slug) %}
   <a href="{{ linkHref }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noreferrer noopener">
     {{ linkHref }} (opens in a new tab)
   </a>


### PR DESCRIPTION
- Tactically patch the legacy editor
- Adds `forms/` prefix to buildPreviewUrl
- Removes manual URL creation in Nunjucks, instead passing the helper through the context
- Create new `buildFormUrl` helper to bring it into alignment with preview/error messages URL building.