### PR TITLE
Feature/566740 number value conditions

### DIFF
--- a/designer/server/src/common/components/condition-value-editor/template.njk
+++ b/designer/server/src/common/components/condition-value-editor/template.njk
@@ -7,6 +7,8 @@
 {% switch params.conditionType %}
   {% case "StringValue" %}
     {{ govukInput(params.value) }}
+  {% case "NumberValue" %}
+    {{ govukInput(params.value) }}
   {% case "ListItemRef" %}
     {{ govukRadios(params.value) }}
   {% case "BooleanValue" %}

--- a/designer/server/src/models/forms/editor-v2/condition-value.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.js
@@ -147,82 +147,25 @@ export function buildValueField(
 ) {
   switch (type) {
     case ConditionType.ListItemRef: {
-      return {
-        id: `items[${idx}].value`,
-        name: `items[${idx}][value][itemId]`,
-        fieldset: {
-          legend: {
-            text: 'Select a value'
-          }
-        },
-        classes: GOVUK_RADIOS_SMALL,
-        value:
-          'value' in item && 'itemId' in item.value
-            ? item.value.itemId
-            : undefined,
-        items: getListFromComponent(selectedComponent, definition)?.items.map(
-          (itm) => {
-            return { text: itm.text, value: itm.id ?? itm.value }
-          }
-        ),
-        ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
-      }
+      return buildListItemValueField(
+        idx,
+        item,
+        selectedComponent,
+        definition,
+        validation
+      )
     }
 
     case ConditionType.BooleanValue: {
-      return {
-        id: `items[${idx}].value`,
-        name: `items[${idx}][value][value]`,
-        fieldset: {
-          legend: {
-            text: 'Select a value'
-          }
-        },
-        classes: 'govuk-radios--small',
-        value:
-          'value' in item && 'value' in item.value
-            ? item.value.value.toString()
-            : undefined,
-        items: getYesNoList().items.map((itm) => {
-          return { text: itm.text, value: itm.value.toString() }
-        }),
-        ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
-      }
+      return buildBooleanValueField(idx, item, validation)
     }
 
     case ConditionType.StringValue: {
-      return {
-        id: `items[${idx}].value`,
-        name: `items[${idx}][value][value]`,
-        label: {
-          text: 'Enter a value'
-        },
-        classes: 'govuk-input--width-10',
-        value:
-          'value' in item && 'value' in item.value
-            ? item.value.value
-            : undefined,
-        ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
-      }
+      return buildStringValueField(idx, item, validation)
     }
 
     case ConditionType.NumberValue: {
-      return {
-        id: `items[${idx}].value`,
-        name: `items[${idx}][value][value]`,
-        label: {
-          text: 'Enter a value'
-        },
-        classes: 'govuk-input--width-5',
-        attributes: {
-          inputmode: 'numeric'
-        },
-        value:
-          'value' in item && 'value' in item.value
-            ? item.value.value.toString()
-            : undefined,
-        ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
-      }
+      return buildNumberValueField(idx, item, validation)
     }
 
     case ConditionType.RelativeDate: {
@@ -232,6 +175,109 @@ export function buildValueField(
     default: {
       throw new Error(`Invalid condition type ${type}`)
     }
+  }
+}
+
+/**
+ * @param {number} idx
+ * @param { ConditionDataV2 } item
+ * @param { ConditionalComponentsDef | undefined } selectedComponent
+ * @param {FormDefinition} definition
+ * @param { ValidationFailure<FormEditor> | undefined } validation
+ */
+function buildListItemValueField(
+  idx,
+  item,
+  selectedComponent,
+  definition,
+  validation
+) {
+  return {
+    id: `items[${idx}].value`,
+    name: `items[${idx}][value][itemId]`,
+    fieldset: {
+      legend: {
+        text: 'Select a value'
+      }
+    },
+    classes: GOVUK_RADIOS_SMALL,
+    value:
+      'value' in item && 'itemId' in item.value ? item.value.itemId : undefined,
+    items: getListFromComponent(selectedComponent, definition)?.items.map(
+      (itm) => {
+        return { text: itm.text, value: itm.id ?? itm.value }
+      }
+    ),
+    ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
+  }
+}
+
+/**
+ * @param {number} idx
+ * @param { ConditionDataV2 } item
+ * @param { ValidationFailure<FormEditor> | undefined } validation
+ */
+function buildBooleanValueField(idx, item, validation) {
+  return {
+    id: `items[${idx}].value`,
+    name: `items[${idx}][value][value]`,
+    fieldset: {
+      legend: {
+        text: 'Select a value'
+      }
+    },
+    classes: 'govuk-radios--small',
+    value:
+      'value' in item && 'value' in item.value
+        ? item.value.value.toString()
+        : undefined,
+    items: getYesNoList().items.map((itm) => {
+      return { text: itm.text, value: itm.value.toString() }
+    }),
+    ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
+  }
+}
+
+/**
+ * @param {number} idx
+ * @param { ConditionDataV2 } item
+ * @param { ValidationFailure<FormEditor> | undefined } validation
+ */
+function buildStringValueField(idx, item, validation) {
+  return {
+    id: `items[${idx}].value`,
+    name: `items[${idx}][value][value]`,
+    label: {
+      text: 'Enter a value'
+    },
+    classes: 'govuk-input--width-10',
+    value:
+      'value' in item && 'value' in item.value ? item.value.value : undefined,
+    ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
+  }
+}
+
+/**
+ * @param {number} idx
+ * @param { ConditionDataV2 } item
+ * @param { ValidationFailure<FormEditor> | undefined } validation
+ */
+function buildNumberValueField(idx, item, validation) {
+  return {
+    id: `items[${idx}].value`,
+    name: `items[${idx}][value][value]`,
+    label: {
+      text: 'Enter a value'
+    },
+    classes: 'govuk-input--width-5',
+    attributes: {
+      inputmode: 'numeric'
+    },
+    value:
+      'value' in item && 'value' in item.value
+        ? item.value.value.toString()
+        : undefined,
+    ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
   }
 }
 

--- a/designer/server/src/models/forms/editor-v2/condition-value.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.js
@@ -2,8 +2,7 @@ import {
   ConditionType,
   DateDirections,
   DateUnits,
-  getYesNoList,
-  isConditionBooleanValueDataV2
+  getYesNoList
 } from '@defra/forms-model'
 import upperFirst from 'lodash/upperFirst.js'
 
@@ -180,9 +179,10 @@ export function buildValueField(
           }
         },
         classes: 'govuk-radios--small',
-        value: isConditionBooleanValueDataV2(item.value)
-          ? item.value.value.toString()
-          : undefined,
+        value:
+          'value' in item && 'value' in item.value
+            ? item.value.value.toString()
+            : undefined,
         items: getYesNoList().items.map((itm) => {
           return { text: itm.text, value: itm.value.toString() }
         }),
@@ -201,6 +201,25 @@ export function buildValueField(
         value:
           'value' in item && 'value' in item.value
             ? item.value.value
+            : undefined,
+        ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
+      }
+    }
+
+    case ConditionType.NumberValue: {
+      return {
+        id: `items[${idx}].value`,
+        name: `items[${idx}][value][value]`,
+        label: {
+          text: 'Enter a value'
+        },
+        classes: 'govuk-input--width-5',
+        attributes: {
+          inputmode: 'numeric'
+        },
+        value:
+          'value' in item && 'value' in item.value
+            ? item.value.value.toString()
             : undefined,
         ...insertValidationErrors(validation?.formErrors[`items[${idx}].value`])
       }

--- a/designer/server/src/models/forms/editor-v2/condition-value.test.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.test.js
@@ -275,6 +275,59 @@ describe('editor-v2 - condition-value', () => {
       expect(valueField.value).toBeUndefined()
     })
 
+    test('should return number value field', () => {
+      const numberItem = /** @type {ConditionDataV2} */ ({
+        id: '1',
+        componentId: '7bfc19cf-8d1d-47dd-926e-8363bcc761f2',
+        operator: 'is',
+        value: {
+          value: 1,
+          type: ConditionType.NumberValue
+        }
+      })
+      const valueField = buildValueField(
+        ConditionType.NumberValue,
+        2,
+        numberItem,
+        undefined,
+        testFormDefinitionWithMultipleV2Conditions,
+        undefined
+      )
+      expect(valueField).toEqual({
+        label: {
+          text: 'Enter a value'
+        },
+        id: 'items[2].value',
+        name: 'items[2][value][value]',
+        value: '1',
+        classes: 'govuk-input--width-5',
+        attributes: {
+          inputmode: 'numeric'
+        }
+      })
+    })
+
+    test('should return number value field with undefined value', () => {
+      const numberItem = /** @type {ConditionDataV2} */ ({
+        id: '1',
+        componentId: '7bfc19cf-8d1d-47dd-926e-8363bcc761f2',
+        operator: 'is',
+        value: {}
+      })
+      const valueField = /** @type {{ id: string, value: any }} */ (
+        buildValueField(
+          ConditionType.NumberValue,
+          2,
+          numberItem,
+          undefined,
+          testFormDefinitionWithMultipleV2Conditions,
+          undefined
+        )
+      )
+      expect(valueField.id).toBeDefined()
+      expect(valueField.value).toBeUndefined()
+    })
+
     test('should return relative date fields', () => {
       const dateItem = /** @type {ConditionDataV2} */ ({
         id: '1',

--- a/designer/server/src/models/forms/editor-v2/condition.js
+++ b/designer/server/src/models/forms/editor-v2/condition.js
@@ -308,13 +308,6 @@ export function conditionViewModel(
 }
 
 /**
- * @typedef {object} ConditionPageState
- * @property {string} [selectedComponentId] - The component id
- * @property {string} [selectedOperator] - The operator
- * @property {string} [displayName] - The condition display name
- */
-
-/**
  * @import { ConditionalComponentsDef, ConditionDataV2, ConditionRefDataV2, ConditionSessionState, FormMetadata, FormDefinition, FormEditor, Page } from '@defra/forms-model'
  * @import { ValidationFailure } from '~/src/common/helpers/types.js'
  */

--- a/designer/server/src/models/forms/editor-v2/condition.js
+++ b/designer/server/src/models/forms/editor-v2/condition.js
@@ -59,6 +59,35 @@ export function isRelativeDate(operator) {
 }
 
 /**
+ * Determine if the condition/operator combination should use NumberValue
+ * NumberValue is used when the operator is HasLength, IsLongerThan or IsShorterThan
+ * or if the component is a NumberField
+ * @param { ConditionalComponentsDef | undefined } component
+ * @param { OperatorName | undefined } operator
+ */
+export function isConditionRequiresNumberValue(component, operator) {
+  if (!operator) {
+    return false
+  }
+
+  if (
+    [
+      OperatorName.HasLength,
+      OperatorName.IsLongerThan,
+      OperatorName.IsShorterThan
+    ].includes(operator)
+  ) {
+    return true
+  }
+
+  if (!component) {
+    return false
+  }
+
+  return component.type === ComponentType.NumberField
+}
+
+/**
  * @param { ConditionalComponentsDef | undefined } selectedComponent
  * @param { OperatorName | undefined } operatorValue
  * @returns
@@ -67,12 +96,14 @@ export function getConditionType(selectedComponent, operatorValue) {
   if (hasListField(selectedComponent)) {
     return ConditionType.ListItemRef
   } else if (selectedComponent?.type === ComponentType.YesNoField) {
-    return ConditionType.ListItemRef
+    return ConditionType.BooleanValue
   } else if (
     selectedComponent?.type === ComponentType.DatePartsField &&
     isRelativeDate(operatorValue)
   ) {
     return ConditionType.RelativeDate
+  } else if (isConditionRequiresNumberValue(selectedComponent, operatorValue)) {
+    return ConditionType.NumberValue
   } else {
     return ConditionType.StringValue
   }

--- a/designer/server/src/models/forms/editor-v2/condition.test.js
+++ b/designer/server/src/models/forms/editor-v2/condition.test.js
@@ -202,21 +202,6 @@ describe('editor-v2 - condition model', () => {
         ConditionType.NumberValue
       )
     })
-
-    test('should return NumberValue if Telephone field and operator denotes numeric', () => {
-      const component = /** @type {ConditionalComponentsDef} */ ({
-        type: ComponentType.TelephoneNumberField
-      })
-      expect(getConditionType(component, OperatorName.IsLongerThan)).toBe(
-        ConditionType.NumberValue
-      )
-      expect(getConditionType(component, OperatorName.IsShorterThan)).toBe(
-        ConditionType.NumberValue
-      )
-      expect(getConditionType(component, OperatorName.HasLength)).toBe(
-        ConditionType.NumberValue
-      )
-    })
   })
 
   describe('buildConditionsFields', () => {

--- a/designer/server/src/models/forms/editor-v2/condition.test.js
+++ b/designer/server/src/models/forms/editor-v2/condition.test.js
@@ -106,7 +106,7 @@ describe('editor-v2 - condition model', () => {
         type: ComponentType.YesNoField
       })
       expect(getConditionType(component, undefined)).toBe(
-        ConditionType.ListItemRef
+        ConditionType.BooleanValue
       )
     })
 
@@ -131,6 +131,90 @@ describe('editor-v2 - condition model', () => {
     test('should return StringValue if missing field', () => {
       expect(getConditionType(undefined, undefined)).toBe(
         ConditionType.StringValue
+      )
+    })
+
+    test('should return NumberValue if number field', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.NumberField
+      })
+      expect(getConditionType(component, OperatorName.Is)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsNot)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsAtLeast)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsAtMost)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsLessThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsMoreThan)).toBe(
+        ConditionType.NumberValue
+      )
+    })
+
+    test('should return NumberValue if Text field and operator denotes numeric', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.TextField
+      })
+      expect(getConditionType(component, OperatorName.IsLongerThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsShorterThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.HasLength)).toBe(
+        ConditionType.NumberValue
+      )
+    })
+
+    test('should return NumberValue if Multiline field and operator denotes numeric', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.MultilineTextField
+      })
+      expect(getConditionType(component, OperatorName.IsLongerThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsShorterThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.HasLength)).toBe(
+        ConditionType.NumberValue
+      )
+    })
+
+    test('should return NumberValue if Email field and operator denotes numeric', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.EmailAddressField
+      })
+      expect(getConditionType(component, OperatorName.IsLongerThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsShorterThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.HasLength)).toBe(
+        ConditionType.NumberValue
+      )
+    })
+
+    test('should return NumberValue if Telephone field and operator denotes numeric', () => {
+      const component = /** @type {ConditionalComponentsDef} */ ({
+        type: ComponentType.TelephoneNumberField
+      })
+      expect(getConditionType(component, OperatorName.IsLongerThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.IsShorterThan)).toBe(
+        ConditionType.NumberValue
+      )
+      expect(getConditionType(component, OperatorName.HasLength)).toBe(
+        ConditionType.NumberValue
       )
     })
   })

--- a/model/src/conditions/index.ts
+++ b/model/src/conditions/index.ts
@@ -31,7 +31,9 @@ export {
 export {
   convertConditionWrapperFromV2,
   isConditionBooleanValueDataV2,
+  isConditionDateValueDataV2,
   isConditionListItemRefValueDataV2,
+  isConditionNumberValueDataV2,
   isConditionStringValueDataV2,
   isConditionWrapper,
   isConditionWrapperV2,


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/566740

Used for:

NumberField, is
NumberField, is not
NumberField, is at least
NumberField, is at most
NumberField, is less than
NumberField, is more than

TextField, is longer than
TextField, is shorter than
TextField, has length

MultilineTextField, is longer than
MultilineTextField, is shorter than
MultilineTextField, has length

EmailAddressField, is longer than
EmailAddressField, is shorter than
EmailAddressField, has length


Also [fixes](https://github.com/DEFRA/forms-designer/pull/918/files#diff-21b23afe3b549db03de0178364940fef5abed27fe3b1ea822a840e4e73e936aaR99) YesNoField should use BooleanValue 