### PR TITLE
Feat/551141  relaunch new editor

### DIFF
--- a/designer/client/src/stylesheets/_editor.scss
+++ b/designer/client/src/stylesheets/_editor.scss
@@ -614,3 +614,8 @@ p code {
   min-height: govuk-em(600px, $context-font-size: 16);
   padding-bottom: 0;
 }
+
+.govuk-button--secondary-defra-quiet {
+  color: $defra-brand-colour;
+  border-color: $defra-brand-colour;
+}

--- a/designer/client/src/stylesheets/_editor.scss
+++ b/designer/client/src/stylesheets/_editor.scss
@@ -615,7 +615,10 @@ p code {
   padding-bottom: 0;
 }
 
-.govuk-button--secondary-defra-quiet {
+.govuk-button--secondary-defra-quiet,
+.govuk-button--secondary-defra-quiet:link,
+.govuk-button--secondary-defra-quiet:hover,
+.govuk-button--secondary-defra-quiet:visited {
   color: $defra-brand-colour;
   border-color: $defra-brand-colour;
 }

--- a/designer/client/src/stylesheets/variables/_colours.scss
+++ b/designer/client/src/stylesheets/variables/_colours.scss
@@ -8,3 +8,4 @@ $app-action-border-color: govuk-shade(govuk-colour("light-grey"), 40%);
 $app-action-divider-color: govuk-shade(govuk-colour("light-grey"), 10%);
 $app-action-focus-color: govuk-shade(govuk-colour("yellow"), 10%);
 $app-action-focus-border-color: govuk-shade(govuk-colour("yellow"), 60%);
+$defra-brand-colour: govuk-organisation-colour(department-for-environment-food-rural-affairs);

--- a/designer/package.json
+++ b/designer/package.json
@@ -123,7 +123,7 @@
     "terser-webpack-plugin": "^5.3.14",
     "tsx": "^4.19.4",
     "webpack": "~5.98.0",
-    "webpack-assets-manifest": "^5.2.1",
+    "webpack-assets-manifest": "^6.1.0",
     "webpack-cli": "^6.0.1"
   },
   "engines": {

--- a/designer/server/src/common/components/preview-panel/_preview-panel.scss
+++ b/designer/server/src/common/components/preview-panel/_preview-panel.scss
@@ -26,7 +26,7 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
 
     p {
       margin-bottom: 0;
-      color: #005a30;
+      color: $defra-brand-colour;
       padding: 2px 8px 3px;
       text-align: center;
     }

--- a/designer/server/src/lib/forms.test.js
+++ b/designer/server/src/lib/forms.test.js
@@ -1,4 +1,5 @@
-import { FormStatus } from '@defra/forms-model'
+import { FormStatus, SchemaVersion } from '@defra/forms-model'
+import { buildDefinition } from '@defra/forms-model/stubs'
 
 import config from '~/src/config.js'
 import { createServer } from '~/src/createServer.js'
@@ -345,6 +346,9 @@ describe('Forms library routes', () => {
 
     it('Form overview has live buttons in side bar', async () => {
       jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
+      jest
+        .mocked(forms.getDraftFormDefinition)
+        .mockResolvedValueOnce(buildDefinition({ schema: SchemaVersion.V2 }))
 
       const options = {
         method: 'get',

--- a/designer/server/src/models/forms/editor-v2/check-answers-settings.js
+++ b/designer/server/src/models/forms/editor-v2/check-answers-settings.js
@@ -73,7 +73,12 @@ export function checkAnswersSettingsViewModel(
 ) {
   const formTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
   const { formValues, formErrors } = validation ?? {}
 
   const page = getPageFromDefinition(definition, pageId)

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -67,11 +67,13 @@ export function getQuestion(definition, pageId, questionId) {
  * a page, that page will have isActive:true set.
  * @param {string} formPath
  * @param {FormMetadata} _metadata
+ * @param {FormDefinition} _formDefinition
  * @param {string} activePage
  */
 export function getFormSpecificNavigation(
   formPath,
   _metadata,
+  _formDefinition,
   activePage = ''
 ) {
   const navigationItems = [

--- a/designer/server/src/models/forms/editor-v2/conditions.js
+++ b/designer/server/src/models/forms/editor-v2/conditions.js
@@ -76,7 +76,12 @@ export function buildConditionsTable(slug, definition) {
  */
 export function conditionsViewModel(metadata, definition, notification) {
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
   const previewBaseUrl = buildPreviewUrl(metadata.slug, FormStatus.Draft)
   const pageHeading = 'Manage conditions'
   const pageCaption = metadata.title

--- a/designer/server/src/models/forms/editor-v2/guidance.js
+++ b/designer/server/src/models/forms/editor-v2/guidance.js
@@ -69,7 +69,12 @@ export function guidanceViewModel(
 ) {
   const formTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
   const { formValues, formErrors } = validation ?? {}
 
   const pageNum = getPageNum(definition, pageId)

--- a/designer/server/src/models/forms/editor-v2/migrate.js
+++ b/designer/server/src/models/forms/editor-v2/migrate.js
@@ -18,7 +18,7 @@ export function migrateConfirmationPageViewModel(metadata, formDefinition) {
     formDefinition,
     'Editor'
   )
-  const pageTitle = 'Do you want to migrate this form to version 2?'
+  const pageTitle = 'Are you sure you want to switch to the new editor?'
 
   return {
     ...baseModelFields(metadata.slug, `${pageTitle} - ${formTitle}`, formTitle),
@@ -27,11 +27,12 @@ export function migrateConfirmationPageViewModel(metadata, formDefinition) {
       text: metadata.title
     },
     bodyHeadingText: pageTitle,
-    bodyText:
-      'In order to use the new editor, this form needs to be migrated to version 2. <br><br> Migrating this form will mean it cannot be used within the old editor. This operation is irreversible.',
+    bodyWarning: {
+      text: "You won't be able to use the old editor for this form after switching."
+    },
     buttons: [
       {
-        text: 'Migrate',
+        text: 'Switch to new editor',
         classes: 'govuk-button--primary'
       },
       {

--- a/designer/server/src/models/forms/editor-v2/migrate.js
+++ b/designer/server/src/models/forms/editor-v2/migrate.js
@@ -7,11 +7,17 @@ import { formOverviewPath } from '~/src/models/links.js'
 /**
  * Model to represent confirmation page dialog for a given form.
  * @param {FormMetadata} metadata
+ * @param {FormDefinition} formDefinition
  */
-export function migrateConfirmationPageViewModel(metadata) {
+export function migrateConfirmationPageViewModel(metadata, formDefinition) {
   const formTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    formDefinition,
+    'Editor'
+  )
   const pageTitle = 'Do you want to migrate this form to version 2?'
 
   return {
@@ -38,5 +44,5 @@ export function migrateConfirmationPageViewModel(metadata) {
 }
 
 /**
- * @import { FormMetadata } from '@defra/forms-model'
+ * @import { FormMetadata, FormDefinition } from '@defra/forms-model'
  */

--- a/designer/server/src/models/forms/editor-v2/page.js
+++ b/designer/server/src/models/forms/editor-v2/page.js
@@ -8,14 +8,20 @@ import { formOverviewPath } from '~/src/models/links.js'
 
 /**
  * @param {FormMetadata} metadata
+ * @param {FormDefinition} formDefinition
  * @param {Partial<FormEditor>} [editor]
  * @param {ValidationFailure<FormEditor>} [validation]
  */
-export function pageViewModel(metadata, editor, validation) {
+export function pageViewModel(metadata, formDefinition, editor, validation) {
   const formTitle = metadata.title
   const pageHeading = 'What kind of page do you need?'
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    formDefinition,
+    'Editor'
+  )
   const { formValues, formErrors } = validation ?? {}
 
   return {
@@ -59,6 +65,6 @@ export function pageViewModel(metadata, editor, validation) {
 }
 
 /**
- * @import { FormMetadata, FormEditor } from '@defra/forms-model'
+ * @import { FormMetadata, FormEditor, FormDefinition } from '@defra/forms-model'
  * @import { ValidationFailure } from '~/src/common/helpers/types.js'
  */

--- a/designer/server/src/models/forms/editor-v2/pages-reorder.js
+++ b/designer/server/src/models/forms/editor-v2/pages-reorder.js
@@ -41,7 +41,12 @@ export function pagesReorderViewModel(metadata, definition, pageOrder, focus) {
   const formTitle = metadata.title
   const pageHeading = 'Re-order pages'
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
 
   const pageActions = [
     {

--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -163,7 +163,12 @@ export function hideFirstGuidance(page) {
  */
 export function pagesViewModel(metadata, definition, notification) {
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
   const previewBaseUrl = buildPreviewUrl(metadata.slug, FormStatus.Draft)
 
   const pageActions = [

--- a/designer/server/src/models/forms/editor-v2/question-delete.js
+++ b/designer/server/src/models/forms/editor-v2/question-delete.js
@@ -88,7 +88,12 @@ export function deleteQuestionConfirmationPageViewModel(
 ) {
   const formTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
 
   const page = getPageFromDefinition(definition, pageId)
   const components = hasComponents(page) ? page.components : []
@@ -123,6 +128,7 @@ export function deleteQuestionConfirmationPageViewModel(
  * Model to represent confirmation page dialog for a given form.
  * @param { QuestionSessionState | undefined } state
  * @param {FormMetadata} metadata
+ * @param {FormDefinition} definition
  * @param {string} pageId
  * @param {string} questionId
  * @param {string} stateId
@@ -131,6 +137,7 @@ export function deleteQuestionConfirmationPageViewModel(
 export function deleteListItemConfirmationPageViewModel(
   state,
   metadata,
+  definition,
   pageId,
   questionId,
   stateId,
@@ -138,7 +145,12 @@ export function deleteListItemConfirmationPageViewModel(
 ) {
   const formTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
   const listItem = state?.listItems?.find((x) => x.id === itemId)
   const pageHeading = 'Are you sure you want to delete this item?'
 

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -151,7 +151,12 @@ export function getDetails(
 
   return {
     pageTitle: metadata.title,
-    navigation: getFormSpecificNavigation(formPath, metadata, 'Editor'),
+    navigation: getFormSpecificNavigation(
+      formPath,
+      metadata,
+      definition,
+      'Editor'
+    ),
     question: questionOverride,
     questionNum,
     pageNum,

--- a/designer/server/src/models/forms/editor-v2/question-type.js
+++ b/designer/server/src/models/forms/editor-v2/question-type.js
@@ -213,7 +213,12 @@ export function questionTypeViewModel(
 ) {
   const formTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
   const { formValues, formErrors } = validation ?? {}
 
   const pageNum = getPageNum(definition, pageId)

--- a/designer/server/src/models/forms/editor-v2/questions.js
+++ b/designer/server/src/models/forms/editor-v2/questions.js
@@ -247,7 +247,12 @@ export function questionsViewModel(
 ) {
   const formTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
   const { formValues, formErrors } = validation ?? {}
 
   const pageIdx = definition.pages.findIndex((x) => x.id === pageId)

--- a/designer/server/src/models/forms/form-lifecycle.js
+++ b/designer/server/src/models/forms/form-lifecycle.js
@@ -5,13 +5,18 @@ import { formOverviewPath } from '~/src/models/links.js'
 /**
  * Model to represent confirmation page dialog for a given form.
  * @param {FormMetadata} form
+ * @param {FormDefinition} formDefinition
  * @param {ErrorDetailsItem[]} errorList - list of errors to display to the user
  */
-export function makeDraftLiveConfirmationPageViewModel(form, errorList) {
+export function makeDraftLiveConfirmationPageViewModel(
+  form,
+  formDefinition,
+  errorList
+) {
   const pageTitle = 'Are you sure you want to make the draft live?'
 
   const formPath = formOverviewPath(form.slug)
-  const navigation = getFormSpecificNavigation(formPath, form)
+  const navigation = getFormSpecificNavigation(formPath, form, formDefinition)
 
   return {
     navigation,
@@ -50,13 +55,18 @@ export function makeDraftLiveConfirmationPageViewModel(form, errorList) {
 /**
  * Model to represent confirmation page dialog for a given form.
  * @param {FormMetadata} form
+ * @param {FormDefinition} formDefinition
  * @param {ErrorDetailsItem[]} errorList - list of errors to display to the user
  */
-export function deleteDraftConfirmationPageViewModel(form, errorList) {
+export function deleteDraftConfirmationPageViewModel(
+  form,
+  formDefinition,
+  errorList
+) {
   const pageTitle = 'Are you sure you want to delete this form?'
 
   const formPath = formOverviewPath(form.slug)
-  const navigation = getFormSpecificNavigation(formPath, form)
+  const navigation = getFormSpecificNavigation(formPath, form, formDefinition)
 
   return {
     navigation,
@@ -85,6 +95,6 @@ export function deleteDraftConfirmationPageViewModel(form, errorList) {
 }
 
 /**
- * @import { FormMetadata } from '@defra/forms-model'
+ * @import { FormMetadata, FormDefinition } from '@defra/forms-model'
  * @import { ErrorDetailsItem } from '~/src/common/helpers/types.js'
  */

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -202,6 +202,42 @@ export function overviewViewModel(metadata, notification) {
 
   const navigation = getFormSpecificNavigation(formPath, metadata, 'Overview')
 
+  const v1Buttons = [
+    {
+      text: 'Edit draft (new editor)',
+      classes: 'govuk-button--secondary-defra-quiet'
+    },
+    {
+      text: 'Edit draft (legacy editor)',
+      classes: 'govuk-button--secondary-quiet'
+    },
+    {
+      text: 'Make draft live',
+      attributes: {
+        formaction: `${formPath}/make-draft-live`
+      }
+    }
+  ]
+
+  const v2Buttons = [
+    {
+      text: 'Edit draft',
+      classes: 'govuk-button--secondary-quiet'
+    },
+    {
+      text: 'Make draft live',
+      attributes: {
+        formaction: `${formPath}/make-draft-live`
+      }
+    }
+  ]
+
+  const showV2Buttons = true
+
+  // TODO: add functionality
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const draftButtons = showV2Buttons ? v2Buttons : v1Buttons
+
   return {
     backLink: formsLibraryBackLink,
     navigation,
@@ -232,18 +268,7 @@ export function overviewViewModel(metadata, notification) {
       // Adjust buttons when draft is available
       buttons: !metadata.draft
         ? [{ text: 'Create draft to edit' }]
-        : [
-            {
-              text: 'Edit draft',
-              classes: 'govuk-button--secondary-quiet'
-            },
-            {
-              text: 'Make draft live',
-              attributes: {
-                formaction: `${formPath}/make-draft-live`
-              }
-            }
-          ],
+        : draftButtons,
       links: !metadata.live
         ? [
             {

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -205,7 +205,12 @@ export function overviewViewModel(metadata, formDefinition, notification) {
   const editorV1Path = `${formPath}/editor`
   const editorV2Path = `${formPath}/editor-v2/pages`
 
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Overview')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    formDefinition,
+    'Overview'
+  )
 
   const v1Buttons = [
     {
@@ -300,7 +305,12 @@ export function editorViewModel(metadata, definition) {
   const pageTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
 
-  const navigation = getFormSpecificNavigation(formPath, metadata, 'Editor')
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
 
   return {
     backLink: formOverviewBackLink(metadata.slug),
@@ -321,16 +331,26 @@ export function editorViewModel(metadata, definition) {
  * a page, that page will have isActive:true set.
  * @param {string} formPath
  * @param {FormMetadata} metadata
+ * @param { FormDefinition | undefined } draftFormDefinition
  * @param {string} activePage
  */
-export function getFormSpecificNavigation(formPath, metadata, activePage = '') {
+export function getFormSpecificNavigation(
+  formPath,
+  metadata,
+  draftFormDefinition,
+  activePage = ''
+) {
   const navigationItems = [
     ['Forms library', formsLibraryPath],
     ['Overview', formPath]
   ]
 
   if (metadata.draft) {
-    navigationItems.push(['Editor', `${formPath}/editor`])
+    const draftEditorLink =
+      draftFormDefinition?.schema === SchemaVersion.V2
+        ? `${formPath}/editor-v2/pages`
+        : `${formPath}/editor`
+    navigationItems.push(['Editor', draftEditorLink])
   }
 
   return navigationItems.map((item) =>

--- a/designer/server/src/models/forms/library.js
+++ b/designer/server/src/models/forms/library.js
@@ -1,3 +1,5 @@
+import { SchemaVersion } from '@defra/forms-model'
+
 import { buildEntry } from '~/src/common/nunjucks/context/build-navigation.js'
 import config from '~/src/config.js'
 import * as forms from '~/src/lib/forms.js'
@@ -194,18 +196,23 @@ function buildPaginationPages(
 
 /**
  * @param {FormMetadata} metadata
+ * @param { FormDefinition|undefined } formDefinition
  * @param {string} [notification] - success notification to display
  */
-export function overviewViewModel(metadata, notification) {
+export function overviewViewModel(metadata, formDefinition, notification) {
   const pageTitle = metadata.title
   const formPath = formOverviewPath(metadata.slug)
+  const editorV1Path = `${formPath}/editor`
+  const editorV2Path = `${formPath}/editor-v2/pages`
 
   const navigation = getFormSpecificNavigation(formPath, metadata, 'Overview')
 
   const v1Buttons = [
     {
       text: 'Edit draft (new editor)',
-      classes: 'govuk-button--secondary-defra-quiet'
+      classes:
+        'govuk-button--secondary-quiet govuk-button--secondary-defra-quiet',
+      href: editorV2Path
     },
     {
       text: 'Edit draft (legacy editor)',
@@ -232,7 +239,9 @@ export function overviewViewModel(metadata, notification) {
     }
   ]
 
-  const showV2Buttons = true
+  const showV2Buttons = formDefinition?.schema === SchemaVersion.V2
+  const formAction =
+    formDefinition?.schema === SchemaVersion.V2 ? editorV2Path : editorV1Path
 
   // TODO: add functionality
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -261,7 +270,7 @@ export function overviewViewModel(metadata, notification) {
             method: 'POST'
           }
         : {
-            action: `${formPath}/editor`,
+            action: formAction,
             method: 'GET'
           }),
 

--- a/designer/server/src/models/forms/library.test.js
+++ b/designer/server/src/models/forms/library.test.js
@@ -85,6 +85,7 @@ describe('Forms Library Models', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithDraft,
+          formDefinitionV1,
           'Overview'
         )
 
@@ -95,10 +96,28 @@ describe('Forms Library Models', () => {
         ])
       })
 
+      it('includes V2 Editor link', () => {
+        const navigation = getFormSpecificNavigation(
+          formPath,
+          metadataWithDraft,
+          formDefinitionV2,
+          'Overview'
+        )
+
+        expect(navigation).toEqual([
+          buildEntry('Forms library', formsLibraryPath, { isActive: false }),
+          buildEntry('Overview', formPath, { isActive: true }),
+          buildEntry('Editor', `${formPath}/editor-v2/pages`, {
+            isActive: false
+          })
+        ])
+      })
+
       it('shows Editor page as active when activePage is "Editor"', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithDraft,
+          formDefinitionV1,
           'Editor'
         )
 
@@ -108,6 +127,23 @@ describe('Forms Library Models', () => {
           buildEntry('Editor', `${formPath}/editor`, { isActive: true })
         ])
       })
+
+      it('shows EditorV2 page as active when activePage is "Editor" and schema is v2', () => {
+        const navigation = getFormSpecificNavigation(
+          formPath,
+          metadataWithDraft,
+          formDefinitionV2,
+          'Editor'
+        )
+
+        expect(navigation).toEqual([
+          buildEntry('Forms library', formsLibraryPath, { isActive: false }),
+          buildEntry('Overview', formPath, { isActive: false }),
+          buildEntry('Editor', `${formPath}/editor-v2/pages`, {
+            isActive: true
+          })
+        ])
+      })
     })
 
     describe('without draft', () => {
@@ -115,6 +151,7 @@ describe('Forms Library Models', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithLive,
+          undefined,
           'Overview'
         )
 
@@ -128,6 +165,7 @@ describe('Forms Library Models', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithLive,
+          undefined,
           'Editor'
         )
 
@@ -143,6 +181,7 @@ describe('Forms Library Models', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
           metadataWithDraft,
+          formDefinitionV1,
           'NonExistingPage'
         )
 
@@ -158,7 +197,8 @@ describe('Forms Library Models', () => {
       it('shows no navigation item as active when activePage is defaulted', () => {
         const navigation = getFormSpecificNavigation(
           formPath,
-          metadataWithDraft
+          metadataWithDraft,
+          formDefinitionV1
         )
 
         expect(navigation).toEqual([
@@ -184,6 +224,7 @@ describe('Forms Library Models', () => {
           navigation: getFormSpecificNavigation(
             formPath,
             metadataWithDraft,
+            formDefinitionV1,
             'Overview'
           ),
           backLink: {
@@ -237,6 +278,7 @@ describe('Forms Library Models', () => {
           navigation: getFormSpecificNavigation(
             formPath,
             metadataWithDraft,
+            formDefinitionV2,
             'Overview'
           ),
           backLink: {
@@ -279,7 +321,7 @@ describe('Forms Library Models', () => {
         const notificationMessage = 'Form updated successfully'
         const viewModel = overviewViewModel(
           metadataWithLive,
-          formDefinitionV1,
+          undefined,
           notificationMessage
         )
 
@@ -287,6 +329,7 @@ describe('Forms Library Models', () => {
           navigation: getFormSpecificNavigation(
             formPath,
             metadataWithLive,
+            undefined,
             'Overview'
           ),
           backLink: {
@@ -328,6 +371,7 @@ describe('Forms Library Models', () => {
         navigation: getFormSpecificNavigation(
           formPath,
           metadataWithDraft,
+          undefined,
           'Editor'
         ),
         formDefinition: mockDefinition,

--- a/designer/server/src/models/forms/library.test.js
+++ b/designer/server/src/models/forms/library.test.js
@@ -1,4 +1,5 @@
-import { FormStatus } from '@defra/forms-model'
+import { FormStatus, SchemaVersion } from '@defra/forms-model'
+import { buildDefinition } from '@defra/forms-model/stubs'
 
 import { buildEntry } from '~/src/common/nunjucks/context/build-navigation.js'
 import * as forms from '~/src/lib/forms.js'
@@ -25,12 +26,12 @@ describe('Forms Library Models', () => {
   }
 
   const now = new Date()
-
+  const FORM_ID = '661e4ca5039739ef2902b214'
   /**
    * @satisfies {FormMetadata}
    */
   const metadataWithDraft = {
-    id: '661e4ca5039739ef2902b214',
+    id: FORM_ID,
     slug: formSlug,
     title: 'Test Form',
     organisation: 'Defra',
@@ -53,7 +54,7 @@ describe('Forms Library Models', () => {
    * @satisfies {FormMetadata}
    */
   const metadataWithLive = {
-    id: '661e4ca5039739ef2902b214',
+    id: FORM_ID,
     slug: formSlug,
     title: 'Test Form',
     organisation: 'Defra',
@@ -71,6 +72,12 @@ describe('Forms Library Models', () => {
       updatedBy: liveAuthor
     }
   }
+
+  const formDefinitionV1 = buildDefinition()
+
+  const formDefinitionV2 = buildDefinition({
+    schema: SchemaVersion.V2
+  })
 
   describe('getFormSpecificNavigation', () => {
     describe('with draft existing', () => {
@@ -169,6 +176,7 @@ describe('Forms Library Models', () => {
         const notificationMessage = 'Form updated successfully'
         const viewModel = overviewViewModel(
           metadataWithDraft,
+          formDefinitionV1,
           notificationMessage
         )
 
@@ -189,6 +197,59 @@ describe('Forms Library Models', () => {
           notification: notificationMessage,
           formManage: {
             action: `${formPath}/editor`,
+            method: 'GET',
+            buttons: [
+              {
+                text: 'Edit draft (new editor)',
+                classes:
+                  'govuk-button--secondary-quiet govuk-button--secondary-defra-quiet',
+                href: `${formPath}/editor-v2/pages`
+              },
+              {
+                text: 'Edit draft (legacy editor)',
+                classes: 'govuk-button--secondary-quiet'
+              },
+              {
+                text: 'Make draft live',
+                attributes: {
+                  formaction: `${formPath}/make-draft-live`
+                }
+              }
+            ],
+            links: [
+              {
+                text: 'Delete draft',
+                href: `${formPath}/delete-draft`
+              }
+            ]
+          }
+        })
+      })
+      it('returns correct view model structure for V2 schema', () => {
+        const notificationMessage = 'Form updated successfully'
+        const viewModel = overviewViewModel(
+          metadataWithDraft,
+          formDefinitionV2,
+          notificationMessage
+        )
+
+        expect(viewModel).toMatchObject({
+          navigation: getFormSpecificNavigation(
+            formPath,
+            metadataWithDraft,
+            'Overview'
+          ),
+          backLink: {
+            href: formsLibraryPath,
+            text: 'Back to forms library'
+          },
+          pageHeading: {
+            text: metadataWithDraft.title,
+            size: 'large'
+          },
+          notification: notificationMessage,
+          formManage: {
+            action: `${formPath}/editor-v2/pages`,
             method: 'GET',
             buttons: [
               {
@@ -218,6 +279,7 @@ describe('Forms Library Models', () => {
         const notificationMessage = 'Form updated successfully'
         const viewModel = overviewViewModel(
           metadataWithLive,
+          formDefinitionV1,
           notificationMessage
         )
 

--- a/designer/server/src/routes/forms/editor-v2/list-item-delete.js
+++ b/designer/server/src/routes/forms/editor-v2/list-item-delete.js
@@ -25,12 +25,17 @@ export default [
       const { slug, pageId, questionId, stateId, itemId } = params
 
       const metadata = await forms.get(slug, token)
+      const formDefinition = await forms.getDraftFormDefinition(
+        metadata.id,
+        token
+      )
 
       return h.view(
         CONFIRMATION_PAGE_VIEW,
         viewModel.deleteListItemConfirmationPageViewModel(
           getQuestionSessionState(yar, stateId),
           metadata,
+          formDefinition,
           pageId,
           questionId,
           stateId,

--- a/designer/server/src/routes/forms/editor-v2/migrate.js
+++ b/designer/server/src/routes/forms/editor-v2/migrate.js
@@ -22,10 +22,14 @@ export default [
       const { slug } = params
 
       const metadata = await forms.get(slug, token)
+      const formDefinition = await forms.getDraftFormDefinition(
+        metadata.id,
+        token
+      )
 
       return h.view(
         CONFIRMATION_PAGE_VIEW,
-        viewModel.migrateConfirmationPageViewModel(metadata)
+        viewModel.migrateConfirmationPageViewModel(metadata, formDefinition)
       )
     },
     options: {

--- a/designer/server/src/routes/forms/editor-v2/migrate.test.js
+++ b/designer/server/src/routes/forms/editor-v2/migrate.test.js
@@ -42,9 +42,12 @@ describe('Editor v2 migrate routes', () => {
 
     expect($mainHeading).toHaveTextContent('Test form')
     expect($subHeadings[0]).toHaveTextContent(
-      'Do you want to migrate this form to version 2?'
+      'Are you sure you want to switch to the new editor?'
     )
-    expect($buttons[2]).toHaveAccessibleName('Migrate')
+    container.getByText(
+      "You won't be able to use the old editor for this form after switching."
+    )
+    expect($buttons[2]).toHaveAccessibleName('Switch to new editor')
     expect($buttons[3]).toHaveAccessibleName('Cancel')
     expect($buttons[3]).toHaveAttribute('href', '/library/my-form-slug')
   })

--- a/designer/server/src/routes/forms/editor-v2/page.js
+++ b/designer/server/src/routes/forms/editor-v2/page.js
@@ -35,12 +35,16 @@ export default [
 
       // Form metadata, validation errors
       const metadata = await forms.get(slug, token)
+      const formDefinition = await forms.getDraftFormDefinition(
+        metadata.id,
+        token
+      )
 
       const validation = getValidationErrorsFromSession(yar, errorKey)
 
       return h.view(
         'forms/question-radios',
-        viewModel.pageViewModel(metadata, {}, validation)
+        viewModel.pageViewModel(metadata, formDefinition, {}, validation)
       )
     },
     options: {

--- a/designer/server/src/routes/forms/editor-v2/pages.js
+++ b/designer/server/src/routes/forms/editor-v2/pages.js
@@ -1,4 +1,4 @@
-import { Engine } from '@defra/forms-model'
+import { SchemaVersion } from '@defra/forms-model'
 import { StatusCodes } from 'http-status-codes'
 
 import * as scopes from '~/src/common/constants/scopes.js'
@@ -29,7 +29,7 @@ export default [
 
       const definition = await forms.getDraftFormDefinition(formId, token)
 
-      if (definition.engine !== Engine.V2) {
+      if (definition.schema !== SchemaVersion.V2) {
         return h
           .redirect(editorv2Path(slug, 'migrate'))
           .code(StatusCodes.SEE_OTHER)

--- a/designer/server/src/routes/forms/editor-v2/pages.test.js
+++ b/designer/server/src/routes/forms/editor-v2/pages.test.js
@@ -1,4 +1,9 @@
-import { ComponentType, ControllerType, Engine } from '@defra/forms-model'
+import {
+  ComponentType,
+  ControllerType,
+  Engine,
+  SchemaVersion
+} from '@defra/forms-model'
 import { StatusCodes } from 'http-status-codes'
 
 import {
@@ -27,6 +32,7 @@ describe('Editor v2 pages routes', () => {
 
   const testForm = buildDefinition({
     ...testFormDefinitionWithSummaryOnly,
+    schema: SchemaVersion.V2,
     engine: Engine.V2
   })
 
@@ -102,7 +108,8 @@ describe('Editor v2 pages routes', () => {
           controller: ControllerType.Summary
         }
       ],
-      engine: Engine.V2
+      engine: Engine.V2,
+      schema: SchemaVersion.V2
     })
 
     jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
@@ -137,10 +144,11 @@ describe('Editor v2 pages routes', () => {
     expect($actions[3]).toHaveTextContent('Re-order pages')
   })
 
-  test('GET - should redirect to migration to v2 if draft definition is v1', async () => {
+  test('GET - should redirect to migration to v2 if draft definition schema is v1', async () => {
     const v1Definition = buildDefinition({
       ...testFormDefinitionWithSinglePage,
-      engine: Engine.V1
+      engine: Engine.V2,
+      schema: SchemaVersion.V1
     })
     jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
     jest

--- a/designer/server/src/routes/forms/form-lifecycle.js
+++ b/designer/server/src/routes/forms/form-lifecycle.js
@@ -22,6 +22,7 @@ export default [
       const { yar } = request
       const { token } = request.auth.credentials
       const form = await forms.get(request.params.slug, token)
+      const formDefinition = await forms.getDraftFormDefinition(form.id, token)
 
       const formPromotionValidationFailure = yar.flash(sessionNames.errorList)
 
@@ -29,6 +30,7 @@ export default [
         CONFIRMATION_PAGE_VIEW,
         formLifecycle.makeDraftLiveConfirmationPageViewModel(
           form,
+          formDefinition,
           formPromotionValidationFailure
         )
       )
@@ -128,6 +130,7 @@ export default [
       const { yar } = request
       const { token } = request.auth.credentials
       const form = await forms.get(request.params.slug, token)
+      const formDefinition = await forms.getDraftFormDefinition(form.id, token)
 
       const deletionValidationFailure = yar.flash(sessionNames.errorList)
 
@@ -135,6 +138,7 @@ export default [
         CONFIRMATION_PAGE_VIEW,
         formLifecycle.deleteDraftConfirmationPageViewModel(
           form,
+          formDefinition,
           deletionValidationFailure
         )
       )
@@ -160,6 +164,7 @@ export default [
       const { token } = request.auth.credentials
 
       const form = await forms.get(request.params.slug, token)
+      const formDefinition = await forms.getDraftFormDefinition(form.id, token)
 
       try {
         // Currently we don't support leaving the metadata widowed with no form definitions.
@@ -181,7 +186,11 @@ export default [
 
           return h.view(
             CONFIRMATION_PAGE_VIEW,
-            formLifecycle.deleteDraftConfirmationPageViewModel(form, errorList)
+            formLifecycle.deleteDraftConfirmationPageViewModel(
+              form,
+              formDefinition,
+              errorList
+            )
           )
         }
 

--- a/designer/server/src/routes/forms/library.js
+++ b/designer/server/src/routes/forms/library.js
@@ -112,6 +112,10 @@ export default [
 
         // Retrieve form by slug
         const form = await forms.get(params.slug, token)
+        let definition
+        if (form.draft) {
+          definition = await forms.getDraftFormDefinition(form.id, token)
+        }
 
         const titleActionItems = []
         if (!form.live) {
@@ -124,6 +128,7 @@ export default [
 
         const model = library.overviewViewModel(
           form,
+          definition,
           yar.flash(sessionNames.successNotification).at(0)
         )
 

--- a/designer/server/src/routes/forms/library.test.js
+++ b/designer/server/src/routes/forms/library.test.js
@@ -769,29 +769,6 @@ describe('Forms library routes', () => {
     })
 
     describe('Live buttons in side bar', () => {
-      it.skip('should show "Edit draft" and "Make draft live" when draft exists in v1', async () => {
-        jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
-        jest
-          .mocked(forms.getDraftFormDefinition)
-          .mockResolvedValueOnce(formDefinition)
-
-        const options = {
-          method: 'GET',
-          url: '/library/my-form-slug',
-          auth
-        }
-
-        await renderResponse(server, options)
-
-        const $card = document.querySelector('.app-form-card')
-        const $buttons = $card?.querySelectorAll('.govuk-button')
-
-        expect($buttons).toHaveLength(2)
-        expect($buttons?.[0]).toHaveTextContent('Edit draft (new editor)')
-        expect($buttons?.[1]).toHaveTextContent('Edit draft (legacy editor)')
-        expect($buttons?.[2]).toHaveTextContent('Make draft live')
-      })
-
       it('should show "Edit draft" and "Make draft live" when draft exists in v2', async () => {
         jest.mocked(forms.get).mockResolvedValueOnce(formMetadata)
         jest

--- a/designer/server/src/views/forms/confirmation-page.njk
+++ b/designer/server/src/views/forms/confirmation-page.njk
@@ -40,6 +40,10 @@
         </p>
       {% endif %}
 
+      {% if bodyWarning %}
+        {{ govukWarningText(bodyWarning) }}
+      {% endif %}
+
       <div class="govuk-button-group">
         {% for button in buttons %}
           {{ govukButton(button) }}

--- a/designer/webpack.config.js
+++ b/designer/webpack.config.js
@@ -4,7 +4,7 @@ import CopyPlugin from 'copy-webpack-plugin'
 import resolvePkg from 'resolve'
 import TerserPlugin from 'terser-webpack-plugin'
 import webpack from 'webpack'
-import WebpackAssetsManifest from 'webpack-assets-manifest'
+import { WebpackAssetsManifest } from 'webpack-assets-manifest'
 
 const { EnvironmentPlugin } = webpack
 const { NODE_ENV = 'development', REACT_LOG_LEVEL } = process.env

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -796,6 +796,11 @@ export const formDefinitionSchema = Joi.object<FormDefinition>()
       .allow('V1', 'V2')
       .default('V1')
       .description('Form engine version to use (V1 or V2)'),
+    schema: Joi.string()
+      .trim()
+      .allow('V1', 'V2')
+      .default('V1')
+      .description('Form schema version to use (V1 or V2)'),
     name: Joi.string()
       .trim()
       .allow('')

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -11,6 +11,11 @@ export enum Engine {
   V2 = 'V2'
 }
 
+export enum SchemaVersion {
+  V1 = 'V1',
+  V2 = 'V2'
+}
+
 export interface Link {
   path: string
   condition?: string
@@ -174,6 +179,7 @@ export interface ConditionWrapperV2 {
  */
 export interface FormDefinition {
   engine?: Engine
+  schema?: SchemaVersion
   pages: Page[]
   conditions: (ConditionWrapper | ConditionWrapperV2)[]
   lists: List[]

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
         "terser-webpack-plugin": "^5.3.14",
         "tsx": "^4.19.4",
         "webpack": "~5.98.0",
-        "webpack-assets-manifest": "^5.2.1",
+        "webpack-assets-manifest": "^6.1.0",
         "webpack-cli": "^6.0.1"
       },
       "engines": {
@@ -13476,18 +13476,6 @@
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
-    },
-    "node_modules/lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==",
-      "dev": true
-    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -16715,9 +16703,10 @@
       "peer": true
     },
     "node_modules/schema-utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -18787,73 +18776,22 @@
       }
     },
     "node_modules/webpack-assets-manifest": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-5.2.1.tgz",
-      "integrity": "sha512-MsEcXVio1GY6R+b4dVfTHIDMB0RB90KajQG8neRbH92vE2S1ClGw9mNa9NPlratYBvZOhExmN0qqMNFTaCTuIg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-6.1.0.tgz",
+      "integrity": "sha512-ZkuTdncJAmWrjt1IXMLePv+HGQPuVsYfvyaas4FmJiON2gX7ApP46DrqnU5Vm/PXcWbO3CyX2O9VuVdwAGVH8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "chalk": "^4.1.2",
         "deepmerge": "^4.3.1",
         "lockfile": "^1.0.4",
-        "lodash.get": "^4.4.2",
-        "lodash.has": "^4.5.2",
-        "schema-utils": "^3.3.0",
+        "schema-utils": "^4.3.2",
         "tapable": "^2.2.1"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=20.10.0"
       },
       "peerDependencies": {
-        "webpack": "^5.2.0"
-      }
-    },
-    "node_modules/webpack-assets-manifest/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/webpack-assets-manifest/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/webpack-assets-manifest/node_modules/schema-utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
-      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
+        "webpack": "^5.61.0"
       }
     },
     "node_modules/webpack-cli": {


### PR DESCRIPTION
## Switch on Editor version 2

Switching over to version two editor - with nav Editor link and v1 and v2 buttons

We need to pull in the Form Definition on a lot of functions in order to use in the navigation.

This ticket: https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/551141