### PR TITLE
Feat/df 289 fetch definition

### DIFF
--- a/designer/client/src/javascripts/preview/page-controller/get-page-details.js
+++ b/designer/client/src/javascripts/preview/page-controller/get-page-details.js
@@ -3,12 +3,16 @@ import { getPageFromDefinition } from '@defra/forms-model'
 /**
  * @param {string} formId
  * @param { string | undefined } pageId
- * @returns {Promise<{page: Page, definition: FormDefinition>}
+ * @returns {Promise<{ page?: Page, definition: FormDefinition }>}
  */
 export async function getPageAndDefinition(formId, pageId) {
-  const response = await global.fetch(`/api/${formId}/data`)
+  const response = await window.fetch(`/api/${formId}/data`)
   const definition = await response.json()
-  const page = getPageFromDefinition(definition, pageId)
+
+  let page
+  if (pageId) {
+    page = getPageFromDefinition(definition, pageId)
+  }
 
   return {
     page,

--- a/designer/client/src/javascripts/preview/page-controller/get-page-details.js
+++ b/designer/client/src/javascripts/preview/page-controller/get-page-details.js
@@ -1,0 +1,21 @@
+import { getPageFromDefinition } from '@defra/forms-model'
+
+/**
+ * @param {string} formId
+ * @param { string | undefined } pageId
+ * @returns {Promise<{page: Page, definition: FormDefinition>}
+ */
+export async function getPageAndDefinition(formId, pageId) {
+  const response = await global.fetch(`/api/${formId}/data`)
+  const definition = await response.json()
+  const page = getPageFromDefinition(definition, pageId)
+
+  return {
+    page,
+    definition
+  }
+}
+
+/**
+ * @import { Page, FormDefinition } from '@defra/forms-model'
+ */

--- a/designer/client/src/javascripts/preview/page-controller/get-page-details.test.js
+++ b/designer/client/src/javascripts/preview/page-controller/get-page-details.test.js
@@ -9,13 +9,14 @@ describe('get-page-details', () => {
     id: pageId
   })
   const formDefinition = buildDefinition({
-    id: formId,
     pages: [page]
   })
-  global.fetch = jest.fn(() =>
-    Promise.resolve({
-      json: () => Promise.resolve(formDefinition)
-    })
+  window.fetch = jest.fn(() =>
+    Promise.resolve(
+      /** @type {Response} */ ({
+        json: () => Promise.resolve(formDefinition)
+      })
+    )
   )
   describe('getPageAndDefinition', () => {
     it('should get page and declaration', async () => {

--- a/designer/client/src/javascripts/preview/page-controller/get-page-details.test.js
+++ b/designer/client/src/javascripts/preview/page-controller/get-page-details.test.js
@@ -1,0 +1,39 @@
+import { buildDefinition, buildQuestionPage } from '@defra/forms-model/stubs'
+
+import { getPageAndDefinition } from '~/src/javascripts/preview/page-controller/get-page-details.js'
+
+describe('get-page-details', () => {
+  const formId = '54ad568c-28ee-4276-b52b-63ed5309c30b'
+  const pageId = '2c35bb7f-c2d1-4e7f-a753-a38a78d9b1d1'
+  const page = buildQuestionPage({
+    id: pageId
+  })
+  const formDefinition = buildDefinition({
+    id: formId,
+    pages: [page]
+  })
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve(formDefinition)
+    })
+  )
+  describe('getPageAndDefinition', () => {
+    it('should get page and declaration', async () => {
+      const pageAndDeclaration = await getPageAndDefinition(formId, pageId)
+
+      expect(pageAndDeclaration).toEqual({
+        page,
+        definition: formDefinition
+      })
+    })
+
+    it('should get declaration if no pageId exists', async () => {
+      const pageAndDeclaration = await getPageAndDefinition(formId, undefined)
+
+      expect(pageAndDeclaration).toEqual({
+        page: undefined,
+        definition: formDefinition
+      })
+    })
+  })
+})

--- a/designer/client/src/javascripts/preview/page-controller/setup-page-controller.js
+++ b/designer/client/src/javascripts/preview/page-controller/setup-page-controller.js
@@ -34,6 +34,7 @@ import {
 import { AutocompleteRendererBase } from '~/src/javascripts/preview/autocomplete-renderer.js'
 import { NunjucksPageRenderer } from '~/src/javascripts/preview/nunjucks-page-renderer.js'
 import { NunjucksRendererBase } from '~/src/javascripts/preview/nunjucks-renderer.js'
+import { getPageAndDefinition } from '~/src/javascripts/preview/page-controller/get-page-details.js'
 import {
   PagePreviewDomElements,
   PagePreviewListeners
@@ -83,10 +84,14 @@ function setupListener(previewPageController, elements) {
 
 /**
  * Setup the Page Controller for client
- * @param {Page} page
- * @param {FormDefinition} definition
+ * @param {string} pageId
+ * @param {string} definitionId
  */
-export function setupPageController(page, definition) {
+export async function setupPageController(pageId, definitionId) {
+  const { page, definition } = await getPageAndDefinition(definitionId, pageId)
+  if (!page) {
+    throw new Error(`Page not found with id ${pageId}`)
+  }
   const [components, elements, renderer] = baseControllerSetup(page)
 
   const previewPageController = new PreviewPageController(
@@ -101,10 +106,10 @@ export function setupPageController(page, definition) {
 
 /**
  * Setup the Page Controller for client
- * @param {FormDefinition} definition
- * @returns {SummaryPageController}
+ * @param {string} definitionId
  */
-export function setupSummaryPageController(definition) {
+export async function setupSummaryPageController(definitionId) {
+  const { definition } = await getPageAndDefinition(definitionId, undefined)
   const elements = new SummaryPagePreviewDomElements()
   const nunjucksRenderBase = new NunjucksRendererBase(elements)
   const renderer = new NunjucksPageRenderer(nunjucksRenderBase)
@@ -135,10 +140,11 @@ export function setupGuidanceController() {
 
 /**
  * Setup the Page Controller for client
- * @param {Page} page
- * @param {FormDefinition} definition
+ * @param {string} pageId
+ * @param {string} definitionId
  */
-export function setupReorderQuestionsController(page, definition) {
+export async function setupReorderQuestionsController(pageId, definitionId) {
+  const { page, definition } = await getPageAndDefinition(definitionId, pageId)
   const elements = new ReorderQuestionsPagePreviewDomElements()
   const components = /** @type {ComponentDef[]} */ (
     hasComponents(page) ? page.components : []

--- a/designer/client/src/javascripts/preview/page-controller/setup-page-controller.test.js
+++ b/designer/client/src/javascripts/preview/page-controller/setup-page-controller.test.js
@@ -20,6 +20,7 @@ import {
   summaryPageHTML
 } from '~/src/javascripts/preview/__stubs__/page.js'
 import { questionDetailsPreviewHTML } from '~/src/javascripts/preview/__stubs__/question'
+import { getPageAndDefinition } from '~/src/javascripts/preview/page-controller/get-page-details.js'
 import {
   setupGuidanceController,
   setupPageController,
@@ -56,6 +57,7 @@ jest.mock('~/src/views/preview-controllers/summary-controller.njk', () => '')
 jest.mock('~/src/views/summary-preview-component/template.njk', () => '')
 jest.mock('~/src/views/summary-preview-component/macro.njk', () => '')
 jest.mock('~/src/javascripts/preview/nunjucks-renderer.js')
+jest.mock('~/src/javascripts/preview/page-controller/get-page-details.js')
 
 describe('setup-page-controller', () => {
   const components = [
@@ -67,7 +69,10 @@ describe('setup-page-controller', () => {
     }),
     buildMarkdownComponent()
   ]
+  const pageId = 'ff2c6c10-f49b-44e4-bc70-5c85eb5a006a'
+  const definitionId = 'a6060751-3b61-4cf9-ae94-76e15c89eacc'
   const page = buildQuestionPage({
+    id: pageId,
     title: 'Page title',
     components
   })
@@ -76,25 +81,33 @@ describe('setup-page-controller', () => {
   })
 
   describe('setupPageController', () => {
-    it('should setup', () => {
+    jest.mocked(getPageAndDefinition).mockResolvedValue({
+      definition,
+      page
+    })
+    it('should setup', async () => {
       document.body.innerHTML =
         pageHeadingAndGuidanceHTML + questionDetailsPreviewHTML
 
-      const pageController = setupPageController(page, definition)
+      const pageController = await setupPageController(pageId, definitionId)
       expect(pageController).toBeInstanceOf(PreviewPageController)
     })
 
-    it('should handle pages without components', () => {
+    it('should handle pages without components', async () => {
       document.body.innerHTML = '<p>missing content</p>'
 
-      const page2 = buildSummaryPage({ title: 'Summary page' })
+      const page2 = buildSummaryPage({ id: pageId, title: 'Summary page' })
       const definition2 = buildDefinition({ pages: [page2] })
-      const pageController = setupPageController(page2, definition2)
+      jest.mocked(getPageAndDefinition).mockResolvedValue({
+        definition: definition2,
+        page: page2
+      })
+      const pageController = await setupPageController(pageId, definitionId)
       expect(pageController).toBeInstanceOf(PreviewPageController)
       expect(pageController.title).toBe('')
     })
 
-    it('should handle autocomplete components', () => {
+    it('should handle autocomplete components', async () => {
       document.body.innerHTML =
         pageHeadingAndGuidanceHTML + questionDetailsPreviewHTML
       const listId = 'feaa6e19-414d-4633-9c8c-1135bc84f1f2'
@@ -113,13 +126,18 @@ describe('setup-page-controller', () => {
         list: listId
       })
       const page2 = buildQuestionPage({
+        id: pageId,
         components: [autocompleteComponent]
       })
       const definition2 = buildDefinition({
         pages: [page],
         lists: [list]
       })
-      const pageController = setupPageController(page2, definition2)
+      jest.mocked(getPageAndDefinition).mockResolvedValue({
+        definition: definition2,
+        page: page2
+      })
+      const pageController = await setupPageController(pageId, definitionId)
       expect(pageController.components[1].model.attributes).toEqual({
         'data-module': 'govuk-accessible-autocomplete'
       })
@@ -138,10 +156,17 @@ describe('setup-page-controller', () => {
   })
 
   describe('setupReorderQuestionsController', () => {
-    it('should setup', () => {
+    it('should setup', async () => {
       document.body.innerHTML =
         pageHeadingAndGuidanceHTML + questionDetailsPreviewHTML
-      const reorderPage = setupReorderQuestionsController(page, definition)
+      jest.mocked(getPageAndDefinition).mockResolvedValue({
+        definition,
+        page
+      })
+      const reorderPage = await setupReorderQuestionsController(
+        pageId,
+        definitionId
+      )
 
       expect(reorderPage).toBeInstanceOf(ReorderQuestionsPageController)
       expect(reorderPage.title).toBe('Where do you live?')
@@ -149,8 +174,9 @@ describe('setup-page-controller', () => {
   })
 
   describe('setupSummaryPageController', () => {
-    it('should setup', () => {
+    it('should setup', async () => {
       const page = buildSummaryPage({
+        id: pageId,
         components: []
       })
       const formDefinition = buildDefinition({
@@ -158,7 +184,11 @@ describe('setup-page-controller', () => {
       })
       document.body.innerHTML =
         summaryPageHTML(false, '') + questionDetailsPreviewHTML
-      const summaryPage = setupSummaryPageController(formDefinition)
+      jest.mocked(getPageAndDefinition).mockResolvedValue({
+        definition: formDefinition,
+        page: undefined
+      })
+      const summaryPage = await setupSummaryPageController(definitionId)
       expect(summaryPage).toBeInstanceOf(SummaryPageController)
       expect(summaryPage.declarationText).toBe('')
       expect(summaryPage.declaration).toEqual({

--- a/designer/server/src/models/forms/editor-v2/check-answers-settings.js
+++ b/designer/server/src/models/forms/editor-v2/check-answers-settings.js
@@ -188,8 +188,8 @@ export function checkAnswersSettingsViewModel(
     formValues: validation?.formValues,
     previewModel,
     preview: {
-      page: JSON.stringify(page),
-      definition: JSON.stringify(definition),
+      pageId: page?.id,
+      definitionId: metadata.id,
       pageTemplate: 'summary-controller.njk'
     },
     buttonText: SAVE_AND_CONTINUE,

--- a/designer/server/src/models/forms/editor-v2/questions.js
+++ b/designer/server/src/models/forms/editor-v2/questions.js
@@ -448,8 +448,8 @@ export function questionsViewModel(
     // prettier-ignore
     previewModel: getPreviewModel(page, definition, previewPageUrl, previewErrorsUrl, fields.guidanceText.value),
     preview: {
-      page: JSON.stringify(page),
-      definition: JSON.stringify(definition)
+      pageId: page.id,
+      definitionId: metadata.id
     },
     cardTitle,
     cardCaption: pageHeading,

--- a/designer/server/src/routes/forms/editor-v2/check-answers-settings.test.js
+++ b/designer/server/src/routes/forms/editor-v2/check-answers-settings.test.js
@@ -38,13 +38,14 @@ describe('Editor v2 check-answers-settings routes', () => {
       auth
     }
 
-    const { container } = await renderResponse(server, options)
+    const { container, document } = await renderResponse(server, options)
 
     const $mastheadHeading = container.getByText('Test form')
     const $cardHeadings = container.getAllByText('Page settings')
     const $radios = container.getAllByRole('radio')
 
     const $actions = container.getAllByRole('button')
+    const $previewPanel = document.getElementById('preview-panel')
 
     expect($mastheadHeading).toHaveTextContent('Test form')
     expect($mastheadHeading).toHaveClass('govuk-heading-xl')
@@ -59,6 +60,9 @@ describe('Editor v2 check-answers-settings routes', () => {
 
     expect($actions).toHaveLength(4)
     expect($actions[2]).toHaveTextContent('Save changes')
+    expect($previewPanel?.innerHTML).toContain(
+      "setupSummaryPageController('661e4ca5039739ef2902b214')"
+    )
   })
 
   test('GET - should render radio group in the view when declaration text', async () => {

--- a/designer/server/src/routes/forms/editor-v2/questions.test.js
+++ b/designer/server/src/routes/forms/editor-v2/questions.test.js
@@ -72,6 +72,7 @@ describe('Editor v2 questions routes', () => {
     const $tabPanels = container.getAllByRole('tabpanel')
 
     const $actions = container.getAllByRole('button')
+    const $previewPanel = document.getElementById('preview-panel')
 
     expect($mastheadHeading).toHaveTextContent('Test form')
     expect($mastheadHeading).toHaveClass('govuk-heading-xl')
@@ -93,6 +94,9 @@ describe('Editor v2 questions routes', () => {
     expect($actions[5]).toHaveTextContent('Save changes')
     expect($actions[6]).toHaveTextContent('Manage conditions')
     expect($tabPanels).toHaveLength(1)
+    expect($previewPanel?.innerHTML).toContain(
+      "setupPageController('p1','661e4ca5039739ef2902b214')"
+    )
   })
 
   test('GET - should render one question in the view', async () => {
@@ -183,6 +187,31 @@ describe('Editor v2 questions routes', () => {
     expect($questionTitles).toHaveLength(2)
     expect($questionNumbers[0]).toHaveTextContent('')
     expect($questionTitles[0]).toHaveTextContent('No questions')
+  })
+
+  test('GET - should render reorder view', async () => {
+    jest.mocked(forms.get).mockResolvedValueOnce(testFormMetadata)
+    jest
+      .mocked(forms.getDraftFormDefinition)
+      .mockResolvedValueOnce(testFormDefinitionWithTwoQuestions)
+
+    const options = {
+      method: 'get',
+      url: '/library/my-form-slug/editor-v2/page/p1/questions?action=reorder',
+      auth
+    }
+
+    const { container, document } = await renderResponse(server, options)
+    const $previewPanel = document.getElementById('preview-panel')
+    const [$questionList] = container.getAllByRole('list')
+    const $questionListContainer = within($questionList)
+    const $questions = $questionListContainer.getAllByRole('listitem')
+
+    expect($questions).toHaveLength(2)
+
+    expect($previewPanel?.innerHTML).toContain(
+      "setupReorderQuestionsController('p1','661e4ca5039739ef2902b214')"
+    )
   })
 
   test('POST - should error if missing mandatory fields', async () => {

--- a/designer/server/src/views/forms/editor-v2/partials/check-answers-right-panel.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/check-answers-right-panel.njk
@@ -7,6 +7,6 @@
 <script src="{{ getAssetPath("assets/nunjucks/govuk-components.js") }}"></script>
 <script type="module">
   import { setupSummaryPageController } from "{{ getAssetPath("pagePreview.js") }}"
-  const definition = {{ preview.definition | safe }}
-  setupSummaryPageController(definition)
+
+  setupSummaryPageController('{{ preview.definitionId }}')
 </script>

--- a/designer/server/src/views/forms/editor-v2/partials/questions-right-panel.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/questions-right-panel.njk
@@ -8,9 +8,9 @@
 <script type="module">
     {% if action == 'reorder' %}
     import { setupReorderQuestionsController } from "{{ getAssetPath("pagePreview.js") }}"
-    setupReorderQuestionsController({{ preview.page | safe }}, {{ preview.definition | safe }})
+    setupReorderQuestionsController('{{ preview.pageId }}','{{ preview.definitionId }}')
     {% else %}
     import { setupPageController } from "{{ getAssetPath("pagePreview.js") }}"
-    setupPageController({{ preview.page | safe }}, {{ preview.definition | safe }})
+    setupPageController('{{ preview.pageId }}','{{ preview.definitionId }}')
     {% endif %}
 </script>

--- a/model/src/pages/helpers.test.ts
+++ b/model/src/pages/helpers.test.ts
@@ -3,6 +3,7 @@ import {
   buildMarkdownComponent,
   buildTextFieldComponent
 } from '~/src/__stubs__/components.js'
+import { buildDefinition } from '~/src/__stubs__/form-definition.js'
 import {
   buildFileUploadPage,
   buildQuestionPage,
@@ -20,6 +21,7 @@ import { ControllerType } from '~/src/pages/enums.js'
 import {
   controllerNameFromPath,
   getPageDefaults,
+  getPageFromDefinition,
   getPageTitle,
   hasComponents,
   hasComponentsEvenIfNoNext,
@@ -417,6 +419,26 @@ describe('helpers', () => {
         id: '0f711e08-3801-444d-8e37-a88867c48f04'
       }
       expect(getPageTitle(page)).toBe('Page title unknown')
+    })
+  })
+
+  describe('getPageFromDefinition', () => {
+    const pageId = '7dcf119c-9846-4e0e-a350-6b3730e45016'
+    it('should get the page if it exists', () => {
+      const page = buildQuestionPage({
+        id: pageId
+      })
+      const definition = buildDefinition({
+        pages: [page]
+      })
+      expect(getPageFromDefinition(definition, pageId)).toEqual(page)
+    })
+
+    it('should return undefined if it does not exist', () => {
+      const definition = buildDefinition({
+        pages: []
+      })
+      expect(getPageFromDefinition(definition, pageId)).toBeUndefined()
     })
   })
 })

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -8,6 +8,7 @@ import {
   type PageQuestion,
   type PageRepeat
 } from '~/src/form/form-definition/types.js'
+import { type FormDefinition } from '~/src/index.js'
 import {
   ControllerNames,
   ControllerTypes
@@ -172,4 +173,17 @@ export function getPageTitle(page: Page) {
     }
   }
   return 'Page title unknown'
+}
+
+/**
+ *
+ * @param {FormDefinition} definition
+ * @param {string} pageId
+ * @returns { Page | undefined }
+ */
+export function getPageFromDefinition(
+  definition: FormDefinition,
+  pageId: string
+): Page | undefined {
+  return definition.pages.find((x) => x.id === pageId)
 }

--- a/model/src/pages/index.ts
+++ b/model/src/pages/index.ts
@@ -8,6 +8,7 @@ export { PageTypes } from '~/src/pages/page-types.js'
 export {
   controllerNameFromPath,
   getPageDefaults,
+  getPageFromDefinition,
   getPageTitle,
   hasComponents,
   hasComponentsEvenIfNoNext,


### PR DESCRIPTION
## Cleanup Page and Definition when setting up preview

For `setupPageController` and its siblings, when a page or definition is needed we are now doing an api call to collect these.

Links to: https://eaflood.atlassian.net/browse/DF-289