### PR TITLE
DF-352: Fix guidance position during component reorder

### DIFF
--- a/designer/server/src/__stubs__/form-definition.js
+++ b/designer/server/src/__stubs__/form-definition.js
@@ -464,6 +464,60 @@ export const testFormDefinitionWithExistingGuidance = {
 /**
  * @satisfies {FormDefinition}
  */
+export const testFormDefinitionWithComponentsAndLeadingGuidance = {
+  name: 'Test form',
+  pages: [
+    {
+      path: '/page-one',
+      title: 'Page one',
+      section: 'section',
+      id: '12345',
+      components: [
+        {
+          id: '04132d25-a648-43ae-9d5d-6fa410ae8d99',
+          type: ComponentType.Markdown,
+          name: 'html-guidance',
+          title: 'html-title',
+          content: 'Original guidance',
+          options: {}
+        },
+        {
+          id: 'cda48ac2-91b1-47a8-ba14-8480b5d2c86f',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your first field',
+          hint: 'Help text',
+          options: {},
+          schema: {}
+        },
+        {
+          id: '43425d8e-4832-4ed1-a574-1d29fd63cf3c',
+          type: ComponentType.TextField,
+          name: 'textField',
+          title: 'This is your second question - page two',
+          hint: 'Help text',
+          options: {
+            required: false
+          },
+          schema: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      title: 'Summary',
+      path: '/summary',
+      controller: ControllerType.Summary
+    }
+  ],
+  conditions: [],
+  sections: [],
+  lists: []
+}
+
+/**
+ * @satisfies {FormDefinition}
+ */
 export const testFormDefinitionWithExistingSummaryDeclaration = {
   name: 'Test form',
   pages: [

--- a/designer/server/src/routes/forms/editor-v2/helpers.js
+++ b/designer/server/src/routes/forms/editor-v2/helpers.js
@@ -1,3 +1,5 @@
+import { hasComponentsEvenIfNoNext } from '@defra/forms-model'
+
 import * as forms from '~/src/lib/forms.js'
 import { getPageFromDefinition } from '~/src/lib/utils.js'
 
@@ -38,3 +40,25 @@ export const customItemOrder = (value) => {
 
   return []
 }
+
+/**
+ * Ensure any components that are not in the
+ * order array are retained in their current position
+ * @param {Page} page
+ * @param {string[]} order
+ */
+export const mergeMissingComponentsIntoOrder = (page, order) => {
+  if (hasComponentsEvenIfNoNext(page)) {
+    const { components } = page
+
+    components.forEach((component, idx) => {
+      if (component.id && !order.includes(component.id)) {
+        order.splice(idx, 0, component.id)
+      }
+    })
+  }
+}
+
+/**
+ * @import { Page } from '@defra/forms-model'
+ */

--- a/designer/server/src/routes/forms/editor-v2/helpers.test.js
+++ b/designer/server/src/routes/forms/editor-v2/helpers.test.js
@@ -1,0 +1,21 @@
+import { testFormDefinitionWithComponentsAndLeadingGuidance } from '~/src/__stubs__/form-definition.js'
+import { mergeMissingComponentsIntoOrder } from '~/src/routes/forms/editor-v2/helpers.js'
+
+describe('Editor v2 helpers', () => {
+  describe('mergeMissingComponentsIntoOrder', () => {
+    test('should retain position of components not in the order array', () => {
+      const page =
+        testFormDefinitionWithComponentsAndLeadingGuidance.pages.at(0)
+      const order = [
+        '43425d8e-4832-4ed1-a574-1d29fd63cf3c',
+        'cda48ac2-91b1-47a8-ba14-8480b5d2c86f'
+      ]
+      mergeMissingComponentsIntoOrder(page, order)
+      expect(order).toEqual([
+        '04132d25-a648-43ae-9d5d-6fa410ae8d99',
+        '43425d8e-4832-4ed1-a574-1d29fd63cf3c',
+        'cda48ac2-91b1-47a8-ba14-8480b5d2c86f'
+      ])
+    })
+  })
+})

--- a/designer/server/src/routes/forms/editor-v2/helpers.test.js
+++ b/designer/server/src/routes/forms/editor-v2/helpers.test.js
@@ -4,13 +4,20 @@ import { mergeMissingComponentsIntoOrder } from '~/src/routes/forms/editor-v2/he
 describe('Editor v2 helpers', () => {
   describe('mergeMissingComponentsIntoOrder', () => {
     test('should retain position of components not in the order array', () => {
-      const page =
-        testFormDefinitionWithComponentsAndLeadingGuidance.pages.at(0)
+      const { pages } = testFormDefinitionWithComponentsAndLeadingGuidance
+      /** @type {import('@defra/forms-model').Page | undefined} */
+      const page = pages.at(0)
+
+      if (!page) {
+        throw new Error('Unexpected missing page')
+      }
+
       const order = [
         '43425d8e-4832-4ed1-a574-1d29fd63cf3c',
         'cda48ac2-91b1-47a8-ba14-8480b5d2c86f'
       ]
       mergeMissingComponentsIntoOrder(page, order)
+
       expect(order).toEqual([
         '04132d25-a648-43ae-9d5d-6fa410ae8d99',
         '43425d8e-4832-4ed1-a574-1d29fd63cf3c',

--- a/designer/server/src/routes/forms/editor-v2/questions.js
+++ b/designer/server/src/routes/forms/editor-v2/questions.js
@@ -37,7 +37,10 @@ import {
 } from '~/src/models/forms/editor-v2/pages-helper.js'
 import * as viewModel from '~/src/models/forms/editor-v2/questions.js'
 import { editorv2Path } from '~/src/models/links.js'
-import { customItemOrder } from '~/src/routes/forms/editor-v2/helpers.js'
+import {
+  customItemOrder,
+  mergeMissingComponentsIntoOrder
+} from '~/src/routes/forms/editor-v2/helpers.js'
 
 export const ROUTE_FULL_PATH_QUESTIONS = `/library/{slug}/editor-v2/page/{pageId}/questions`
 
@@ -170,6 +173,7 @@ export default [
       }
 
       if (saveReorder) {
+        mergeMissingComponentsIntoOrder(page, itemOrder)
         await reorderQuestions(metadata.id, token, pageId, itemOrder)
         yar.flash(sessionNames.successNotification, CHANGES_SAVED_SUCCESSFULLY)
         yar.clear(reorderQuestionsKey)
@@ -207,6 +211,7 @@ export default [
         // Save re-order (if in reorder mode) in case user pressed the main 'Save changes' button
         // as opposed to the reorder 'Save changes' button
         if (action === 'reorder') {
+          mergeMissingComponentsIntoOrder(page, itemOrder)
           await reorderQuestions(metadata.id, token, pageId, itemOrder)
         }
 

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -418,6 +418,7 @@ export const componentSchema = Joi.object<ComponentDef>()
       otherwise: Joi.string()
         .trim()
         .pattern(/^[a-zA-Z]+$/)
+        .required()
         .description('Unique identifier for the component, used in form data')
     }),
     title: Joi.when('type', {

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -646,7 +646,7 @@ export const pageUploadComponentsSchema = Joi.array<
     contentComponentSchema.optional()
   )
   .unique('id')
-  .unique('name')
+  .unique('name', { ignoreUndefined: true })
   .min(1)
   .max(2)
   .description('Components allowed on Page Upload schema')
@@ -731,7 +731,7 @@ export const pageSchemaV2 = pageSchema
       otherwise: Joi.array<ComponentDef>()
         .items(componentSchemaV2)
         .unique('id')
-        .unique('name')
+        .unique('name', { ignoreUndefined: true })
         .description('Components schema for V2 forms')
         .error(
           checkErrors([


### PR DESCRIPTION
- Relax component name unique constraint by ignoring undefined. This will allow us to support multiple `ContentComponents` for plugin users.
- Make `name` field required for form components
