### PR TITLE
Handle external links in markdown

### DIFF
--- a/model/src/utils/markdown.test.js
+++ b/model/src/utils/markdown.test.js
@@ -1,7 +1,9 @@
 import { markdownToHtml } from '~/src/utils/markdown.js'
 
 describe('Helpers', () => {
-  describe('markdown', () => {
+  describe('markdown with base URL', () => {
+    const exampleBaseUrl = 'https://defra.gov.uk'
+
     it.each([
       {
         markdown: '',
@@ -29,6 +31,33 @@ describe('Helpers', () => {
       {
         markdown: '1. item 1',
         html: '<ol>\n<li>item 1</li>\n</ol>\n'
+      },
+      {
+        markdown: '[link](https://defra.gov.uk)',
+        html: '<p><a class="govuk-link" href="https://defra.gov.uk">link</a></p>\n'
+      },
+      {
+        markdown: '[link](https://example.com)',
+        html: '<p><a class="govuk-link" href="https://example.com" target="_blank" rel="noreferrer noopener">link (opens in new tab)</a></p>\n'
+      },
+      {
+        markdown: '[link](mailto:dummy@defra.gov.uk)',
+        html: '<p><a class="govuk-link" href="mailto:dummy@defra.gov.uk">link</a></p>\n'
+      }
+    ])("formats '$markdown' to '$html'", ({ markdown, html }) => {
+      expect(markdownToHtml(markdown, exampleBaseUrl)).toBe(html)
+    })
+  })
+
+  describe('markdown without base URL should always show as internal', () => {
+    it.each([
+      {
+        markdown: '[link](https://defra.gov.uk)',
+        html: '<p><a class="govuk-link" href="https://defra.gov.uk">link</a></p>\n'
+      },
+      {
+        markdown: '[link](https://example.com)',
+        html: '<p><a class="govuk-link" href="https://example.com">link</a></p>\n'
       }
     ])("formats '$markdown' to '$html'", ({ markdown, html }) => {
       expect(markdownToHtml(markdown)).toBe(html)


### PR DESCRIPTION
Handles external links when rendering markdown. Relies on a `baseUrl` parameter fed by the consumer. For use-cases where it's a bit complicated (e.g. designer where the hostname of the running service won't match the runner which renders the form), I've left it optional. This effectively means only runner will change.