### PR TITLE
Provide controller flags when question is being updated

### DIFF
--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -296,7 +296,7 @@ export function getRepeaterProperties(page, isCurrentlyRepeater, payload) {
 export function getControllerTypeAndPropertiesForQuestion(page, components) {
   return getControllerTypeAndPropertiesForPage(page, components, {
     exitPage: page?.controller === ControllerType.Terminal,
-    repeater: page?.controller === ControllerType.Repeat ? 'true' : ''
+    repeater: page?.controller === ControllerType.Repeat ? 'true' : '' // TODO why is this a string?
   })
 }
 

--- a/designer/server/src/lib/editor.js
+++ b/designer/server/src/lib/editor.js
@@ -154,11 +154,11 @@ export async function updateQuestion(
     // Side-effect to the component within the page
     questionToChange.type = questionDetails.type ?? ComponentType.TextField
   }
-  const { controllerType: newControllerType } = getControllerTypeAndProperties(
-    page,
-    hasComponents(page) ? page.components : [],
-    {}
-  )
+  const { controllerType: newControllerType } =
+    getControllerTypeAndPropertiesForQuestion(
+      page,
+      hasComponents(page) ? page.components : []
+    )
   if (
     origControllerType !== newControllerType ||
     isFirstQuestionAndNoPageTitle
@@ -292,9 +292,25 @@ export function getRepeaterProperties(page, isCurrentlyRepeater, payload) {
  *
  * @param { Page | undefined } page
  * @param {ComponentDef[]} components
+ */
+export function getControllerTypeAndPropertiesForQuestion(page, components) {
+  return getControllerTypeAndPropertiesForPage(page, components, {
+    exitPage: page?.controller === ControllerType.Terminal,
+    repeater: page?.controller === ControllerType.Repeat ? 'true' : ''
+  })
+}
+
+/**
+ *
+ * @param { Page | undefined } page
+ * @param {ComponentDef[]} components
  * @param {Partial<FormEditorInputPageSettings>} payload
  */
-export function getControllerTypeAndProperties(page, components, payload) {
+export function getControllerTypeAndPropertiesForPage(
+  page,
+  components,
+  payload
+) {
   const { exitPage, repeater } = payload
   let controllerType = /** @type { ControllerType | undefined | null } */ (
     page?.controller
@@ -358,7 +374,7 @@ export async function setPageSettings(
   const pagePathForCall = `/${slugify(resolvePageHeading(page, pageHeadingForCall, components))}`
 
   const { controllerType, additionalProperties } =
-    getControllerTypeAndProperties(page, components, payload)
+    getControllerTypeAndPropertiesForPage(page, components, payload)
 
   const requestPayload = {
     title: pageHeadingForCall,

--- a/designer/server/src/lib/editor.test.js
+++ b/designer/server/src/lib/editor.test.js
@@ -25,7 +25,7 @@ import {
   deletePage,
   deleteQuestion,
   getControllerType,
-  getControllerTypeAndProperties,
+  getControllerTypeAndPropertiesForPage,
   getRepeaterProperties,
   migrateDefinitionToV2,
   reorderPages,
@@ -1438,7 +1438,7 @@ describe('editor.js', () => {
     })
   })
 
-  describe('getControllerTypeAndProperties', () => {
+  describe('getControllerTypeAndPropertiesForPage', () => {
     test('should return controller type for file upload', () => {
       const page = /** @type {Page} */ ({})
       const components = /** @type {ComponentDef[]} */ ([
@@ -1448,7 +1448,7 @@ describe('editor.js', () => {
       ])
       const payload = {}
       const { controllerType, additionalProperties } =
-        getControllerTypeAndProperties(page, components, payload)
+        getControllerTypeAndPropertiesForPage(page, components, payload)
       expect(controllerType).toBe(ControllerType.FileUpload)
       expect(additionalProperties).toEqual({})
     })
@@ -1460,7 +1460,7 @@ describe('editor.js', () => {
       const components = /** @type {ComponentDef[]} */ ([])
       const payload = {}
       const { controllerType, additionalProperties } =
-        getControllerTypeAndProperties(page, components, payload)
+        getControllerTypeAndPropertiesForPage(page, components, payload)
       expect(controllerType).toBeNull()
       expect(additionalProperties).toEqual({})
     })
@@ -1472,7 +1472,7 @@ describe('editor.js', () => {
         exitPage: true
       }
       const { controllerType, additionalProperties } =
-        getControllerTypeAndProperties(page, components, payload)
+        getControllerTypeAndPropertiesForPage(page, components, payload)
       expect(controllerType).toBe(ControllerType.Terminal)
       expect(additionalProperties).toEqual({})
     })
@@ -1484,7 +1484,7 @@ describe('editor.js', () => {
         exitPage: false
       }
       const { controllerType, additionalProperties } =
-        getControllerTypeAndProperties(page, components, payload)
+        getControllerTypeAndPropertiesForPage(page, components, payload)
       expect(controllerType).toBeNull()
       expect(additionalProperties).toEqual({})
     })
@@ -1499,7 +1499,7 @@ describe('editor.js', () => {
         questionSetName: 'questionSetName'
       }
       const { controllerType, additionalProperties } =
-        getControllerTypeAndProperties(page, components, payload)
+        getControllerTypeAndPropertiesForPage(page, components, payload)
       expect(controllerType).toBe(ControllerType.Repeat)
       expect(additionalProperties).toEqual({
         repeat: {
@@ -1522,7 +1522,7 @@ describe('editor.js', () => {
       const components = /** @type {ComponentDef[]} */ ([])
       const payload = {}
       const { controllerType, additionalProperties } =
-        getControllerTypeAndProperties(page, components, payload)
+        getControllerTypeAndPropertiesForPage(page, components, payload)
       expect(controllerType).toBeNull()
       expect(additionalProperties).toEqual({})
     })


### PR DESCRIPTION
This PR splits out `getControllerTypeAndProperties` into two:

- `getControllerTypeAndPropertiesForPage`
  - Used when setting the controller type from a page settings screen
- `getControllerTypeAndPropertiesForQuestion`
  - Used wen setting the controller type from a question settings screen