### PR TITLE
Fixed edit of radio item

### DIFF
--- a/designer/server/src/lib/list.js
+++ b/designer/server/src/lib/list.js
@@ -147,13 +147,19 @@ export async function removeUniquelyMappedListsFromPage(
  */
 export function populateListIds(definition, listRef, listItems) {
   /**
+   * Matches list items against existing items (if they exist)
+   * This method handles the following scenarios:
+   * 1. When editing an individual option (e.g. checkbox or radio), an ID will be present so this is used initially to find a match
+   * 2. When editing an autocomplete (or possibly checkbox or radio if we have implemented textarea editing). Here we do not have any IDs to pass,
+   * just a text value (and possibly code value), so we try to match on 'code' first, then 'text' if not matched on 'code'.
    * @param {Item[]} listItems
    * @param {Item} item
    */
   function populateExistingId(listItems, item) {
     const found =
-      listItems.find((i) => i.value === item.value) ??
-      listItems.find((i) => i.text === item.text)
+      listItems.find((i) => i.id === item.id) ?? // for when we are editing individual items
+      listItems.find((i) => i.value === item.value) ?? // for when no IDs present in submitted data (see note on method)
+      listItems.find((i) => i.text === item.text) // for when no IDs present in submitted data (see note on method)
     return {
       id: found?.id,
       text: item.text,

--- a/designer/server/src/lib/list.test.js
+++ b/designer/server/src/lib/list.test.js
@@ -286,6 +286,20 @@ describe('list.js', () => {
       ])
     })
 
+    test('should populate known ids using existing ids', () => {
+      const { definition, listIdWithItemIds } = listStubs.exampleWithListItemIds
+      const populated = populateListIds(definition, listIdWithItemIds, [
+        { id: 'id1', text: 'England1', value: 'eng1' },
+        { id: 'id2', text: 'Scotland2', value: 'scot2' },
+        { id: 'id3', text: 'Wales3', value: 'wal3' }
+      ])
+      expect(populated).toEqual([
+        { id: 'id1', text: 'England1', value: 'eng1' },
+        { id: 'id2', text: 'Scotland2', value: 'scot2' },
+        { id: 'id3', text: 'Wales3', value: 'wal3' }
+      ])
+    })
+
     test('should populate known ids using display text', () => {
       const { definition, listIdWithItemIds } = listStubs.exampleWithListItemIds
       const populated = populateListIds(definition, listIdWithItemIds, [


### PR DESCRIPTION
Ticket [DF-399](https://eaflood.atlassian.net/browse/DF-399)

When editing a radio option item, and you change both text and code value, the id gets lost and is replaced by a new guid. The original id should remain instead.

A very small fix.

[DF-399]: https://eaflood.atlassian.net/browse/DF-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ