### PR TITLE
Feat/556328 relative date condition

### DIFF
--- a/designer/server/src/common/components/condition-value-editor/template.njk
+++ b/designer/server/src/common/components/condition-value-editor/template.njk
@@ -10,6 +10,17 @@
   {% case "ListItemRef" %}
     {{ govukRadios(params.value) }}
   {% case "RelativeDate" %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-quarter">
+        {{ govukInput(params.value.period) }}
+      </div>
+      <div class="govuk-grid-column-one-quarter">
+      {{ govukRadios(params.value.unit) }}
+      </div>
+      <div class="govuk-grid-column-one-half">
+      {{ govukRadios(params.value.direction) }}
+      </div>
+    </div>
 {% endswitch %}
 <input type="hidden" name="{{ params.conditionTypeName }}" value="{{ params.conditionType }}" />
 <input type="hidden" name="{{ params.listIdName }}" value="{{ params.listId }}" />

--- a/designer/server/src/models/forms/editor-v2/condition-value.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.js
@@ -8,6 +8,7 @@ import {
 
 const dateUnits = Object.values(DateUnits)
 const dateDirections = Object.values(DateDirections)
+const GOVUK_RADIOS_SMALL = 'govuk-radios--small'
 
 /**
  * @param { ErrorDetails | undefined } formErrors
@@ -62,7 +63,7 @@ export function relativeDateValueViewModel(idx, item, validation) {
         text: 'Units'
       }
     },
-    classes: 'govuk-radios--small',
+    classes: GOVUK_RADIOS_SMALL,
     value: unitValue,
     ...insertDateValidationErrors(formErrors, idx, unitValue)
   }
@@ -81,7 +82,7 @@ export function relativeDateValueViewModel(idx, item, validation) {
         text: 'Direction'
       }
     },
-    classes: 'govuk-radios--small',
+    classes: GOVUK_RADIOS_SMALL,
     value: directionValue,
     ...insertDateValidationErrors(formErrors, idx, directionValue)
   }
@@ -140,7 +141,7 @@ export function buildValueField(
             text: 'Select a value'
           }
         },
-        classes: 'govuk-radios--small',
+        classes: GOVUK_RADIOS_SMALL,
         value:
           'value' in item && 'itemId' in item.value
             ? item.value.itemId

--- a/designer/server/src/models/forms/editor-v2/condition-value.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.js
@@ -7,58 +7,80 @@ const dateUnits = Object.values(DateUnits)
 const dateDirections = Object.values(DateDirections)
 
 /**
+ * @param { ErrorDetails | undefined } formErrors
  * @param {number} idx
+ * @param { string | undefined } fieldValue
+ */
+export function insertDateValidationErrors(formErrors, idx, fieldValue) {
+  if (fieldValue && fieldValue !== '') {
+    return {}
+  }
+  const formError = formErrors ? formErrors[`items[${idx}].value`] : undefined
+  return {
+    ...(formError && {
+      errorMessage: {
+        text: formError.text
+      }
+    })
+  }
+}
+
+/**
+ * @param {number} idx
+ * @param { ConditionDataV2 | ConditionRefDataV2 } item
  * @param {ValidationFailure<FormEditor>} [validation]
  */
-export function relativeDateValueViewModel(idx, validation) {
-  const { formValues, formErrors } = validation ?? {}
+export function relativeDateValueViewModel(idx, item, validation) {
+  const { formErrors } = validation ?? {}
 
   // Period text field
+  const periodValue =
+    'value' in item && 'period' in item.value ? item.value.period : undefined
   const period = {
-    id: `items[${idx}].value.period`,
+    id: `items[${idx}].value`,
     name: `items[${idx}][value][period]`,
     label: {
-      text: 'Enter a period'
+      text: 'Period'
     },
     classes: 'govuk-input--width-10',
-    value: formValues?.period,
-    ...insertValidationErrors(
-      formErrors ? formErrors[`items[${idx}].value.unit`] : undefined
-    )
+    value: periodValue,
+    ...insertDateValidationErrors(formErrors, idx, periodValue)
   }
 
   // Unit select field
+  const unitValue =
+    'value' in item && 'unit' in item.value ? item.value.unit : undefined
   const unit = {
     id: `items[${idx}].value.unit`,
     name: `items[${idx}][value][unit]`,
     items: dateUnits.map((value) => ({ text: upperFirst(value), value })),
     fieldset: {
       legend: {
-        text: 'Select a unit'
+        text: 'Units'
       }
     },
     classes: 'govuk-radios--small',
-    value: formValues?.unit,
-    ...insertValidationErrors(
-      formErrors ? formErrors[`items[${idx}].value.unit`] : undefined
-    )
+    value: unitValue,
+    ...insertDateValidationErrors(formErrors, idx, unitValue)
   }
 
   // Direction select field
+  const directionValue =
+    'value' in item && 'direction' in item.value
+      ? item.value.direction
+      : undefined
   const direction = {
     id: `items[${idx}].value.direction`,
     name: `items[${idx}][value][direction]`,
     items: dateDirections.map((value) => ({ text: upperFirst(value), value })),
     fieldset: {
       legend: {
-        text: 'Select a direction'
+        text: 'Direction'
       }
     },
     classes: 'govuk-radios--small',
-    value: formValues?.direction,
-    ...insertValidationErrors(
-      formErrors ? formErrors[`items[${idx}].value.direction`] : undefined
-    )
+    value: directionValue,
+    ...insertDateValidationErrors(formErrors, idx, directionValue)
   }
 
   return {
@@ -90,6 +112,7 @@ export function listItemRefValueViewModel(list, validation) {
 }
 
 /**
- * @import { FormEditor, List } from '@defra/forms-model'
+ * @import { ErrorDetails } from '~/src/common/helpers/types.js'
+ * @import { ConditionDataV2, ConditionRefDataV2, FormEditor, List } from '@defra/forms-model'
  * @import { ValidationFailure } from '~/src/common/helpers/types.js'
  */

--- a/designer/server/src/models/forms/editor-v2/condition-value.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.js
@@ -7,35 +7,58 @@ const dateUnits = Object.values(DateUnits)
 const dateDirections = Object.values(DateDirections)
 
 /**
+ * @param {number} idx
  * @param {ValidationFailure<FormEditor>} [validation]
  */
-export function relativeDateValueViewModel(validation) {
+export function relativeDateValueViewModel(idx, validation) {
   const { formValues, formErrors } = validation ?? {}
 
   // Period text field
   const period = {
-    id: 'period',
-    name: 'period',
+    id: `items[${idx}].value.period`,
+    name: `items[${idx}][value][period]`,
+    label: {
+      text: 'Enter a period'
+    },
+    classes: 'govuk-input--width-10',
     value: formValues?.period,
-    ...insertValidationErrors(formErrors?.period)
+    ...insertValidationErrors(
+      formErrors ? formErrors[`items[${idx}].value.unit`] : undefined
+    )
   }
 
   // Unit select field
   const unit = {
-    id: 'unit',
-    name: 'unit',
+    id: `items[${idx}].value.unit`,
+    name: `items[${idx}][value][unit]`,
     items: dateUnits.map((value) => ({ text: upperFirst(value), value })),
+    fieldset: {
+      legend: {
+        text: 'Select a unit'
+      }
+    },
+    classes: 'govuk-radios--small',
     value: formValues?.unit,
-    ...insertValidationErrors(formErrors?.unit)
+    ...insertValidationErrors(
+      formErrors ? formErrors[`items[${idx}].value.unit`] : undefined
+    )
   }
 
   // Direction select field
   const direction = {
-    id: 'direction',
-    name: 'direction',
+    id: `items[${idx}].value.direction`,
+    name: `items[${idx}][value][direction]`,
     items: dateDirections.map((value) => ({ text: upperFirst(value), value })),
+    fieldset: {
+      legend: {
+        text: 'Select a direction'
+      }
+    },
+    classes: 'govuk-radios--small',
     value: formValues?.direction,
-    ...insertValidationErrors(formErrors?.direction)
+    ...insertValidationErrors(
+      formErrors ? formErrors[`items[${idx}].value.direction`] : undefined
+    )
   }
 
   return {

--- a/designer/server/src/models/forms/editor-v2/condition-value.test.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.test.js
@@ -1,0 +1,105 @@
+import { ConditionType, DateDirections, OperatorName } from '@defra/forms-model'
+
+import {
+  insertDateValidationErrors,
+  listItemRefValueViewModel,
+  relativeDateValueViewModel
+} from '~/src/models/forms/editor-v2/condition-value.js'
+
+describe('editor-v2 - condition-value', () => {
+  describe('insertDateValidationErrors', () => {
+    const formsErrors = /** @type {ErrorDetails} */ ({
+      [`items[0].value`]: {
+        value: 'example value',
+        text: 'Error on this field'
+      }
+    })
+
+    test('should return empty object if field populated', () => {
+      expect(insertDateValidationErrors(formsErrors, 0, 'some value')).toEqual(
+        {}
+      )
+    })
+
+    test('should return empty object if no error object', () => {
+      expect(insertDateValidationErrors(undefined, 0, '')).toEqual({})
+    })
+
+    test('should return error structure if field value undefined', () => {
+      expect(insertDateValidationErrors(formsErrors, 0, '')).toEqual({
+        errorMessage: {
+          text: 'Error on this field'
+        }
+      })
+    })
+  })
+
+  describe('relativeDateValueViewModel', () => {
+    test('should create view model with empty field values', () => {
+      const item = /** @type {ConditionDataV2} */ ({
+        id: 'id',
+        componentId: 'componentId',
+        value: {}
+      })
+      const model = relativeDateValueViewModel(0, item, undefined)
+      expect(model.period).toBeDefined()
+      expect(model.period.value).toBeUndefined()
+      expect(model.unit).toBeDefined()
+      expect(model.unit.value).toBeUndefined()
+      expect(model.direction).toBeDefined()
+      expect(model.direction.value).toBeUndefined()
+    })
+
+    test('should create view model with populated field values', () => {
+      const item = /** @type {ConditionDataV2} */ ({
+        id: 'id',
+        componentId: 'componentId',
+        operator: OperatorName.Is,
+        value: {
+          period: '5',
+          unit: 'months',
+          direction: DateDirections.FUTURE,
+          type: ConditionType.RelativeDate
+        }
+      })
+      const model = relativeDateValueViewModel(0, item, undefined)
+      expect(model.period).toBeDefined()
+      expect(model.period.value).toBe('5')
+      expect(model.unit).toBeDefined()
+      expect(model.unit.value).toBe('months')
+      expect(model.direction).toBeDefined()
+      expect(model.direction.value).toBe('in the future')
+    })
+  })
+
+  describe('listItemRefValueViewModel', () => {
+    test('should create view model with empty field value', () => {
+      const list = /** @type {List} */ ({
+        id: 'list-id',
+        name: 'itemId',
+        title: '',
+        type: 'string',
+        items: [
+          { text: 'Option 1', value: 'opt1' },
+          { text: 'Option 2', value: 'opt2' }
+        ]
+      })
+      expect(listItemRefValueViewModel(list, undefined)).toEqual({
+        itemId: {
+          id: 'itemId',
+          name: 'itemId',
+          items: [
+            { text: 'Option 1', value: 'opt1' },
+            { text: 'Option 2', value: 'opt2' }
+          ],
+          value: undefined
+        }
+      })
+    })
+  })
+})
+
+/**
+ * @import { ErrorDetails } from '~/src/common/helpers/types.js'
+ * @import { ConditionDataV2, List } from '@defra/forms-model'
+ */

--- a/designer/server/src/models/forms/editor-v2/condition.js
+++ b/designer/server/src/models/forms/editor-v2/condition.js
@@ -82,7 +82,7 @@ export function buildValueField(
     }
 
     case ConditionType.RelativeDate: {
-      return relativeDateValueViewModel(idx, validation)
+      return relativeDateValueViewModel(idx, item, validation)
     }
 
     default: {
@@ -149,6 +149,7 @@ export function buildConditionsFields(
     label: {
       text: 'Select a question'
     },
+    classes: 'govuk-input--width-20',
     items: componentItems,
     value: getComponentId(item),
     ...insertValidationErrors(

--- a/designer/server/src/models/forms/editor-v2/condition.test.js
+++ b/designer/server/src/models/forms/editor-v2/condition.test.js
@@ -1,11 +1,13 @@
-import { ConditionType } from '@defra/forms-model'
+import { ComponentType, ConditionType, OperatorName } from '@defra/forms-model'
 
 import { testFormDefinitionWithMultipleV2Conditions } from '~/src/__stubs__/form-definition.js'
+import { buildValueField } from '~/src/models/forms/editor-v2/condition-value.js'
 import {
   buildConditionEditor,
-  buildValueField,
   getComponentId,
-  getOperator
+  getConditionType,
+  getOperator,
+  isRelativeDate
 } from '~/src/models/forms/editor-v2/condition.js'
 
 describe('editor-v2 - condition model', () => {
@@ -160,8 +162,75 @@ describe('editor-v2 - condition model', () => {
       })
     })
   })
+
+  describe('isRelativeDate', () => {
+    test('should return false if no operator', () => {
+      expect(isRelativeDate(undefined)).toBeFalsy()
+    })
+
+    test('should return false if operator but not for relative dates', () => {
+      expect(isRelativeDate(OperatorName.Is)).toBeFalsy()
+    })
+
+    test('should return true if operator is for relative dates', () => {
+      expect(isRelativeDate(OperatorName.IsAtLeast)).toBeTruthy()
+    })
+  })
+
+  describe('getConditionType', () => {
+    test('should return ListItemRef if a list field', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.AutocompleteField
+      })
+      expect(getConditionType(component, undefined)).toBe(
+        ConditionType.ListItemRef
+      )
+    })
+
+    test('should return ListItemRef if YesNo field', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.YesNoField
+      })
+      expect(getConditionType(component, undefined)).toBe(
+        ConditionType.ListItemRef
+      )
+    })
+
+    test('should return RelativeDate if date parts field and operator denotes relative', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.DatePartsField
+      })
+      expect(getConditionType(component, OperatorName.IsAtLeast)).toBe(
+        ConditionType.RelativeDate
+      )
+    })
+
+    test('should return RelativeDate if month year field and operator denotes relative', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.MonthYearField
+      })
+      expect(getConditionType(component, OperatorName.IsAtLeast)).toBe(
+        ConditionType.RelativeDate
+      )
+    })
+
+    test('should return StringValue if date field but operator does not denote relative', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.MonthYearField
+      })
+      expect(getConditionType(component, OperatorName.Is)).toBe(
+        ConditionType.StringValue
+      )
+    })
+
+    test('should return StringValue if missing field', () => {
+      expect(getConditionType(undefined, undefined)).toBe(
+        ConditionType.StringValue
+      )
+    })
+  })
 })
 
 /**
- * @import { ConditionDataV2 } from '@defra/forms-model'
+ * @import { ConditionalComponentsDef, ConditionDataV2 } from '@defra/forms-model'
  */

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -296,7 +296,6 @@ export type ConditionalComponentsDef = Exclude<
   ComponentDef,
   | InsetTextComponent
   | ListComponent
-  | MonthYearFieldComponent
   | UkAddressFieldComponent
   | FileUploadFieldComponent
 >

--- a/model/src/conditions/condition-operators.ts
+++ b/model/src/conditions/condition-operators.ts
@@ -114,7 +114,7 @@ function getConditionals(
   }
 
   return fieldType in customOperators
-    ? customOperators[fieldType]
+    ? customOperators[fieldType as keyof typeof customOperators]
     : defaultOperators
 }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.sourceEncoding=UTF-8
 
 sonar.sources=designer/client/src,designer/server/src,model/src,model/scripts
-sonar.exclusions=**/*.test.*,**/__stubs__/**,**/__mocks__/**,designer/client/src/javascripts/preview/nunjucks.js,designer/client/src/javascripts/application.js,designer/server/src/common/nunjucks/client.js,designer/server/src/models/forms/editor-v2/condition-value.js
+sonar.exclusions=**/*.test.*,**/__stubs__/**,**/__mocks__/**,designer/client/src/javascripts/preview/nunjucks.js,designer/client/src/javascripts/application.js,designer/server/src/common/nunjucks/client.js
 sonar.tests=designer/client/src,designer/server/src,model/src
 sonar.test.inclusions=**/*.test.*,**/__stubs__/**
 sonar.cpd.exclusions=**/*.test.*,**/__stubs__/**


### PR DESCRIPTION
Handles relative dates prompting user to supply period/units/direction
TODO - handle absolute date as a specific date field (not as string value as is currently the case)