### PR TITLE
Fixed joined condition original condition summary text

### DIFF
--- a/designer/server/src/models/forms/editor-v2/check-answers-settings.js
+++ b/designer/server/src/models/forms/editor-v2/check-answers-settings.js
@@ -1,5 +1,6 @@
 import {
   ComponentType,
+  FormStatus,
   SummaryPageController,
   hasComponentsEvenIfNoNext
 } from '@defra/forms-model'
@@ -14,6 +15,7 @@ import {
   GOVUK_LABEL__M,
   SAVE_AND_CONTINUE,
   baseModelFields,
+  buildPreviewUrl,
   getFormSpecificNavigation
 } from '~/src/models/forms/editor-v2/common.js'
 import { SummaryPreviewSSR } from '~/src/models/forms/editor-v2/preview/page-preview.js'
@@ -163,9 +165,11 @@ export function checkAnswersSettingsViewModel(
     validation
   )
   const pageHeading = 'Page settings'
+  const previewPageUrl = `${buildPreviewUrl(metadata.slug, FormStatus.Draft)}${page?.path}?force`
+
   // prettier-ignore
   const previewModel = getPreviewModel(
-    page, definition, 'previewPageUrl', fields
+    page, definition, previewPageUrl, fields
   )
 
   return {

--- a/designer/server/src/models/forms/editor-v2/conditions-join.js
+++ b/designer/server/src/models/forms/editor-v2/conditions-join.js
@@ -4,7 +4,8 @@ import { buildErrorList } from '~/src/common/helpers/build-error-details.js'
 import {
   baseModelFields,
   buildPreviewUrl,
-  getFormSpecificNavigation
+  getFormSpecificNavigation,
+  toPresentationHtmlV2
 } from '~/src/models/forms/editor-v2/common.js'
 import {
   buildConditionsField,
@@ -70,6 +71,9 @@ export function conditionsJoinViewModel(
     validation
   )
 
+  const existingConditionHtml = existingCondition
+    ? toPresentationHtmlV2(existingCondition, definition)
+    : ''
   const cardTitle =
     conditionId === 'new' ? 'Create joined condition' : 'Edit joined condition'
 
@@ -90,6 +94,7 @@ export function conditionsJoinViewModel(
       displayName
     },
     existingCondition,
+    existingConditionHtml,
     conditionId,
     backLink: {
       href: `/library/${metadata.slug}/editor-v2/conditions`,

--- a/designer/server/src/models/forms/editor-v2/conditions-join.test.js
+++ b/designer/server/src/models/forms/editor-v2/conditions-join.test.js
@@ -130,6 +130,9 @@ describe('editor-v2 - conditions-join model', () => {
         conditionId: 'existing-joined'
       })
       expect(result.existingCondition).toBe(existingJoinedCondition)
+      expect(result.existingConditionHtml).toBe(
+        "'First condition' <span class=\"govuk-!-font-weight-bold\">OR</span> 'Second condition'"
+      )
     })
 
     it('should generate conditions field correctly', () => {

--- a/designer/server/src/views/forms/editor-v2/conditions-join.njk
+++ b/designer/server/src/views/forms/editor-v2/conditions-join.njk
@@ -40,7 +40,7 @@
           <div class="govuk-summary-card__title">Original condition</div>
         </div>
         <div class="govuk-summary-card__content">
-          <p class="govuk-body govuk-!-font-weight-bold">{{ existingCondition.displayName }}</p>
+          <p class="govuk-body">{{ existingConditionHtml | safe }}</p>
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
Bug [DF-324](https://eaflood.atlassian.net/browse/DF-324)

Wrong summary text for original condition when editing a joined condition

- Also fixed wrong preview link in Check Your Answers

[DF-324]: https://eaflood.atlassian.net/browse/DF-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ