### PR TITLE
Feat/572248 allow email domains

### DIFF
--- a/designer/server/src/models/forms/notification-email.js
+++ b/designer/server/src/models/forms/notification-email.js
@@ -24,7 +24,7 @@ export function notificationEmailViewModel(metadata, validation) {
       },
       value: formValues?.notificationEmail ?? metadata.notificationEmail,
       hint: {
-        text: 'Used to send submitted forms for processing. Emails must end with ‘.gov.uk’ or ‘.org.uk’, like name@example.gov.uk or name@example.org.uk'
+        text: 'Used to send submitted forms for processing'
       }
     },
     buttonText: 'Save and continue'

--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -122,9 +122,7 @@ export const privacyNoticeUrlSchema = Joi.string()
 export const notificationEmailAddressSchema = Joi.string()
   .email()
   .trim()
-  .description(
-    'Email address to receive form submission notifications.Can be any domain'
-  )
+  .description('Email address to receive form submission notifications')
 
 export const authoredAtSchema = Joi.date()
   .iso()

--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -122,9 +122,8 @@ export const privacyNoticeUrlSchema = Joi.string()
 export const notificationEmailAddressSchema = Joi.string()
   .email({ tlds: { allow: ['uk'] } })
   .trim()
-  .pattern(/\.gov\.uk$|\.org\.uk$/)
   .description(
-    'Email address to receive form submission notifications, must be a .gov.uk or .org.uk address'
+    'Email address to receive form submission notifications.Can be any domain'
   )
 
 export const authoredAtSchema = Joi.date()

--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -120,7 +120,7 @@ export const privacyNoticeUrlSchema = Joi.string()
   .description('URL to the privacy notice for this form')
 
 export const notificationEmailAddressSchema = Joi.string()
-  .email({ tlds: { allow: ['uk'] } })
+  .email()
   .trim()
   .description(
     'Email address to receive form submission notifications.Can be any domain'


### PR DESCRIPTION
Allows any email domain for the notification email.
(Removed restriction on '.gov.uk' and '.org.uk'. Also removed further restriction on 'uk' TLD)