### PR TITLE
feat: delete condition page

### DIFF
--- a/designer/server/src/lib/condition-references.js
+++ b/designer/server/src/lib/condition-references.js
@@ -1,0 +1,46 @@
+import { isConditionWrapperV2 } from '@defra/forms-model'
+
+/**
+ * Find all pages that reference a condition
+ * @param {FormDefinition} definition
+ * @param {string} conditionId
+ * @returns {{ pages: Array<{ pageId: string, pageNumber: number, pageTitle: string }>, conditions: Array<{ conditionId: string, conditionName: string }> }}
+ */
+export function findConditionReferences(definition, conditionId) {
+  const { pages, conditions } = definition
+
+  const pagesUsingCondition = pages
+    .map((page, index) => ({
+      page,
+      pageNumber: index + 1,
+      pageId: page.id ?? '',
+      pageTitle: page.title || `Page ${index + 1}`
+    }))
+    .filter(({ page }) => page.condition === conditionId)
+    .map(({ pageId, pageNumber, pageTitle }) => ({
+      pageId,
+      pageNumber,
+      pageTitle
+    }))
+
+  const conditionsReferencingThis = conditions
+    .filter(isConditionWrapperV2)
+    .filter((condition) =>
+      condition.items.some(
+        (item) => 'conditionId' in item && item.conditionId === conditionId
+      )
+    )
+    .map((condition) => ({
+      conditionId: condition.id,
+      conditionName: condition.displayName
+    }))
+
+  return {
+    pages: pagesUsingCondition,
+    conditions: conditionsReferencingThis
+  }
+}
+
+/**
+ * @import { FormDefinition } from '@defra/forms-model'
+ */

--- a/designer/server/src/lib/condition-references.test.js
+++ b/designer/server/src/lib/condition-references.test.js
@@ -1,0 +1,390 @@
+import { ConditionType, OperatorName } from '@defra/forms-model'
+import {
+  buildDefinition,
+  buildQuestionPage,
+  buildTextFieldComponent
+} from '@defra/forms-model/stubs'
+
+import { findConditionReferences } from '~/src/lib/condition-references.js'
+
+describe('condition-references', () => {
+  const componentId = 'farm-type-field'
+  const conditionId = 'cattle-farm-condition'
+  const referencingConditionId = 'joined-condition'
+
+  const testComponent = buildTextFieldComponent({
+    id: componentId,
+    name: 'farmType',
+    title: 'What type of farming do you do?'
+  })
+
+  const baseCondition = {
+    id: conditionId,
+    displayName: 'Show if cattle farming',
+    items: [
+      {
+        id: 'cattle-farm-check',
+        componentId,
+        operator: OperatorName.Is,
+        type: ConditionType.StringValue,
+        value: 'cattle'
+      }
+    ]
+  }
+
+  const referencingCondition = {
+    id: referencingConditionId,
+    displayName: 'Joined condition',
+    items: [
+      {
+        id: 'joined-item',
+        conditionId,
+        operator: OperatorName.Is,
+        type: ConditionType.StringValue,
+        value: true
+      }
+    ]
+  }
+
+  describe('findConditionReferences', () => {
+    it('should return empty arrays when condition has no references', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            components: [testComponent]
+          })
+        ],
+        conditions: [baseCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(0)
+      expect(result.conditions).toHaveLength(0)
+    })
+
+    it('should find pages that reference the condition', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            title: 'Farm Details',
+            components: [testComponent],
+            condition: conditionId
+          })
+        ],
+        conditions: [baseCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(1)
+      expect(result.pages[0]).toEqual({
+        pageId: 'page1',
+        pageNumber: 1,
+        pageTitle: 'Farm Details'
+      })
+      expect(result.conditions).toHaveLength(0)
+    })
+
+    it('should find multiple pages that reference the condition', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            title: 'Farm Details',
+            components: [testComponent],
+            condition: conditionId
+          }),
+          buildQuestionPage({
+            id: 'page2',
+            title: 'Livestock Information',
+            components: [testComponent],
+            condition: conditionId
+          }),
+          buildQuestionPage({
+            id: 'page3',
+            title: 'Other Page',
+            components: [testComponent]
+          })
+        ],
+        conditions: [baseCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(2)
+      expect(result.pages[0]).toEqual({
+        pageId: 'page1',
+        pageNumber: 1,
+        pageTitle: 'Farm Details'
+      })
+      expect(result.pages[1]).toEqual({
+        pageId: 'page2',
+        pageNumber: 2,
+        pageTitle: 'Livestock Information'
+      })
+      expect(result.conditions).toHaveLength(0)
+    })
+
+    it('should handle pages without titles', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            components: [testComponent],
+            condition: conditionId
+          })
+        ],
+        conditions: [baseCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(1)
+      expect(result.pages[0]).toEqual({
+        pageId: 'page1',
+        pageNumber: 1,
+        pageTitle: 'Page One'
+      })
+    })
+
+    it('should handle pages without IDs', () => {
+      const definition = buildDefinition({
+        pages: [
+          {
+            ...buildQuestionPage({
+              components: [testComponent],
+              condition: conditionId
+            }),
+            id: undefined
+          }
+        ],
+        conditions: [baseCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(1)
+      expect(result.pages[0]).toEqual({
+        pageId: '',
+        pageNumber: 1,
+        pageTitle: 'Page One'
+      })
+    })
+
+    it('should find conditions that reference the condition', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            components: [testComponent]
+          })
+        ],
+        conditions: [baseCondition, referencingCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(0)
+      expect(result.conditions).toHaveLength(1)
+      expect(result.conditions[0]).toEqual({
+        conditionId: referencingConditionId,
+        conditionName: 'Joined condition'
+      })
+    })
+
+    it('should find multiple conditions that reference the condition', () => {
+      const secondReferencingCondition = {
+        id: 'second-joined-condition',
+        displayName: 'Another joined condition',
+        items: [
+          {
+            id: 'second-joined-item',
+            conditionId,
+            operator: OperatorName.Is,
+            type: ConditionType.StringValue,
+            value: true
+          }
+        ]
+      }
+
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            components: [testComponent]
+          })
+        ],
+        conditions: [
+          baseCondition,
+          referencingCondition,
+          secondReferencingCondition
+        ]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(0)
+      expect(result.conditions).toHaveLength(2)
+      expect(result.conditions[0]).toEqual({
+        conditionId: referencingConditionId,
+        conditionName: 'Joined condition'
+      })
+      expect(result.conditions[1]).toEqual({
+        conditionId: 'second-joined-condition',
+        conditionName: 'Another joined condition'
+      })
+    })
+
+    it('should find both page and condition references', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            title: 'Farm Details',
+            components: [testComponent],
+            condition: conditionId
+          }),
+          buildQuestionPage({
+            id: 'page2',
+            title: 'Other Page',
+            components: [testComponent]
+          })
+        ],
+        conditions: [baseCondition, referencingCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(1)
+      expect(result.pages[0]).toEqual({
+        pageId: 'page1',
+        pageNumber: 1,
+        pageTitle: 'Farm Details'
+      })
+      expect(result.conditions).toHaveLength(1)
+      expect(result.conditions[0]).toEqual({
+        conditionId: referencingConditionId,
+        conditionName: 'Joined condition'
+      })
+    })
+
+    it('should handle conditions with multiple items', () => {
+      const multiItemCondition = {
+        id: 'multi-item-condition',
+        displayName: 'Multi-item condition',
+        items: [
+          {
+            id: 'item1',
+            componentId,
+            operator: OperatorName.Is,
+            type: ConditionType.StringValue,
+            value: 'test'
+          },
+          {
+            id: 'item2',
+            conditionId,
+            operator: OperatorName.Is,
+            type: ConditionType.StringValue,
+            value: true
+          }
+        ]
+      }
+
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            components: [testComponent]
+          })
+        ],
+        conditions: [baseCondition, multiItemCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(0)
+      expect(result.conditions).toHaveLength(1)
+      expect(result.conditions[0]).toEqual({
+        conditionId: 'multi-item-condition',
+        conditionName: 'Multi-item condition'
+      })
+    })
+
+    it('should not find conditions that reference different conditions', () => {
+      const nonReferencingCondition = {
+        id: 'non-referencing-condition',
+        displayName: 'Non-referencing condition',
+        items: [
+          {
+            id: 'non-ref-item',
+            conditionId: 'different-condition-id',
+            operator: OperatorName.Is,
+            type: ConditionType.StringValue,
+            value: true
+          }
+        ]
+      }
+
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            components: [testComponent]
+          })
+        ],
+        conditions: [baseCondition, nonReferencingCondition]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(0)
+      expect(result.conditions).toHaveLength(0)
+    })
+
+    it('should handle empty definition', () => {
+      const definition = buildDefinition({
+        pages: [],
+        conditions: []
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(0)
+      expect(result.conditions).toHaveLength(0)
+    })
+
+    it('should handle condition items without conditionId property', () => {
+      const conditionWithoutRef = {
+        id: 'condition-without-ref',
+        displayName: 'Condition without ref',
+        items: [
+          {
+            id: 'item-without-ref',
+            componentId,
+            operator: OperatorName.Is,
+            type: ConditionType.StringValue,
+            value: 'test'
+          }
+        ]
+      }
+
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            components: [testComponent]
+          })
+        ],
+        conditions: [baseCondition, conditionWithoutRef]
+      })
+
+      const result = findConditionReferences(definition, conditionId)
+
+      expect(result.pages).toHaveLength(0)
+      expect(result.conditions).toHaveLength(0)
+    })
+  })
+})

--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -507,5 +507,17 @@ export async function setPageCondition(formId, token, pageId, conditionName) {
 }
 
 /**
+ * Delete a condition from a form
+ * @param {string} formId
+ * @param {string} token
+ * @param {string} conditionId
+ */
+export async function deleteCondition(formId, token, conditionId) {
+  await delJson(buildRequestUrl(formId, `conditions/${conditionId}`), {
+    ...getHeaders(token)
+  })
+}
+
+/**
  * @import { ComponentDef, FormEditorInputCheckAnswersSettings, FormEditorInputPageSettings, FormDefinition, ConditionWrapperV2, Page } from '@defra/forms-model'
  */

--- a/designer/server/src/lib/editor.test.js
+++ b/designer/server/src/lib/editor.test.js
@@ -21,6 +21,7 @@ import {
   addCondition,
   addPageAndFirstQuestion,
   addQuestion,
+  deleteCondition,
   deletePage,
   deleteQuestion,
   getControllerType,
@@ -1110,6 +1111,40 @@ describe('editor.js', () => {
         await expect(
           deleteQuestion(formId, token, '12345', '67890', formDefinition)
         ).rejects.toThrow(testError)
+      })
+    })
+  })
+
+  describe('deleteCondition', () => {
+    const requestUrl = new URL(
+      `./${formId}/definition/draft/conditions/67890`,
+      formsEndpoint
+    )
+    const expectedOptions = {
+      headers: { Authorization: `Bearer ${token}` }
+    }
+
+    describe('when delJson succeeds', () => {
+      test('calls forms manager DELETE endpoint', async () => {
+        mockedDelJson.mockResolvedValueOnce({
+          response: createMockResponse(),
+          body: { result: 'ok' }
+        })
+
+        await deleteCondition(formId, token, '67890')
+
+        expect(mockedDelJson).toHaveBeenCalledWith(requestUrl, expectedOptions)
+      })
+    })
+
+    describe('when delJson fails', () => {
+      test('throws the error', async () => {
+        const testError = new Error('Network error')
+        mockedDelJson.mockRejectedValueOnce(testError)
+
+        await expect(deleteCondition(formId, token, '67890')).rejects.toThrow(
+          testError
+        )
       })
     })
   })

--- a/designer/server/src/models/forms/editor-v2/condition-delete.js
+++ b/designer/server/src/models/forms/editor-v2/condition-delete.js
@@ -1,0 +1,65 @@
+import { getConditionV2 } from '@defra/forms-model'
+
+import { findConditionReferences } from '~/src/lib/condition-references.js'
+import {
+  baseModelFields,
+  getFormSpecificNavigation
+} from '~/src/models/forms/editor-v2/common.js'
+import { editorFormPath, formOverviewPath } from '~/src/models/links.js'
+
+/**
+ * Model to represent delete condition confirmation page
+ * @param {FormMetadata} metadata
+ * @param {FormDefinition} definition
+ * @param {string} conditionId
+ */
+export function deleteConditionConfirmationPageViewModel(
+  metadata,
+  definition,
+  conditionId
+) {
+  const formTitle = metadata.title
+  const formPath = formOverviewPath(metadata.slug)
+  const navigation = getFormSpecificNavigation(
+    formPath,
+    metadata,
+    definition,
+    'Editor'
+  )
+
+  const condition = getConditionV2(definition, conditionId)
+  const { pages, conditions } = findConditionReferences(definition, conditionId)
+
+  const hasReferences = pages.length > 0 || conditions.length > 0
+  const pageHeading = 'Are you sure you want to delete this condition?'
+  const pageTitle = `${pageHeading} - ${formTitle}`
+
+  return {
+    ...baseModelFields(metadata.slug, pageTitle, pageHeading),
+    navigation,
+    bodyCaptionText: `Condition: ${condition.displayName}`,
+    bodyHeadingText: pageHeading,
+    bodyWarning: hasReferences
+      ? {
+          html: `Deleting this condition will affect the following pages:<ul class="govuk-list govuk-list--bullet">
+        ${pages.map((page) => `<li>Page ${page.pageNumber}</li>`).join('')}
+      </ul>`
+        }
+      : null,
+    buttons: [
+      {
+        text: 'Delete condition',
+        classes: 'govuk-button--warning'
+      },
+      {
+        href: editorFormPath(metadata.slug, 'conditions'),
+        text: 'Cancel',
+        classes: 'govuk-button--secondary'
+      }
+    ]
+  }
+}
+
+/**
+ * @import { FormMetadata, FormDefinition } from '@defra/forms-model'
+ */

--- a/designer/server/src/models/forms/editor-v2/condition-delete.test.js
+++ b/designer/server/src/models/forms/editor-v2/condition-delete.test.js
@@ -59,9 +59,10 @@ describe('editor-v2 - condition-delete model', () => {
       expect(result.pageTitle).toBe(
         'Are you sure you want to delete this condition? - Test form'
       )
-      expect(result.pageHeading).toBe(
-        'Are you sure you want to delete this condition?'
-      )
+      expect(result.pageHeading).toEqual({
+        text: 'Are you sure you want to delete this condition?',
+        size: 'large'
+      })
       expect(result.bodyCaptionText).toBe('Condition: Show if cattle farming')
       expect(result.bodyHeadingText).toBe(
         'Are you sure you want to delete this condition?'

--- a/designer/server/src/models/forms/editor-v2/condition-delete.test.js
+++ b/designer/server/src/models/forms/editor-v2/condition-delete.test.js
@@ -1,0 +1,170 @@
+import { ConditionType, OperatorName } from '@defra/forms-model'
+import {
+  buildDefinition,
+  buildMetaData,
+  buildQuestionPage,
+  buildTextFieldComponent
+} from '@defra/forms-model/stubs'
+
+import { deleteConditionConfirmationPageViewModel } from '~/src/models/forms/editor-v2/condition-delete.js'
+
+describe('editor-v2 - condition-delete model', () => {
+  const componentId = 'farm-type-field'
+  const pageId = 'farm-details-page'
+  const conditionId = 'cattle-farm-condition'
+
+  const testComponent = buildTextFieldComponent({
+    id: componentId,
+    name: 'farmType',
+    title: 'What type of farming do you do?'
+  })
+
+  const metadata = buildMetaData({
+    title: 'Test form',
+    slug: 'test-form'
+  })
+
+  const mockConditionV2 = {
+    id: conditionId,
+    displayName: 'Show if cattle farming',
+    items: [
+      {
+        id: 'cattle-farm-check',
+        componentId,
+        operator: OperatorName.Is,
+        type: ConditionType.StringValue,
+        value: 'cattle'
+      }
+    ]
+  }
+
+  describe('deleteConditionConfirmationPageViewModel', () => {
+    it('should return correct view model for condition with no references', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: pageId,
+            components: [testComponent]
+          })
+        ],
+        conditions: [mockConditionV2]
+      })
+
+      const result = deleteConditionConfirmationPageViewModel(
+        metadata,
+        definition,
+        conditionId
+      )
+
+      expect(result.pageTitle).toBe(
+        'Are you sure you want to delete this condition? - Test form'
+      )
+      expect(result.pageHeading).toBe(
+        'Are you sure you want to delete this condition?'
+      )
+      expect(result.bodyCaptionText).toBe('Condition: Show if cattle farming')
+      expect(result.bodyHeadingText).toBe(
+        'Are you sure you want to delete this condition?'
+      )
+      expect(result.bodyWarning).toBeNull()
+      expect(result.buttons).toHaveLength(2)
+      expect(result.buttons[0].text).toBe('Delete condition')
+      expect(result.buttons[0].classes).toBe('govuk-button--warning')
+      expect(result.buttons[1].text).toBe('Cancel')
+      expect(result.buttons[1].classes).toBe('govuk-button--secondary')
+      expect(result.buttons[1].href).toBe(
+        '/library/test-form/editor-v2/conditions'
+      )
+    })
+
+    it('should return correct view model for condition with page references', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: pageId,
+            components: [testComponent],
+            condition: conditionId
+          })
+        ],
+        conditions: [mockConditionV2]
+      })
+
+      const result = deleteConditionConfirmationPageViewModel(
+        metadata,
+        definition,
+        conditionId
+      )
+
+      expect(result.pageTitle).toBe(
+        'Are you sure you want to delete this condition? - Test form'
+      )
+      expect(result.bodyWarning).not.toBeNull()
+      expect(result.bodyWarning?.html).toContain(
+        'Deleting this condition will affect the following pages:'
+      )
+      expect(result.bodyWarning?.html).toContain('<li>Page 1</li>')
+    })
+
+    it('should return correct view model for condition with multiple page references', () => {
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: 'page1',
+            components: [testComponent],
+            condition: conditionId
+          }),
+          buildQuestionPage({
+            id: 'page2',
+            components: [testComponent],
+            condition: conditionId
+          })
+        ],
+        conditions: [mockConditionV2]
+      })
+
+      const result = deleteConditionConfirmationPageViewModel(
+        metadata,
+        definition,
+        conditionId
+      )
+
+      expect(result.bodyWarning).not.toBeNull()
+      expect(result.bodyWarning?.html).toContain('<li>Page 1</li>')
+      expect(result.bodyWarning?.html).toContain('<li>Page 2</li>')
+    })
+
+    it('should handle condition with different display name', () => {
+      const customCondition = {
+        id: 'custom-condition',
+        displayName: 'Custom condition name',
+        items: [
+          {
+            id: 'custom-check',
+            componentId,
+            operator: OperatorName.Is,
+            type: ConditionType.StringValue,
+            value: 'test'
+          }
+        ]
+      }
+
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            id: pageId,
+            components: [testComponent]
+          })
+        ],
+        conditions: [customCondition]
+      })
+
+      const result = deleteConditionConfirmationPageViewModel(
+        metadata,
+        definition,
+        'custom-condition'
+      )
+
+      expect(result.bodyCaptionText).toBe('Condition: Custom condition name')
+    })
+  })
+})

--- a/designer/server/src/routes/forms/editor-v2/condition-delete.js
+++ b/designer/server/src/routes/forms/editor-v2/condition-delete.js
@@ -1,0 +1,114 @@
+import { FormDefinitionError } from '@defra/forms-model'
+import { StatusCodes } from 'http-status-codes'
+
+import * as scopes from '~/src/common/constants/scopes.js'
+import { sessionNames } from '~/src/common/constants/session-names.js'
+import { buildSimpleErrorList } from '~/src/common/helpers/build-error-details.js'
+import { deleteCondition } from '~/src/lib/editor.js'
+import { isInvalidFormErrorType } from '~/src/lib/error-boom-helper.js'
+import * as forms from '~/src/lib/forms.js'
+import { CHANGES_SAVED_SUCCESSFULLY } from '~/src/models/forms/editor-v2/common.js'
+import * as viewModel from '~/src/models/forms/editor-v2/condition-delete.js'
+import { editorFormPath } from '~/src/models/links.js'
+
+const ROUTE_FULL_PATH = `/library/{slug}/editor-v2/condition/{conditionId}/delete`
+const CONFIRMATION_PAGE_VIEW = 'forms/confirmation-page'
+
+export default [
+  /**
+   * @satisfies {ServerRoute<{ Params: { slug: string, conditionId: string } }>}
+   */
+  ({
+    method: 'GET',
+    path: ROUTE_FULL_PATH,
+    async handler(request, h) {
+      const { params, auth } = request
+      const { token } = auth.credentials
+      const { slug, conditionId } = params
+
+      const metadata = await forms.get(slug, token)
+      const definition = await forms.getDraftFormDefinition(metadata.id, token)
+
+      return h.view(
+        CONFIRMATION_PAGE_VIEW,
+        viewModel.deleteConditionConfirmationPageViewModel(
+          metadata,
+          definition,
+          conditionId
+        )
+      )
+    },
+    options: {
+      auth: {
+        mode: 'required',
+        access: {
+          entity: 'user',
+          scope: [`+${scopes.SCOPE_WRITE}`]
+        }
+      }
+    }
+  }),
+
+  /**
+   * @satisfies {ServerRoute<{ Params: { slug: string, conditionId: string } }>}
+   */
+  ({
+    method: 'POST',
+    path: ROUTE_FULL_PATH,
+    async handler(request, h) {
+      const { params, auth, yar } = request
+      const { token } = auth.credentials
+      const { slug, conditionId } = params
+
+      const metadata = await forms.get(slug, token)
+      const formId = metadata.id
+
+      try {
+        await deleteCondition(formId, token, conditionId)
+
+        yar.flash(sessionNames.successNotification, CHANGES_SAVED_SUCCESSFULLY)
+
+        return h
+          .redirect(editorFormPath(slug, 'conditions'))
+          .code(StatusCodes.SEE_OTHER)
+      } catch (err) {
+        if (
+          isInvalidFormErrorType(
+            err,
+            FormDefinitionError.RefConditionConditionId
+          )
+        ) {
+          const definition = await forms.getDraftFormDefinition(formId, token)
+
+          const errorList = buildSimpleErrorList([
+            'This condition cannot be deleted because it is referenced by other conditions. Remove all references to this condition before deleting it.'
+          ])
+
+          return h.view(CONFIRMATION_PAGE_VIEW, {
+            ...viewModel.deleteConditionConfirmationPageViewModel(
+              metadata,
+              definition,
+              conditionId
+            ),
+            errorList
+          })
+        }
+
+        throw err
+      }
+    },
+    options: {
+      auth: {
+        mode: 'required',
+        access: {
+          entity: 'user',
+          scope: [`+${scopes.SCOPE_WRITE}`]
+        }
+      }
+    }
+  })
+]
+
+/**
+ * @import { ServerRoute } from '@hapi/hapi'
+ */

--- a/designer/server/src/routes/forms/editor-v2/condition-delete.test.js
+++ b/designer/server/src/routes/forms/editor-v2/condition-delete.test.js
@@ -1,0 +1,148 @@
+import { Engine } from '@defra/forms-model'
+import { buildDefinition } from '@defra/forms-model/stubs'
+import { StatusCodes } from 'http-status-codes'
+
+import { testFormMetadata } from '~/src/__stubs__/form-metadata.js'
+import { createServer } from '~/src/createServer.js'
+import * as editor from '~/src/lib/editor.js'
+import * as forms from '~/src/lib/forms.js'
+import { auth } from '~/test/fixtures/auth.js'
+import { renderResponse } from '~/test/helpers/component-helpers.js'
+
+jest.mock('~/src/lib/forms.js')
+jest.mock('~/src/lib/editor.js')
+
+describe('Editor v2 condition delete routes', () => {
+  /** @type {Server} */
+  let server
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const testDefinition = buildDefinition({
+    engine: Engine.V2,
+    pages: [
+      {
+        id: 'page1',
+        title: 'Page 1',
+        path: '/page-1',
+        condition: 'cond1',
+        next: [],
+        components: []
+      },
+      {
+        id: 'page2',
+        title: 'Page 2',
+        path: '/page-2',
+        next: [],
+        components: []
+      }
+    ],
+    conditions: [
+      {
+        id: 'cond1',
+        displayName: 'Test condition',
+        items: []
+      },
+      {
+        id: 'cond2',
+        displayName: 'Another condition',
+        items: [
+          {
+            id: 'ref1',
+            conditionId: 'cond1'
+          }
+        ]
+      }
+    ]
+  })
+
+  describe('GET /condition/{conditionId}/delete', () => {
+    test('should render confirmation page with warnings when condition is used', async () => {
+      jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+      jest
+        .mocked(forms.getDraftFormDefinition)
+        .mockResolvedValueOnce(testDefinition)
+
+      const options = {
+        method: 'get',
+        url: '/library/my-form-slug/editor-v2/condition/cond1/delete',
+        auth
+      }
+
+      const { container } = await renderResponse(server, options)
+
+      const $heading = container.getByRole('heading', {
+        level: 2,
+        name: 'Are you sure you want to delete this condition?'
+      })
+      const $warning = container.getByText(
+        'Deleting this condition will affect the following pages:'
+      )
+
+      expect($heading).toBeInTheDocument()
+      expect($warning).toBeInTheDocument()
+    })
+
+    test('should render confirmation page without warnings when condition is not used', async () => {
+      jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+      jest
+        .mocked(forms.getDraftFormDefinition)
+        .mockResolvedValueOnce(testDefinition)
+
+      const options = {
+        method: 'get',
+        url: '/library/my-form-slug/editor-v2/condition/cond2/delete',
+        auth
+      }
+
+      const { container } = await renderResponse(server, options)
+
+      const $heading = container.getByRole('heading', {
+        level: 2,
+        name: 'Are you sure you want to delete this condition?'
+      })
+      const $warning = container.queryByText(
+        'Deleting this condition will affect the following pages:'
+      )
+
+      expect($heading).toBeInTheDocument()
+      expect($warning).not.toBeInTheDocument()
+    })
+  })
+
+  describe('POST /condition/{conditionId}/delete', () => {
+    test('should delete condition and redirect to conditions list', async () => {
+      jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+      jest.mocked(editor.deleteCondition).mockResolvedValueOnce()
+
+      const options = {
+        method: 'post',
+        url: '/library/my-form-slug/editor-v2/condition/cond2/delete',
+        auth
+      }
+
+      const { response } = await renderResponse(server, options)
+
+      expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
+      expect(response.headers.location).toBe(
+        '/library/my-form-slug/editor-v2/conditions'
+      )
+      expect(editor.deleteCondition).toHaveBeenCalledWith(
+        testFormMetadata.id,
+        auth.credentials.token,
+        'cond2'
+      )
+    })
+  })
+})
+
+/**
+ * @import { Server } from '@hapi/hapi'
+ */

--- a/designer/server/src/routes/forms/index.js
+++ b/designer/server/src/routes/forms/index.js
@@ -6,6 +6,7 @@ import create from '~/src/routes/forms/create.js'
 import edit from '~/src/routes/forms/edit.js'
 import editorCheckAnswersSettings from '~/src/routes/forms/editor-v2/check-answers-settings.js'
 import editorConditionCheckChanges from '~/src/routes/forms/editor-v2/condition-check-changes.js'
+import editorConditionDelete from '~/src/routes/forms/editor-v2/condition-delete.js'
 import editorCondition from '~/src/routes/forms/editor-v2/condition.js'
 import editorConditions from '~/src/routes/forms/editor-v2/conditions.js'
 import editorDownload from '~/src/routes/forms/editor-v2/download.js'
@@ -45,6 +46,7 @@ export default [
   editorListItemDelete,
   editorCheckAnswersSettings,
   editorConditionCheckChanges,
+  editorConditionDelete,
   editorCondition,
   editorConditions,
   editorError,


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DF-59?atlOrigin=eyJpIjoiOTkwMTA5MDI1MGI1NGQ5ODhlN2M3MzcxNzFmYzBlNjkiLCJwIjoiaiJ9

This PR introduces the ability to delete a condition whether assigned to a page or not. It also surfaces an error if the user attempts to delete a joined condition.