### PR TITLE
Use sonarqube-scan-action v5

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -226,7 +226,7 @@ jobs:
           path: coverage
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5.2.0
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
To fix vulnerability: https://community.sonarsource.com/t/security-advisory-sonarqube-scanner-github-action/147696

I could have opted to pin us to `v5.3.1` specifically but this gives us wiggle room for future changes, and as they follow semver this shouldn't be an issue.