### PR TITLE
Feat/df 289 sanitise preview instantiation

### DIFF
--- a/designer/server/src/lib/utils.js
+++ b/designer/server/src/lib/utils.js
@@ -295,6 +295,14 @@ export function requiresPageTitle(page) {
 }
 
 /**
+ * @param {string} json
+ * @returns {string}
+ */
+export function sanitiseJSON(json) {
+  return json.replace(/(<([^>]+)>)/gi, '')
+}
+
+/**
  * @import { ErrorDetailsItem } from '~/src/common/helpers/types.js'
  * @import { ComponentDef, FormDefinition, Item, List, ListItem, Page, QuestionSessionState, ListComponentsDef } from '@defra/forms-model'
  * @import Wreck from '@hapi/wreck'

--- a/designer/server/src/lib/utils.test.js
+++ b/designer/server/src/lib/utils.test.js
@@ -21,7 +21,8 @@ import {
   getHeaders,
   getListFromComponent,
   mapListToTextareaStr,
-  noListToSave
+  noListToSave,
+  sanitiseJSON
 } from '~/src/lib/utils.js'
 
 jest.mock('@defra/hapi-tracing')
@@ -312,6 +313,17 @@ describe('utils', () => {
           'e36fdaad-1395-4efe-bfec-ceae7efaf8e3'
         )
       ).toEqual([])
+    })
+  })
+
+  describe('sanitiseJSON', () => {
+    it('should remove HTML tags from JSON objects', () => {
+      const dirtyJSON = JSON.stringify({
+        text: "<script>alert('xss')</script>"
+      })
+      expect(sanitiseJSON(dirtyJSON)).toEqual(
+        JSON.stringify({ text: "alert('xss')" })
+      )
     })
   })
 })

--- a/designer/server/src/models/forms/editor-v2/check-answers-settings.js
+++ b/designer/server/src/models/forms/editor-v2/check-answers-settings.js
@@ -8,6 +8,7 @@ import { buildErrorList } from '~/src/common/helpers/build-error-details.js'
 import {
   getPageFromDefinition,
   insertValidationErrors,
+  sanitiseJSON,
   stringHasValue
 } from '~/src/lib/utils.js'
 import {
@@ -101,9 +102,13 @@ export function getPreviewModel(page, definition, previewPageUrl, fields) {
     needDeclaration
   )
 
+  const sanitisedDefinition = JSON.parse(
+    sanitiseJSON(JSON.stringify(definition))
+  )
+
   const previewPageController = new SummaryPageController(
     elements,
-    definition,
+    sanitisedDefinition,
     dummyRenderer
   )
 
@@ -184,8 +189,7 @@ export function checkAnswersSettingsViewModel(
     formValues: validation?.formValues,
     previewModel,
     preview: {
-      page: JSON.stringify(page),
-      definition: JSON.stringify(definition),
+      definition: sanitiseJSON(JSON.stringify(definition)),
       pageTemplate: 'summary-controller.njk'
     },
     buttonText: SAVE_AND_CONTINUE,

--- a/designer/server/src/models/forms/editor-v2/check-answers-settings.test.js
+++ b/designer/server/src/models/forms/editor-v2/check-answers-settings.test.js
@@ -1,11 +1,14 @@
 import {
   buildDefinition,
+  buildMarkdownComponent,
+  buildMetaData,
   buildQuestionPage,
   buildSummaryPage,
   buildTextFieldComponent
 } from '@defra/forms-model/stubs'
 
 import {
+  checkAnswersSettingsViewModel,
   getPreviewModel,
   settingsFields
 } from '~/src/models/forms/editor-v2/check-answers-settings.js'
@@ -35,6 +38,61 @@ describe('check answers settings', () => {
       expect(previewModel.componentRows.rows).toBeInstanceOf(Array)
       expect(previewModel.components).toEqual([])
       expect(previewModel.previewTitle).toBe('Preview of Check answers page')
+    })
+
+    it('should strip html tags from the preview JSON', () => {
+      const page = buildSummaryPage()
+      const definition = buildDefinition({
+        pages: [
+          buildQuestionPage({
+            components: [
+              buildTextFieldComponent({
+                shortDescription: "Your name <script>alert('xss')</script>"
+              })
+            ]
+          })
+        ]
+      })
+      const fields = settingsFields('false', '')
+      const previewModel = getPreviewModel(
+        page,
+        definition,
+        'http://url',
+        fields
+      )
+      expect(previewModel.componentRows.rows[0].key).toEqual({
+        text: "Your name alert('xss')"
+      })
+    })
+  })
+  describe('checkAnswersSettingsViewModel', () => {
+    it('should remove html tags', () => {
+      const metadata = buildMetaData()
+      const pageId = 'ee54ead5-3dcb-4066-a13c-b1cd3562ae0b'
+      const definition = buildDefinition({
+        pages: [
+          buildSummaryPage({
+            id: pageId,
+            components: [
+              buildMarkdownComponent({
+                content: "<script>alert('xss')</script>"
+              })
+            ]
+          })
+        ]
+      })
+
+      const model = checkAnswersSettingsViewModel(
+        metadata,
+        definition,
+        pageId,
+        undefined,
+        []
+      )
+
+      expect(model.preview.definition).toBe(
+        '{"name":"Test form","pages":[{"id":"ee54ead5-3dcb-4066-a13c-b1cd3562ae0b","title":"Summary page","components":[{"id":"4a2dc88c-be1a-4277-aff8-04220de2e778","title":"Markdown Component","name":"MarkdownComponent","options":{},"content":"alert(\'xss\')","type":"Markdown"}],"path":"/summary","controller":"SummaryPageController"}],"conditions":[],"sections":[],"lists":[]}'
+      )
     })
   })
 })

--- a/designer/server/src/models/forms/editor-v2/questions.js
+++ b/designer/server/src/models/forms/editor-v2/questions.js
@@ -13,6 +13,7 @@ import {
   insertValidationErrors,
   isCheckboxSelected,
   numberHasValue,
+  sanitiseJSON,
   stringHasValue
 } from '~/src/lib/utils.js'
 import {
@@ -448,8 +449,8 @@ export function questionsViewModel(
     // prettier-ignore
     previewModel: getPreviewModel(page, definition, previewPageUrl, previewErrorsUrl, fields.guidanceText.value),
     preview: {
-      page: JSON.stringify(page),
-      definition: JSON.stringify(definition)
+      page: sanitiseJSON(JSON.stringify(page)),
+      definition: sanitiseJSON(JSON.stringify(definition))
     },
     cardTitle,
     cardCaption: pageHeading,

--- a/designer/server/src/models/forms/editor-v2/questions.test.js
+++ b/designer/server/src/models/forms/editor-v2/questions.test.js
@@ -378,6 +378,39 @@ describe('editor-v2 - questions model', () => {
         ])
       })
 
+      it('should sanitise the JSON', () => {
+        const definition = buildDefinition({
+          pages: [
+            buildQuestionPage({
+              id: pageId,
+              title: 'Farm Details',
+              components: [
+                buildMarkdownComponent({
+                  content: `</script><script>alert('xss attack')</script><script>`
+                }),
+                testComponent
+              ]
+            }),
+            buildSummaryPage()
+          ],
+          conditions: [],
+          engine: Engine.V2
+        })
+
+        const result = questionsViewModel(
+          metadata,
+          definition,
+          pageId,
+          emptyReorderDetails
+        )
+        const definitionParsed = JSON.parse(result.preview.definition)
+        const pageParsed = JSON.parse(result.preview.page)
+        expect(pageParsed.components[0].content).toBe("alert('xss attack')")
+        expect(definitionParsed.pages[0].components[0].content).toBe(
+          "alert('xss attack')"
+        )
+      })
+
       it('should include the page title required properties', () => {
         const definition = buildDefinition({
           pages: [


### PR DESCRIPTION
## Sanitise JSON output on preview pages

As we are using JSON on the f/e it's worth removing any html tags from the page/definition JSONs.

Ticket:
https://eaflood.atlassian.net/browse/DF-289