### PR TITLE
Extra properties in SaveAndExit message

### DIFF
--- a/model/src/form/form-submission/index.ts
+++ b/model/src/form/form-submission/index.ts
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 
 import { FormStatus } from '~/src/common/enums.js'
+import { slugSchema, titleSchema } from '~/src/form/form-metadata/index.js'
 import {
   SecurityQuestionsEnum,
   SubmissionEventMessageCategory,
@@ -80,8 +81,8 @@ export const saveAndExitMessageData = Joi.object<SaveAndExitMessageData>().keys(
   {
     form: {
       id: Joi.string().required(),
-      slug: Joi.string().required(),
-      formName: Joi.string().required(),
+      slug: slugSchema,
+      title: titleSchema,
       status: Joi.string().valid(FormStatus.Draft, FormStatus.Live).required(),
       isPreview: Joi.boolean().required()
     },

--- a/model/src/form/form-submission/types.ts
+++ b/model/src/form/form-submission/types.ts
@@ -97,7 +97,7 @@ export interface SaveAndExitMessageData {
   form: {
     id: string
     slug: string
-    name: string
+    title: string
     status: FormStatus
     isPreview: boolean
   }


### PR DESCRIPTION
Added 'slug' and form 'name'
Restructured all form properties to sit under a parent of 'form'

Ticket [DF-370](https://eaflood.atlassian.net/browse/DF-370)

[DF-370]: https://eaflood.atlassian.net/browse/DF-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ