### PR TITLE
Fixed autocomplete and fixed highlighting css during reorder

### DIFF
--- a/designer/client/src/javascripts/preview/page-controller/setup-page-controller.js
+++ b/designer/client/src/javascripts/preview/page-controller/setup-page-controller.js
@@ -149,7 +149,14 @@ export async function setupReorderQuestionsController(pageId, definitionId) {
   const components = /** @type {ComponentDef[]} */ (
     hasComponents(page) ? page.components : []
   )
-  const nunjucksRenderBase = new NunjucksRendererBase(elements)
+
+  const hasAutocomplete = components.some(
+    (component) => component.type === ComponentType.AutocompleteField
+  )
+  const nunjucksRenderBase = hasAutocomplete
+    ? new AutocompleteRendererBase(elements)
+    : new NunjucksRendererBase(elements)
+
   const renderer = new NunjucksPageRenderer(nunjucksRenderBase)
   const reorderQuestionsPageController = new ReorderQuestionsPageController(
     components,

--- a/designer/client/src/javascripts/preview/page-controller/setup-page-controller.test.js
+++ b/designer/client/src/javascripts/preview/page-controller/setup-page-controller.test.js
@@ -181,6 +181,58 @@ describe('setup-page-controller', () => {
       expect(reorderPage).toBeInstanceOf(ReorderQuestionsPageController)
       expect(reorderPage.title).toBe('Where do you live?')
     })
+
+    it('should setup with autocomplete', async () => {
+      document.body.innerHTML =
+        pageHeadingAndGuidanceHTML + questionDetailsPreviewHTML
+
+      const componentsWithAutocomplete = [
+        buildTextFieldComponent(),
+        buildAutoCompleteComponent({
+          id: '756286fc-ee67-470c-b62c-d4638eb8df35',
+          name: 'Autocomplete question',
+          title: 'Autocomplete question',
+          list: 'feaa6e19-414d-4633-9c8c-1135bc84f1f2'
+        }),
+        buildMarkdownComponent()
+      ]
+      const pageIdWithAutocomplete = '4962a6bb-95cf-4b9f-882c-e9c6dd726a6c'
+      const pageWithAutocomplete = buildQuestionPage({
+        title: 'Page title',
+        components: componentsWithAutocomplete,
+        id: pageIdWithAutocomplete
+      })
+      const listId = 'feaa6e19-414d-4633-9c8c-1135bc84f1f2'
+      const list = buildList({
+        id: listId,
+        items: [
+          buildListItem({
+            text: 'Item 1'
+          }),
+          buildListItem({
+            text: 'Item 2'
+          })
+        ]
+      })
+
+      const definitionWithAutocomplete = buildDefinition({
+        pages: [pageWithAutocomplete],
+        lists: [list]
+      })
+
+      jest.mocked(getPageAndDefinition).mockResolvedValue({
+        page: pageWithAutocomplete,
+        definition: definitionWithAutocomplete
+      })
+
+      const reorderPage = await setupReorderQuestionsController(
+        pageIdWithAutocomplete,
+        definitionId
+      )
+
+      expect(reorderPage).toBeInstanceOf(ReorderQuestionsPageController)
+      expect(reorderPage.title).toBe('Where do you live?')
+    })
   })
 
   describe('setupSummaryPageController', () => {

--- a/designer/server/src/common/components/preview-panel-layout/_preview-panel-layout.scss
+++ b/designer/server/src/common/components/preview-panel-layout/_preview-panel-layout.scss
@@ -72,6 +72,14 @@ $defra-brand-colour: govuk-organisation-colour(department-for-environment-food-r
     .highlight {
       border-bottom: inherit;
     }
+
+    // stylelint-disable -- max nesting
+    input[type="text"].highlight,
+    input[type="number"].highlight,
+    select.highlight {
+      border-bottom: 2px solid govuk-colour("black");
+    }
+    // stylelint-enable
   }
 
   .govuk-radios__hint {


### PR DESCRIPTION
Added autocomplete renderer where necessary (as per setupPageController)
Fixed highlight CSS bug where (when reordering), the bottom border of a component was disappearing
(hit a caching problem on original PR so closed PR https://github.com/DEFRA/forms-designer/pull/1008 and created this one instead)