### PR TITLE
Add auth config to page

### DIFF
--- a/model/src/form/form-definition/types.ts
+++ b/model/src/form/form-definition/types.ts
@@ -37,6 +37,14 @@ export interface Events {
   onSave?: Event
 }
 
+export interface AuthConfig {
+  mode?: 'required' | 'try' | 'none'
+  strategy?: string
+  access?: {
+    scope?: string[]
+  }
+}
+
 export interface PageBase {
   id?: string
   title: string
@@ -44,6 +52,7 @@ export interface PageBase {
   condition?: string
   events?: Events
   view?: string
+  auth?: AuthConfig
 }
 
 export interface RepeatOptions {

--- a/model/src/form/form-metadata/types.ts
+++ b/model/src/form/form-metadata/types.ts
@@ -173,11 +173,6 @@ export interface FormMetadata {
    * The date the form was last updated
    */
   updatedAt: FormMetadataState['updatedAt']
-
-  /**
-   * Is Authentication required to access the form
-   */
-  authRequired?: boolean
 }
 
 export type FormByIdInput = Pick<FormMetadata, 'id'>


### PR DESCRIPTION
This PR is to facilitate auth on per page level. This is part of a change that is implemented by https://github.com/DEFRA/grants-ui/pull/107 and https://github.com/DEFRA/forms-engine-plugin/pull/84.