### PR TITLE
fix 551320: capitalise first letter on error preview

### DIFF
--- a/designer/client/src/javascripts/error-preview/error-preview.js
+++ b/designer/client/src/javascripts/error-preview/error-preview.js
@@ -2,6 +2,7 @@ import {
   ComponentType,
   allowedErrorTemplateFunctions
 } from '@defra/forms-model'
+import capitalize from 'lodash/capitalize.js'
 import lowerFirst from 'lodash/lowerFirst.js'
 
 import { fieldMappings } from '~/src/javascripts/error-preview/field-mappings'
@@ -94,8 +95,13 @@ export class ErrorPreviewDomElements {
    */
   applyTemplateFunction(elem, newText) {
     const func = elem?.dataset.templatefunc ?? ''
-    if (allowedErrorTemplateFunctions.includes(func) && func === 'lowerFirst') {
-      return this.lowerFirstEnhanced(newText)
+    if (allowedErrorTemplateFunctions.includes(func)) {
+      if (func === 'lowerFirst') {
+        return this.lowerFirstEnhanced(newText)
+      }
+      if (func === 'capitalise') {
+        return capitalize(newText)
+      }
     }
     return newText
   }
@@ -110,9 +116,17 @@ export class ErrorPreviewDomElements {
       if (elem) {
         const sourceText = source?.value ?? ''
         const newText = sourceText !== '' ? sourceText : placeholder
-        const newTextFinal = elem.dataset.templatefunc
+        let newTextFinal = elem.dataset.templatefunc
           ? this.applyTemplateFunction(elem, newText)
           : newText
+
+        if (
+          !elem.dataset.templatefunc &&
+          elem.classList.contains('error-preview-shortDescription')
+        ) {
+          newTextFinal = capitalize(newText)
+        }
+
         elem.textContent = newTextFinal
       }
     })

--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -606,4 +606,4 @@ export function govukFieldIsQuestionOptional(
 }
 
 // A list of allowed template funtions for use within error message templates
-export const allowedErrorTemplateFunctions = ['lowerFirst']
+export const allowedErrorTemplateFunctions = ['lowerFirst', 'capitalise']

--- a/model/src/form/form-manager/types.ts
+++ b/model/src/form/form-manager/types.ts
@@ -5,6 +5,7 @@ export interface PatchPageFields {
   path?: string
   controller?: ControllerType | null
   repeat?: Repeat
+  condition?: string | null
 }
 
 export interface AddComponentQueryOptions {


### PR DESCRIPTION
A fix following https://github.com/DEFRA/forms-designer/pull/871 to capitalise the first letter on the error descriptions:

<img width="1300" alt="Screenshot 2025-05-30 at 10 03 48" src="https://github.com/user-attachments/assets/861ce7f5-fa39-4ecd-b1c9-a5c63214f845" />
