### PR TITLE
Prevent double highlighting on page preview

### DIFF
--- a/designer/server/src/common/components/preview-panel-layout/_preview-panel-layout.scss
+++ b/designer/server/src/common/components/preview-panel-layout/_preview-panel-layout.scss
@@ -68,6 +68,10 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
   .highlight {
     border-bottom: 2px solid #ffb266;
     color: govuk-colour("black");
+
+    .highlight {
+      border-bottom: inherit;
+    }
   }
 
   .govuk-radios__hint {

--- a/model/src/form/form-editor/preview/number-only.js
+++ b/model/src/form/form-editor/preview/number-only.js
@@ -6,6 +6,16 @@ export class NumberOnlyQuestion extends Question {
    * @type {ComponentType}
    */
   componentType = ComponentType.NumberField
+
+  /**
+   * @param {QuestionElements} htmlElements
+   * @param {QuestionRenderer} questionRenderer
+   */
+  constructor(htmlElements, questionRenderer) {
+    super(htmlElements, questionRenderer)
+    this._fieldName = 'numberField'
+  }
+
   /**
    * @returns {Partial<QuestionBaseModel>}
    */
@@ -17,5 +27,5 @@ export class NumberOnlyQuestion extends Question {
 }
 
 /**
- * @import { QuestionBaseModel } from '~/src/form/form-editor/preview/types.js'
+ * @import { QuestionElements, QuestionBaseModel, QuestionRenderer } from '~/src/form/form-editor/preview/types.js'
  */

--- a/model/src/form/form-editor/preview/number-only.test.js
+++ b/model/src/form/form-editor/preview/number-only.test.js
@@ -13,8 +13,8 @@ describe('NumberOnly', () => {
     )
     const res = new NumberOnlyQuestion(elements, renderer)
     expect(res.renderInput).toEqual({
-      id: 'inputField',
-      name: 'inputField',
+      id: 'numberField',
+      name: 'numberField',
       classes: '',
       label: {
         text: 'Which quest would you like to pick?',


### PR DESCRIPTION
Prevent double highlighting on page preview

<img width="814" height="341" alt="image" src="https://github.com/user-attachments/assets/fd5261a8-f5fd-4b38-8851-7f66895dca31" />
