### PR TITLE
Update conditions schema

### DIFF
--- a/designer/server/src/__stubs__/form-definition.js
+++ b/designer/server/src/__stubs__/form-definition.js
@@ -965,7 +965,7 @@ export const testFormDefinitionWithMultipleV2Conditions = {
     {
       id: 'd5e9f931-e151-4dd6-a2b9-68a03f3537e2',
       displayName: 'isBobV2',
-      conditions: [
+      items: [
         {
           id: 'bd071563-1261-4e5c-ab30-05dde59b86f6',
           componentId: '154271c2-79a2-4b59-b535-d210a13dbfe9',
@@ -978,31 +978,9 @@ export const testFormDefinitionWithMultipleV2Conditions = {
       ]
     },
     {
-      displayName: 'isBob',
-      name: 'LoaWPy',
-      value: {
-        name: 'isBob',
-        conditions: [
-          {
-            field: {
-              name: 'RRwYht',
-              type: ComponentType.TextField,
-              display: 'What is your full name'
-            },
-            operator: OperatorName.Is,
-            value: {
-              type: ConditionType.Value,
-              value: 'Bob',
-              display: 'Bob'
-            }
-          }
-        ]
-      }
-    },
-    {
       id: '4a82930a-b8f5-498c-adae-6158bb2aeeb5',
       displayName: 'isFaveColourRedV2',
-      conditions: [
+      items: [
         {
           id: '7ccd81c7-6c44-4de2-9c2b-fc917b7e9f35',
           componentId: '7bfc19cf-8d1d-47dd-926e-8363bcc761f2',
@@ -1015,50 +993,10 @@ export const testFormDefinitionWithMultipleV2Conditions = {
       ]
     },
     {
-      displayName: 'isFaveColourRed',
-      name: 'SxzrgR',
-      value: {
-        name: 'isFaveColourRed',
-        conditions: [
-          {
-            field: {
-              name: 'nUaCCW',
-              type: ComponentType.RadiosField,
-              display: 'What is your favourite color'
-            },
-            operator: OperatorName.Is,
-            value: {
-              type: ConditionType.Value,
-              value: 'red',
-              display: 'Red'
-            }
-          }
-        ]
-      }
-    },
-    {
-      displayName: 'isBobAndFaveColourRed',
-      name: 'drFGth',
-      value: {
-        name: 'isBobAndFaveColourRed',
-        conditions: [
-          {
-            conditionName: 'isBob',
-            conditionDisplayName: 'isBob'
-          },
-          {
-            conditionName: 'isFaveColourRed',
-            conditionDisplayName: 'isFaveColourRed',
-            coordinator: Coordinator.AND
-          }
-        ]
-      }
-    },
-    {
       id: 'c685ae47-a134-485a-a819-b6271644722e',
       displayName: 'isBobAndFaveColourRedV2',
       coordinator: Coordinator.AND,
-      conditions: [
+      items: [
         {
           id: 'f54fcebc-f103-451f-8356-1a08f1f32f56',
           conditionId: 'd5e9f931-e151-4dd6-a2b9-68a03f3537e2'

--- a/model/src/conditions/migration.test.ts
+++ b/model/src/conditions/migration.test.ts
@@ -31,7 +31,7 @@ describe('Migration', () => {
     const conditionWrapper: ConditionWrapperV2 = {
       id: '1df76f06-3aa0-435e-974d-030b3daa0b9d',
       displayName: 'Test Wrapper',
-      conditions: [
+      items: [
         {
           id: 'condition1',
           componentId: 'component1',
@@ -62,7 +62,7 @@ describe('Migration', () => {
     const conditionWrapper: ConditionWrapperV2 = {
       id: '1df76f06-3aa0-435e-974d-030b3daa0b9d',
       displayName: 'Test Wrapper',
-      conditions: [
+      items: [
         {
           id: 'condition1',
           componentId: 'component1',
@@ -117,7 +117,7 @@ describe('Migration', () => {
     const conditionWrapper: ConditionWrapperV2 = {
       id: '1df76f06-3aa0-435e-974d-030b3daa0b9d',
       displayName: 'Test Wrapper',
-      conditions: [
+      items: [
         {
           id: 'condition1',
           componentId: 'nonExistentComponent',
@@ -142,7 +142,7 @@ describe('Migration', () => {
       const conditionWrapper: ConditionWrapperV2 = {
         id: '1df76f06-3aa0-435e-974d-030b3daa0b9d',
         displayName: 'Test Wrapper',
-        conditions: [
+        items: [
           {
             id: 'condition1',
             componentId: 'component1',
@@ -213,7 +213,7 @@ describe('Migration', () => {
       const conditionWrapper: ConditionWrapperV2 = {
         id: '1df76f06-3aa0-435e-974d-030b3daa0b9d',
         displayName: 'Test Wrapper',
-        conditions: [
+        items: [
           {
             id: 'condition1',
             componentId: 'component1',
@@ -248,7 +248,7 @@ describe('Migration', () => {
       const conditionWrapper: ConditionWrapperV2 = {
         id: '1df76f06-3aa0-435e-974d-030b3daa0b9d',
         displayName: 'Test Wrapper',
-        conditions: [
+        items: [
           {
             id: 'condition1',
             componentId: 'component1',
@@ -293,7 +293,7 @@ describe('Migration', () => {
       const conditionWrapper: ConditionWrapperV2 = {
         id: '1df76f06-3aa0-435e-974d-030b3daa0b9d',
         displayName: 'Test Wrapper',
-        conditions: [
+        items: [
           {
             id: 'condition1',
             componentId: 'component1',
@@ -353,7 +353,7 @@ describe('Migration', () => {
         id: '1df76f06-3aa0-435e-974d-030b3daa0b9d',
         displayName: 'Test Wrapper',
         coordinator: Coordinator.OR,
-        conditions: [
+        items: [
           {
             id: 'c1ec4d73-d0f7-4d1a-8e33-222e60376e69',
             conditionId: 'condition1'
@@ -369,7 +369,7 @@ describe('Migration', () => {
         id: '1f7473dd-45b1-4f7e-b9bf-ea4595d6f642',
         displayName: 'Test condition',
         coordinator: Coordinator.OR,
-        conditions: []
+        items: []
       }
 
       model.getComponentById = jest.fn().mockReturnValue(condition)

--- a/model/src/conditions/migration.ts
+++ b/model/src/conditions/migration.ts
@@ -135,7 +135,7 @@ function convertConditionRefDataFromV2(
 export function isConditionWrapperV2(
   wrapper: ConditionWrapper | ConditionWrapperV2
 ): wrapper is ConditionWrapperV2 {
-  return Array.isArray((wrapper as ConditionWrapperV2).conditions)
+  return Array.isArray((wrapper as ConditionWrapperV2).items)
 }
 
 export function isConditionWrapper(
@@ -150,7 +150,7 @@ export function convertConditionWrapperFromV2(
 ): ConditionWrapper {
   let coordinator
 
-  if (conditionWrapper.conditions.length > 1 && !conditionWrapper.coordinator) {
+  if (conditionWrapper.items.length > 1 && !conditionWrapper.coordinator) {
     throw new Error('Coordinator is required for multiple conditions')
   } else {
     coordinator = conditionWrapper.coordinator
@@ -161,7 +161,7 @@ export function convertConditionWrapperFromV2(
     displayName: conditionWrapper.displayName,
     value: {
       name: conditionWrapper.id,
-      conditions: conditionWrapper.conditions.map((condition, index) => {
+      conditions: conditionWrapper.items.map((condition, index) => {
         let newCondition: ConditionData | ConditionRefData
 
         if (isConditionDataV2(condition)) {

--- a/model/src/form/form-definition/index.test.ts
+++ b/model/src/form/form-definition/index.test.ts
@@ -440,19 +440,19 @@ describe('Form definition schema', () => {
       const stringValueCondition: ConditionWrapperV2 = {
         id: 'ab1bbaae-bf0e-4577-8416-8a8c83da1fb9',
         displayName: 'isFullNameEnriqueChase',
-        conditions: [stringValueData]
+        items: [stringValueData]
       }
 
       const relativeDateCondition: ConditionWrapperV2 = {
         id: '193a413b-65d3-42bd-bddb-d02ca100c749',
         displayName: 'isDueDateWithin7Days',
-        conditions: [relativeDateData]
+        items: [relativeDateData]
       }
 
       const listItemRefCondition: ConditionWrapperV2 = {
         id: '7baf03ce-e0d8-47a5-9010-fbe461031399',
         displayName: 'isFaveColourRed',
-        conditions: [listItemRefData]
+        items: [listItemRefData]
       }
 
       const fullNameConditionRefData: ConditionRefDataV2 = {
@@ -469,7 +469,7 @@ describe('Form definition schema', () => {
         id: 'dc1e112f-2855-42d0-830c-bd5d2332975c',
         displayName: 'isEnriqueChaseAndFaveColourRed',
         coordinator: Coordinator.AND,
-        conditions: [fullNameConditionRefData, faveColourRefData]
+        items: [fullNameConditionRefData, faveColourRefData]
       }
 
       const list: List = {

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -158,13 +158,19 @@ const conditionListItemRefDataSchemaV2 =
         .required()
         .description('Type of the condition value, should be "ListItemRef"'),
       listId: Joi.string()
-        .valid(listIdRef)
         .trim()
         .required()
+        .when('/lists', {
+          is: Joi.exist(),
+          then: Joi.valid(listIdRef)
+        })
         .description('The id of the list'),
       itemId: Joi.string()
         .trim()
-        .valid(listItemIdRef)
+        .when('/lists', {
+          is: Joi.exist(),
+          then: Joi.valid(listItemIdRef)
+        })
         .required()
         .description('The id of the list item')
     })
@@ -217,7 +223,10 @@ const conditionRefDataSchemaV2 = Joi.object<ConditionRefDataV2>()
     conditionId: Joi.string()
       .trim()
       .required()
-      .valid(conditionIdRef)
+      .when('/conditions', {
+        is: Joi.exist(),
+        then: Joi.valid(conditionIdRef)
+      })
       .description('Name of the referenced condition')
   })
 
@@ -252,8 +261,12 @@ const conditionDataSchemaV2 = Joi.object<ConditionDataV2>()
     ),
     componentId: Joi.string()
       .trim()
-      .valid(componentIdRefSchema)
+      .valid()
       .required()
+      .when('/pages', {
+        is: Joi.exist(),
+        then: Joi.valid(componentIdRefSchema)
+      })
       .description(
         'Reference to the component id being evaluated in this condition'
       ),
@@ -334,7 +347,7 @@ export const conditionWrapperSchemaV2 = Joi.object<ConditionWrapperV2>()
       .description(
         'Logical operator connecting this condition with others (AND, OR)'
       ),
-    conditions: Joi.array<ConditionGroupDataV2>()
+    items: Joi.array<ConditionGroupDataV2>()
       .items(
         Joi.alternatives().try(conditionDataSchemaV2, conditionRefDataSchemaV2)
       )
@@ -446,7 +459,10 @@ export const componentSchemaV2 = componentSchema
   .keys({
     id: idSchema.description('Unique identifier for the component'),
     list: Joi.string()
-      .valid(listIdRef)
+      .when('/lists', {
+        is: Joi.exist(),
+        then: Joi.valid(listIdRef)
+      })
       .optional()
       .description(
         'List id reference to a predefined list of options for select components'
@@ -683,7 +699,10 @@ export const pageSchemaV2 = pageSchema
     }),
     condition: Joi.string()
       .trim()
-      .valid(conditionIdRef)
+      .when('/conditions', {
+        is: Joi.exist(),
+        then: Joi.valid(conditionIdRef)
+      })
       .optional()
       .description('Optional condition that determines if this page is shown')
   })

--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -171,7 +171,7 @@ export interface ConditionWrapperV2 {
   id: string
   displayName: string
   coordinator?: Coordinator
-  conditions: ConditionGroupDataV2
+  items: ConditionGroupDataV2
 }
 
 /**


### PR DESCRIPTION
Makes the referential integrity of conditions optional using `joi.when`.

`joi.string().uuid().required().when('/lists', { is: joi.exist(), then: joi.valid(joi.ref('/lists', { in: true })) })`

This approach will validate referential integrity of the data _only_ when the `/lists` are present at the root mean we don't have to maintain two copies of the same schema (the full one and a "payload" one")

Example
```
import joi from 'joi'

const list = joi.string().uuid().required()
const condition = joi
  .object()
  .keys({
    list: joi
      .string()
      .uuid()
      .required()
      .when('/lists', { is: joi.exist(), then: joi.valid(joi.ref('/lists', { in: true })) }),
    name: joi.string().required()
  })
  .required()

const def = joi
  .object()
  .keys({
    lists: joi.array().items(list).required(),
    conditions: joi.array().items(condition).required()
  })
  .required()

const result = condition.validate({
  list: 'd03400bf-bd1c-4f97-93f8-12eb2a5ae69c',
  name: 'My condition'
})

const result2 = def.validate({
  lists: ['d03400bf-bd1c-4f97-93f8-12eb2a5ae69c'],
  conditions: [
    {
      list: 'd03400bf-bd1c-4f97-93f8-12eb2a5ae69c',
      name: 'My condition'
    }
  ]
})

const result3 = def.validate({
  lists: ['d03400bf-bd1c-4f97-93f8-12eb2a5ae69c'],
  conditions: [
    {
      list: 'bfe17998-e9f1-4eb8-8e4c-cbaa0a22f204',
      name: 'My condition'
    }
  ]
})

const result4 = condition.validate({
  list: 'not-a-uuid',
  name: 'My condition'
})

console.log(result)
console.log(result2)
console.log(result3)
console.log(result4)
```
