### PR TITLE
Use displayName when converting ConditionRefData

### DIFF
--- a/model/src/conditions/migration.ts
+++ b/model/src/conditions/migration.ts
@@ -126,7 +126,7 @@ function convertConditionRefDataFromV2(
   }
 
   return {
-    conditionName: refCondition.id,
+    conditionName: refCondition.displayName,
     conditionDisplayName: refCondition.displayName,
     coordinator
   }


### PR DESCRIPTION
Part 1 of: https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/565812

This ensures that when an expression is created for a `ConditionRefData`, it uses the displayName not the uuid otherwise the expression looks like.

`the-uuid-of-the-referenced-condition-with-dashes OR the-uuid-of-the-2nd-referenced-condition-with-dashes`