### PR TITLE
Corrected controller logic DF-288

### DIFF
--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -326,6 +326,8 @@ export function getControllerTypeAndProperties(page, components, payload) {
       isCurrentlyRepeater,
       payload
     )
+  } else {
+    // Do nothing - to satisfy SonarCloud
   }
   return { controllerType, additionalProperties }
 }

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -52,8 +52,8 @@ export function getQuestionsOnPage(definition, pageId) {
  * @param {string} questionId
  */
 export function getQuestionNum(definition, pageId, questionId) {
-  const questions = getQuestionsOnPage(definition, pageId).filter((q) =>
-    isFormType(q.type)
+  const questions = getQuestionsOnPage(definition, pageId).filter(
+    (q) => isFormType(q.type) // Exclude non-form components such as Markdown
   )
   if (questionId === 'new') {
     return questions.length + 1

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -4,7 +4,8 @@ import {
   convertConditionWrapperFromV2,
   hasComponents,
   hasComponentsEvenIfNoNext,
-  isConditionWrapperV2
+  isConditionWrapperV2,
+  isFormType
 } from '@defra/forms-model'
 
 import { buildEntry } from '~/src/common/nunjucks/context/build-navigation.js'
@@ -51,7 +52,9 @@ export function getQuestionsOnPage(definition, pageId) {
  * @param {string} questionId
  */
 export function getQuestionNum(definition, pageId, questionId) {
-  const questions = getQuestionsOnPage(definition, pageId)
+  const questions = getQuestionsOnPage(definition, pageId).filter((q) =>
+    isFormType(q.type)
+  )
   if (questionId === 'new') {
     return questions.length + 1
   }

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -116,7 +116,7 @@ export function controllerNameFromPath(nameOrPath?: ControllerType | string) {
   return options?.name
 }
 
-function includesFileUploadField(components: ComponentDef[]): boolean {
+export function includesFileUploadField(components: ComponentDef[]): boolean {
   return components.some(
     (component) => component.type === ComponentType.FileUploadField
   )

--- a/model/src/pages/index.ts
+++ b/model/src/pages/index.ts
@@ -14,6 +14,7 @@ export {
   hasFormComponents,
   hasNext,
   hasRepeater,
+  includesFileUploadField,
   isControllerName,
   omitFileUploadComponent,
   showRepeaterSettings


### PR DESCRIPTION
Bug [DF-288](https://eaflood.atlassian.net/browse/DF-288)

Sets appropriate controller type (or unsets if no longer needed)
- on add question
- on update question
- allows component type to be changed during edit of question, and correct controller gets set
- fixes a different bug where the incorrect question number was appearing when editing a question (when you had guidance on that page)

[DF-288]: https://eaflood.atlassian.net/browse/DF-288