### PR TITLE
Fix/readonly modifier

### DIFF
--- a/model/src/form/form-editor/preview/list.js
+++ b/model/src/form/form-editor/preview/list.js
@@ -117,7 +117,6 @@ export class ListQuestion extends Question {
 
   /**
    * @returns {ListItemReadonly[]}
-   * @readonly
    */
   get list() {
     const iterator = /** @type {MapIterator<ListElement>} */ (

--- a/model/src/form/form-editor/preview/list.js
+++ b/model/src/form/form-editor/preview/list.js
@@ -208,5 +208,5 @@ export class ListQuestion extends Question {
 
 /**
  * @import { ListElement, ListItemReadonly } from '~/src/form/form-editor/types.js'
- * @import { ListenerRow, ListElements, QuestionRenderer, HTMLBuilder, DefaultComponent, GovukFieldset } from '~/src/form/form-editor/preview/types.js'
+ * @import { ListElements, QuestionRenderer, DefaultComponent, GovukFieldset } from '~/src/form/form-editor/preview/types.js'
  */


### PR DESCRIPTION
Fixes:

> Error TS1024: 'readonly' modifier can only appear on a property declaration or index signature.

67     readonly get list(): ListItemReadonly[];