### PR TITLE
Fixed autocomplete textarea value after error

### DIFF
--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.js
@@ -324,6 +324,11 @@ export function getFieldValue(
   const validationResult = validation?.formValues[fieldName]
 
   if (validationResult || validationResult === '') {
+    if (fieldName === 'autoCompleteOptions') {
+      return mapListToAutoCompleteStr(
+        /** @type {List} */ ({ items: validationResult })
+      )
+    }
     return validationResult
   }
 
@@ -481,6 +486,6 @@ export function getFileUploadFields(questionFields, validation) {
 }
 
 /**
- * @import { FormDefinition, ComponentDef, FormEditor, FormEditorGovukField, FormEditorInputQuestion, GovukField, InputFieldsComponentsDef, FormEditorGovukFieldBase, FormEditorGovukFieldBaseKeys, FormComponentsDef } from '@defra/forms-model'
+ * @import { FormDefinition, ComponentDef, FormEditor, FormEditorGovukField, FormEditorInputQuestion, GovukField, InputFieldsComponentsDef, FormEditorGovukFieldBase, FormEditorGovukFieldBaseKeys, FormComponentsDef, List } from '@defra/forms-model'
  * @import { ValidationFailure } from '~/src/common/helpers/types.js'
  */

--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.test.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.test.js
@@ -128,6 +128,50 @@ describe('editor-v2 - advanced settings fields model', () => {
         )
       ).toEqual(expectedArray)
     })
+
+    test('should handle reconstructing autocomplete textarea during error condition', () => {
+      const expectedResult = {
+        id: 'autoCompleteOptions',
+        name: 'autoCompleteOptions',
+        idPrefix: 'autoCompleteOptions',
+        label: {
+          text: 'Add each option on a new line',
+          classes: 'govuk-label--s',
+          isPageHeading: false
+        },
+        hint: {
+          text: 'To optionally set an input value for each item, separate the option text and value with a colon (e.g English:en-gb)'
+        },
+        value: 'Red:red\r\nGreen:green\r\nBlue:blue',
+        customTemplate: 'auto-complete-options'
+      }
+      const validationInError = {
+        formValues: {
+          question: 'My autocomplete question',
+          hint: '',
+          shortDescription: 'Autocomplete',
+          autoCompleteOptions: [
+            { text: 'Red', value: 'red' },
+            { text: 'Green', value: 'green' },
+            { text: 'Blue', value: 'blue' }
+          ]
+        },
+        formErrors: {},
+        questionType: 'Autocomplete'
+      }
+      const res = getFieldList(
+        /** @type {InputFieldsComponentsDef} */ ({
+          options: { required: true }
+        }),
+        ComponentType.AutocompleteField,
+        // @ts-expect-error - types do not need to match for this test
+        validationInError,
+        buildDefinition()
+      )
+
+      const autoCompleteRes = res.find((x) => x.name === 'autoCompleteOptions')
+      expect(autoCompleteRes).toEqual(expectedResult)
+    })
   })
   describe('getFieldComponentType', () => {
     test('should throw if invalid or not implemented field type', () => {
@@ -421,5 +465,6 @@ describe('editor-v2 - advanced settings fields model', () => {
 })
 
 /**
- * @import { InputFieldsComponentsDef } from '@defra/forms-model'
+ * @import { FormEditor, InputFieldsComponentsDef } from '@defra/forms-model'
+ * @import { ValidationFailure } from '~/src/common/helpers/types.js'
  */


### PR DESCRIPTION
When saving on the Autcomplete question page, if an error occurred (e.g. if a condition was linked ot his autocomplete), the autocomplete textarea value was not being restored correctly