### PR TITLE
Added conditions tab to guidance pages

### DIFF
--- a/designer/server/src/__stubs__/form-definition.js
+++ b/designer/server/src/__stubs__/form-definition.js
@@ -446,15 +446,6 @@ export const testFormDefinitionWithExistingGuidance = {
           title: 'html-title',
           content: 'Original guidance',
           options: {}
-        },
-        {
-          id: '99011',
-          type: ComponentType.TextField,
-          name: 'textField',
-          title: 'This is your first field',
-          hint: 'Help text',
-          options: {},
-          schema: {}
         }
       ],
       next: [{ path: '/summary' }]

--- a/designer/server/src/lib/editor.test.js
+++ b/designer/server/src/lib/editor.test.js
@@ -484,7 +484,7 @@ describe('editor.js', () => {
         })
 
         const patchUrl = new URL(
-          `./${formId}/definition/draft/pages/12345`,
+          `./${formId}/definition/draft/pages/p1`,
           formsEndpoint
         )
 
@@ -510,7 +510,7 @@ describe('editor.js', () => {
         }
 
         const formDefinitionWithNoPageHeading = structuredClone(
-          testFormDefinitionWithExistingGuidance
+          testFormDefinitionWithTwoPagesAndQuestions
         )
         formDefinitionWithNoPageHeading.pages[0].title = ''
 
@@ -518,8 +518,8 @@ describe('editor.js', () => {
           formId,
           token,
           formDefinitionWithNoPageHeading,
-          '12345',
-          '99011',
+          'p1',
+          'q1',
           questionDetails
         )
 

--- a/designer/server/src/models/forms/editor-v2/page-conditions.js
+++ b/designer/server/src/models/forms/editor-v2/page-conditions.js
@@ -8,7 +8,10 @@ import {
   getPageNum,
   toPresentationStringV2
 } from '~/src/models/forms/editor-v2/common.js'
-import { determineEditUrl } from '~/src/models/forms/editor-v2/pages.js'
+import {
+  determineEditUrl,
+  isGuidancePage
+} from '~/src/models/forms/editor-v2/pages.js'
 import { editorv2Path, formOverviewPath } from '~/src/models/links.js'
 
 /**
@@ -97,7 +100,7 @@ export function pageConditionsViewModel(
 
   const backLink = {
     href: backUrl,
-    text: backUrl.includes('/guidance/')
+    text: isGuidancePage(/** @type {Page} */ (page))
       ? 'Back to guidance'
       : 'Back to questions'
   }

--- a/designer/server/src/models/forms/editor-v2/page-conditions.js
+++ b/designer/server/src/models/forms/editor-v2/page-conditions.js
@@ -8,6 +8,7 @@ import {
   getPageNum,
   toPresentationStringV2
 } from '~/src/models/forms/editor-v2/common.js'
+import { determineEditUrl } from '~/src/models/forms/editor-v2/pages.js'
 import { editorv2Path, formOverviewPath } from '~/src/models/links.js'
 
 /**
@@ -89,9 +90,16 @@ export function pageConditionsViewModel(
     ? `Page ${pageNum}: ${page.title}`
     : `Page ${pageNum}`
 
+  const baseUrl = editorv2Path(metadata.slug, `page/`)
+  const pageUrl = `${baseUrl}${pageId}`
+
+  const backUrl = determineEditUrl(/** @type {Page} */ (page), false, baseUrl)
+
   const backLink = {
-    href: editorv2Path(metadata.slug, `page/${pageId}/questions`),
-    text: 'Back to questions'
+    href: backUrl,
+    text: backUrl.includes('/guidance/')
+      ? 'Back to guidance'
+      : 'Back to questions'
   }
 
   const conditionsManagerPath = editorv2Path(metadata.slug, 'conditions')
@@ -111,7 +119,7 @@ export function pageConditionsViewModel(
     backLink,
     currentTab: 'conditions',
     pageTitle: cardCaption,
-    baseUrl: editorv2Path(metadata.slug, `page/${pageId}`),
+    baseUrl: pageUrl,
     notification,
     errorList,
     formErrors: validation?.formErrors,
@@ -127,6 +135,6 @@ export function pageConditionsViewModel(
 }
 
 /**
- * @import { FormDefinition, ConditionWrapperV2, FormMetadata, RuntimeFormModel } from '@defra/forms-model'
+ * @import { FormDefinition, ConditionWrapperV2, FormMetadata, Page } from '@defra/forms-model'
  * @import { ValidationFailure } from '~/src/common/helpers/types.js'
  */

--- a/designer/server/src/models/forms/editor-v2/page-conditions.test.js
+++ b/designer/server/src/models/forms/editor-v2/page-conditions.test.js
@@ -1,6 +1,7 @@
 import { ConditionType, Engine, OperatorName } from '@defra/forms-model'
 import {
   buildDefinition,
+  buildMarkdownComponent,
   buildMetaData,
   buildQuestionPage,
   buildSummaryPage,
@@ -52,6 +53,12 @@ describe('page-conditions model', () => {
     id: componentId,
     name: 'farmType',
     title: 'What type of farming do you do?'
+  })
+
+  const testGuidanceComponent = buildMarkdownComponent({
+    id: componentId,
+    name: 'farmType',
+    title: 'Explanation of farming'
   })
 
   describe('getPageConditionDetails', () => {
@@ -299,7 +306,20 @@ describe('page-conditions model', () => {
       engine: Engine.V2
     })
 
-    it('should return complete view model with all required fields', () => {
+    const baseDefinitionWithGuidance = buildDefinition({
+      pages: [
+        buildQuestionPage({
+          id: pageId,
+          title: 'Farm Details',
+          components: [testGuidanceComponent]
+        }),
+        buildSummaryPage()
+      ],
+      conditions: [mockConditionV2],
+      engine: Engine.V2
+    })
+
+    it('should return complete view model with all required fields for a question', () => {
       const result = pageConditionsViewModel(metadata, baseDefinition, pageId)
 
       expect(result).toHaveProperty(
@@ -316,6 +336,41 @@ describe('page-conditions model', () => {
       expect(result).toHaveProperty('currentTab', 'conditions')
       expect(result).toHaveProperty('baseUrl')
       expect(result).toHaveProperty('backLink')
+      expect(result.backLink.href).toBe(
+        '/library/environmental-permit-application/editor-v2/page/farm-details-page/questions'
+      )
+      expect(result.backLink.text).toBe('Back to questions')
+      expect(result).toHaveProperty('navigation')
+      expect(result).toHaveProperty('allConditions')
+      expect(result).toHaveProperty('conditionsManagerPath')
+      expect(result).toHaveProperty('pageConditionsApiUrl')
+    })
+
+    it('should return complete view model with all required fields for a guidance page', () => {
+      const result = pageConditionsViewModel(
+        metadata,
+        baseDefinitionWithGuidance,
+        pageId
+      )
+
+      expect(result).toHaveProperty(
+        'formSlug',
+        'environmental-permit-application'
+      )
+      expect(result).toHaveProperty('pageId', pageId)
+      expect(result).toHaveProperty('cardTitle', 'Page 1')
+      expect(result).toHaveProperty('cardCaption', 'Page 1')
+      expect(result).toHaveProperty(
+        'pageSpecificHeading',
+        'Page 1: Farm Details'
+      )
+      expect(result).toHaveProperty('currentTab', 'conditions')
+      expect(result).toHaveProperty('baseUrl')
+      expect(result).toHaveProperty('backLink')
+      expect(result.backLink.href).toBe(
+        '/library/environmental-permit-application/editor-v2/page/farm-details-page/guidance/farm-type-field'
+      )
+      expect(result.backLink.text).toBe('Back to guidance')
       expect(result).toHaveProperty('navigation')
       expect(result).toHaveProperty('allConditions')
       expect(result).toHaveProperty('conditionsManagerPath')

--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -24,7 +24,9 @@ const BUTTON_SECONDARY_CLASS = 'govuk-button--secondary'
  */
 export function isGuidancePage(page) {
   const components = hasComponents(page) ? page.components : []
-  return components.length >= 1 && components[0].type === ComponentType.Markdown
+  return (
+    components.length === 1 && components[0].type === ComponentType.Markdown
+  )
 }
 
 /**

--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -21,6 +21,14 @@ const BUTTON_SECONDARY_CLASS = 'govuk-button--secondary'
 
 /**
  * @param {Page} page
+ */
+export function isGuidancePage(page) {
+  const components = hasComponents(page) ? page.components : []
+  return components.length >= 1 && components[0].type === ComponentType.Markdown
+}
+
+/**
+ * @param {Page} page
  * @param {boolean} isEndPage
  * @param {string} editBaseUrl
  */
@@ -29,11 +37,8 @@ export function determineEditUrl(page, isEndPage, editBaseUrl) {
     return `${editBaseUrl}${page.id}/check-answers-settings`
   }
 
-  const components = hasComponents(page) ? page.components : []
-  if (
-    components.length === 1 &&
-    components[0].type === ComponentType.Markdown
-  ) {
+  if (isGuidancePage(page)) {
+    const components = hasComponents(page) ? page.components : []
     return `${editBaseUrl}${page.id}/guidance/${components[0].id}`
   }
 

--- a/designer/server/src/models/forms/editor-v2/pages.test.js
+++ b/designer/server/src/models/forms/editor-v2/pages.test.js
@@ -2,6 +2,7 @@ import { ComponentType } from '@defra/forms-model'
 
 import {
   testFormDefinitionWithAGuidancePage,
+  testFormDefinitionWithExistingGuidance,
   testFormDefinitionWithExistingSummaryDeclaration,
   testFormDefinitionWithNoPages,
   testFormDefinitionWithNoQuestions,
@@ -12,6 +13,7 @@ import {
 import {
   determineEditUrl,
   hideFirstGuidance,
+  isGuidancePage,
   mapMarkdown,
   mapPageData,
   mapQuestionRows
@@ -240,8 +242,23 @@ describe('editor-v2 - pages model', () => {
       })
     })
   })
+
+  describe('isGuidancePage', () => {
+    test('should return false if page has no components', () => {
+      const [page1] = testFormDefinitionWithNoQuestions.pages
+      expect(isGuidancePage(page1)).toBeFalsy()
+    })
+    test('should return false if page has components but not guidance', () => {
+      const [page1] = testFormDefinitionWithTwoQuestions.pages
+      expect(isGuidancePage(page1)).toBeFalsy()
+    })
+    test('should return true if page is guidance page', () => {
+      const [page1] = testFormDefinitionWithExistingGuidance.pages
+      expect(isGuidancePage(page1)).toBeTruthy()
+    })
+  })
 })
 
 /**
- * @import { ComponentDef, MarkdownComponent, PageQuestion } from '@defra/forms-model'
+ * @import { ComponentDef, MarkdownComponent, Page, PageQuestion } from '@defra/forms-model'
  */

--- a/designer/server/src/routes/forms/editor-v2/guidance.test.js
+++ b/designer/server/src/routes/forms/editor-v2/guidance.test.js
@@ -52,8 +52,9 @@ describe('Editor v2 guidance routes', () => {
 
     expect($mainHeadings[0]).toHaveTextContent('Test form')
     expect($mainHeadings[1]).toHaveTextContent('Edit guidance page')
-    expect($actions).toHaveLength(3)
+    expect($actions).toHaveLength(4)
     expect($actions[2]).toHaveTextContent('Save')
+    expect($actions[3]).toHaveTextContent('Manage conditions')
   })
 
   test('POST - should error if missing mandatory fields', async () => {

--- a/designer/server/src/views/forms/editor-v2/guidance.njk
+++ b/designer/server/src/views/forms/editor-v2/guidance.njk
@@ -16,39 +16,15 @@
   description: pageDescription,
   caption: pageCaption,
   actions: pageActions,
-  classes: "govuk-grid-column-full govuk-grid-column-one-half-from-desktop",
+  classes: "govuk-grid-column-full",
   backLink: backLink,
   useNewMasthead: true
 }) %}
 
-  {% call appEditorCard({
-    title: cardTitle,
-    heading: cardHeading,
-    caption: cardCaption,
-    notification: notification,
-    errorList: errorList
-  }) %}
+    <div class="govuk-grid-column-one-half-from-desktop">
+      {%- include "../views/forms/editor-v2/partials/guidance-left-panel.njk" -%}
 
-    <form class="form" method="post">
-
-    {{ govukInput(fields.pageHeading) }}
-
-    {{ govukTextarea(fields.guidanceText) }}
-
-    {%- include "../views/forms/editor-v2/partials/markdown-help.njk" -%}
-
-    <div class="govuk-button-group govuk-!-margin-top-6">
-      {{ govukButton({
-        text: buttonText
-      }) }}
-
-      <a href="{{ baseUrl }}/delete/{{ questionId }}" class="govuk-link govuk-link--no-visited-state">
-        Delete page
-      </a>
     </div>
-
-    </form>
-    {% endcall %}
 
   {% endcall %}
 {% endblock %}

--- a/designer/server/src/views/forms/editor-v2/page-conditions.njk
+++ b/designer/server/src/views/forms/editor-v2/page-conditions.njk
@@ -27,7 +27,7 @@
                   <div class="govuk-summary-card__content">
 
                     <div class="app-tab-container">
-                      <a href="{{ baseUrl }}/questions" class="editor-card-title app-tab-link">{{ cardTitle }}</a>
+                      <a href="{{ backLink.href }}" class="editor-card-title app-tab-link">{{ cardTitle }}</a>
                       {%- include "../views/forms/editor-v2/partials/page-navigation-tabs.njk" -%}
                     </div>
 

--- a/designer/server/src/views/forms/editor-v2/partials/conditions.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/conditions.njk
@@ -1,0 +1,29 @@
+  {% set conditionsContent %}
+    <h2 class="govuk-heading-m govuk-!-margin-top-0">Current conditions</h2>
+    {% if hasPageCondition %}
+      <div class="govuk-!-margin-bottom-3">
+              <span class="govuk-body">
+                <span class="govuk-checkboxes__tick" style="color: #00703c; font-weight: bold;">✓</span>
+                {{ pageConditionDetails.displayName }}
+              </span>
+      </div>
+      {% if pageConditionPresentationString %}
+        <p class="govuk-body-s govuk-!-margin-bottom-0" style="color: #626a6e;">
+          {{ pageConditionPresentationString }}
+        </p>
+      {% endif %}
+    {% else %}
+        <p class="govuk-body govuk-!-margin-bottom-0">No conditions have been added to this page yet.</p>
+    {% endif %}
+  {% endset %}
+
+  <h1 class="govuk-heading-l">Page conditions</h1>
+  <p class="govuk-body">Control whether this page is shown to users based on their answer to a previous question</p>
+
+  {{ govukInsetText({
+    html: conditionsContent
+  }) }}
+
+  <a href="{{ baseUrl }}/conditions" class="govuk-button" role="button" draggable="false" data-module="govuk-button">
+    Manage conditions
+  </a>

--- a/designer/server/src/views/forms/editor-v2/partials/guidance-left-panel.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/guidance-left-panel.njk
@@ -60,35 +60,7 @@
                   </form>
 
                   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-                  {% set conditionsContent %}
-                    <h2 class="govuk-heading-m govuk-!-margin-top-0">Current conditions</h2>
-                    {% if hasPageCondition %}
-                      <div class="govuk-!-margin-bottom-3">
-                              <span class="govuk-body">
-                                <span class="govuk-checkboxes__tick" style="color: #00703c; font-weight: bold;">✓</span>
-                                {{ pageConditionDetails.displayName }}
-                              </span>
-                      </div>
-                      {% if pageConditionPresentationString %}
-                        <p class="govuk-body-s govuk-!-margin-bottom-0" style="color: #626a6e;">
-                          {{ pageConditionPresentationString }}
-                        </p>
-                      {% endif %}
-                    {% else %}
-                        <p class="govuk-body govuk-!-margin-bottom-0">No conditions have been added to this page yet.</p>
-                    {% endif %}
-                  {% endset %}
-
-                  <h1 class="govuk-heading-l">Page conditions</h1>
-                  <p class="govuk-body">Control whether this page is shown to users based on their answer to a previous question</p>
-
-                  {{ govukInsetText({
-                    html: conditionsContent
-                  }) }}
-
-                  <a href="{{ baseUrl }}/conditions" class="govuk-button" role="button" draggable="false" data-module="govuk-button">
-                    Manage conditions
-                  </a>
+                  {%- include "../../../../views/forms/editor-v2/partials/conditions.njk" -%}
                 </div>
               </div>
             </div>

--- a/designer/server/src/views/forms/editor-v2/partials/guidance-left-panel.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/guidance-left-panel.njk
@@ -58,7 +58,7 @@
                     </div>
 
                   </form>
-                  
+
                   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
                   {% set conditionsContent %}
                     <h2 class="govuk-heading-m govuk-!-margin-top-0">Current conditions</h2>

--- a/designer/server/src/views/forms/editor-v2/partials/guidance-left-panel.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/guidance-left-panel.njk
@@ -1,0 +1,100 @@
+{% from "icon-button/macro.njk" import appIconButton %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+
+<div class="govuk-summary-card govuk-!-margin-top-0 pages-panel-left-standard">
+  <div class="govuk-summary-card__content govuk-!-padding-top-0 editor-card-background">
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dd class="govuk-summary-list__value">
+          <div class="govuk-grid-row" id="page-settings-container-1">
+            <div id="card-1">
+              <div class="govuk-summary-card__content">
+                <div class="app-tab-container app-tab-container--title-only">
+                  <div class="editor-card-title">{{ cardTitle }}</div>
+                  {%- include "../../../../views/forms/editor-v2/partials/page-navigation-tabs.njk" -%}
+                </div>
+                <div class="govuk-!-padding-top-3">
+                  <span class="govuk-caption-l">{{ cardCaption }}</span>
+                  <h1 class="govuk-heading-l" id="page-heading">{{ cardHeading }}</h1>
+
+                  {% if errorList | length %}
+                    {{ govukErrorSummary({
+                      titleText: "There is a problem",
+                      errorList: errorList,
+                      classes: "govuk-!-margin-top-2 govuk-!-margin-bottom-4"
+                    }) }}
+                  {% endif %}
+                  {% if notification | length %}
+                    {% call govukNotificationBanner({
+                      type: "success"
+                    }) %}
+                      <p class="govuk-notification-banner__heading">{{ notification }}</p>
+                    {% endcall %}
+                  {% endif %}
+
+
+                  <form class="form" method="post">
+
+                    {{ govukInput(fields.pageHeading) }}
+
+                    {{ govukTextarea(fields.guidanceText) }}
+
+                    {%- include "../../../../views/forms/editor-v2/partials/markdown-help.njk" -%}
+
+                    <div class="govuk-button-group govuk-!-margin-top-6">
+                      {{ govukButton({
+                        text: buttonText
+                      }) }}
+
+                      <a href="{{ baseUrl }}/delete/{{ questionId }}" class="govuk-link govuk-link--no-visited-state">
+                        Delete page
+                      </a>
+                    </div>
+
+                  </form>
+                  
+                  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+                  {% set conditionsContent %}
+                    <h2 class="govuk-heading-m govuk-!-margin-top-0">Current conditions</h2>
+                    {% if hasPageCondition %}
+                      <div class="govuk-!-margin-bottom-3">
+                              <span class="govuk-body">
+                                <span class="govuk-checkboxes__tick" style="color: #00703c; font-weight: bold;">✓</span>
+                                {{ pageConditionDetails.displayName }}
+                              </span>
+                      </div>
+                      {% if pageConditionPresentationString %}
+                        <p class="govuk-body-s govuk-!-margin-bottom-0" style="color: #626a6e;">
+                          {{ pageConditionPresentationString }}
+                        </p>
+                      {% endif %}
+                    {% else %}
+                        <p class="govuk-body govuk-!-margin-bottom-0">No conditions have been added to this page yet.</p>
+                    {% endif %}
+                  {% endset %}
+
+                  <h1 class="govuk-heading-l">Page conditions</h1>
+                  <p class="govuk-body">Control whether this page is shown to users based on their answer to a previous question</p>
+
+                  {{ govukInsetText({
+                    html: conditionsContent
+                  }) }}
+
+                  <a href="{{ baseUrl }}/conditions" class="govuk-button" role="button" draggable="false" data-module="govuk-button">
+                    Manage conditions
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</div>

--- a/designer/server/src/views/forms/editor-v2/partials/questions-left-panel.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/questions-left-panel.njk
@@ -81,35 +81,7 @@
                       {%- include "../../../../views/forms/editor-v2/partials/page-settings.njk" -%}
                   </form>
                   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-                  {% set conditionsContent %}
-                    <h2 class="govuk-heading-m govuk-!-margin-top-0">Current conditions</h2>
-                    {% if hasPageCondition %}
-                      <div class="govuk-!-margin-bottom-3">
-                              <span class="govuk-body">
-                                <span class="govuk-checkboxes__tick" style="color: #00703c; font-weight: bold;">✓</span>
-                                {{ pageConditionDetails.displayName }}
-                              </span>
-                      </div>
-                      {% if pageConditionPresentationString %}
-                        <p class="govuk-body-s govuk-!-margin-bottom-0" style="color: #626a6e;">
-                          {{ pageConditionPresentationString }}
-                        </p>
-                      {% endif %}
-                    {% else %}
-                        <p class="govuk-body govuk-!-margin-bottom-0">No conditions have been added to this page yet.</p>
-                    {% endif %}
-                  {% endset %}
-
-                  <h1 class="govuk-heading-l">Page conditions</h1>
-                  <p class="govuk-body">Control whether this page is shown to users based on their answer to a previous question</p>
-
-                  {{ govukInsetText({
-                    html: conditionsContent
-                  }) }}
-
-                  <a href="{{ baseUrl }}/conditions" class="govuk-button" role="button" draggable="false" data-module="govuk-button">
-                    Manage conditions
-                  </a>
+                  {%- include "../../../../views/forms/editor-v2/partials/conditions.njk" -%}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Adds the condition tab (and conditions functionality) to the Guidance page

Ticket [DF-126](https://eaflood.atlassian.net/browse/DF-126)

[DF-126]: https://eaflood.atlassian.net/browse/DF-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ