### PR TITLE
Fixes period field not erroring when given a non-numeric value

### DIFF
--- a/designer/server/src/models/forms/editor-v2/condition-value.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.js
@@ -20,19 +20,16 @@ const GOVUK_INPUT_WIDTH_10 = 'govuk-input--width-10'
 
 /**
  * @param { ErrorDetailsItem | undefined } formError
- * @param { string | number | undefined } fieldValue
  */
-export function insertDateValidationErrors(formError, fieldValue) {
-  if (fieldValue && fieldValue !== '') {
+export function insertDateValidationErrors(formError) {
+  if (!formError) {
     return {}
   }
 
   return {
-    ...(formError && {
-      errorMessage: {
-        text: formError.text
-      }
-    })
+    errorMessage: {
+      text: formError.text
+    }
   }
 }
 
@@ -72,10 +69,7 @@ export function relativeDateValueViewModel(idx, item, validation) {
     },
     classes: GOVUK_INPUT_WIDTH_10,
     value: periodValue,
-    ...insertDateValidationErrors(
-      formErrors?.[`items[${idx}].value.period`],
-      periodValue
-    )
+    ...insertDateValidationErrors(formErrors?.[`items[${idx}].value.period`])
   }
 
   // Unit select field
@@ -95,10 +89,7 @@ export function relativeDateValueViewModel(idx, item, validation) {
     },
     classes: GOVUK_RADIOS_SMALL,
     value: unitValue,
-    ...insertDateValidationErrors(
-      formErrors?.[`items[${idx}].value.unit`],
-      unitValue
-    )
+    ...insertDateValidationErrors(formErrors?.[`items[${idx}].value.unit`])
   }
 
   // Direction select field
@@ -118,10 +109,7 @@ export function relativeDateValueViewModel(idx, item, validation) {
     },
     classes: GOVUK_RADIOS_SMALL,
     value: directionValue,
-    ...insertDateValidationErrors(
-      formErrors?.[`items[${idx}].value.direction`],
-      directionValue
-    )
+    ...insertDateValidationErrors(formErrors?.[`items[${idx}].value.direction`])
   }
 
   return {

--- a/designer/server/src/models/forms/editor-v2/condition-value.test.js
+++ b/designer/server/src/models/forms/editor-v2/condition-value.test.js
@@ -16,16 +16,12 @@ describe('editor-v2 - condition-value', () => {
       text: 'Error on this field'
     })
 
-    test('should return empty object if field populated', () => {
-      expect(insertDateValidationErrors(formsError, 'some value')).toEqual({})
-    })
-
     test('should return empty object if no error object', () => {
-      expect(insertDateValidationErrors(undefined, '')).toEqual({})
+      expect(insertDateValidationErrors(undefined)).toEqual({})
     })
 
     test('should return error structure if field value undefined', () => {
-      expect(insertDateValidationErrors(formsError, '')).toEqual({
+      expect(insertDateValidationErrors(formsError)).toEqual({
         errorMessage: {
           text: 'Error on this field'
         }


### PR DESCRIPTION
Unnecessary extra logic removed to fix this bug.
Issue arose when 'period' was given a non-numeric value.
Typical screenshot of error shown below:
![image](https://github.com/user-attachments/assets/cc4fbc02-93b0-400e-92cd-4e5ac3d16e5c)
