### PR TITLE
Fix RelativeDataSchemaV1

### DIFF
--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -180,6 +180,11 @@ const relativeDateValueDataSchemaV2 = Joi.object<RelativeDateValueDataV2>()
 const relativeDateValueDataSchema = Joi.object<RelativeDateValueData>()
   .description('Relative date specification for date-based conditions')
   .keys({
+    type: Joi.string()
+      .trim()
+      .valid('RelativeDate')
+      .required()
+      .description('Type of the condition value, should be "RelativeDate"'),
     period: Joi.string()
       .trim()
       .required()


### PR DESCRIPTION
In the [previous PR](https://github.com/DEFRA/forms-designer/pull/922) we introduced a new RelativeDataSchemaV2 which does not have the `type`. However, I incorrectly removed the `type` from the V1 schema. This PR put's it back.

Updating the forms-runner forms-model version highlighted the mistake.