### PR TITLE
Move phase banner to footer

### DIFF
--- a/designer/server/src/common/templates/layouts/page.njk
+++ b/designer/server/src/common/templates/layouts/page.njk
@@ -47,6 +47,14 @@
 {% endblock %}
 
 {% block footer %}
+  {% set feedbackRowHtml = "" %}
+
+  {% if ["alpha", "beta"].includes(config.phase) %}
+    {% set feedbackRowHtml %}
+      <strong class="govuk-tag govuk-phase-banner__content__tag">{{ config.phase | title }}</strong>This is a new service. Help us improve it and <a class="govuk-footer__link" href="mailto:defraforms@defra.gov.uk">give your feedback by email</a>.
+    {% endset %}
+  {% endif %}
+
   {{ govukFooter({
     containerClasses: "app-width-container--wide",
     meta: {
@@ -63,7 +71,8 @@
           href: "https://www.gov.uk/help/privacy-notice",
           text: "Privacy"
         }
-      ]
+      ],
+      html: feedbackRowHtml
     }
   }) }}
 {% endblock %}

--- a/designer/server/src/common/templates/layouts/page.test.js
+++ b/designer/server/src/common/templates/layouts/page.test.js
@@ -1,0 +1,57 @@
+import upperFirst from 'lodash/upperFirst.js'
+
+import { renderView } from '~/test/helpers/component-helpers.js'
+
+const contextStub = {
+  getAssetPath: () => 'dummy'
+}
+
+describe('Phase banner', () => {
+  const selectorPhaseBanner = '.govuk-footer__meta-custom'
+  const selectorTag = '.govuk-tag'
+
+  it.each([
+    {
+      context: {
+        ...contextStub,
+        config: { phase: 'alpha' }
+      }
+    },
+    {
+      context: {
+        ...contextStub,
+        config: { phase: 'beta' }
+      }
+    }
+  ])(
+    "should render for '$context.config.phase' phase (via config)",
+    ({ context }) => {
+      renderView('layouts/page.njk', { context })
+
+      const $phaseBanner = document.querySelector(selectorPhaseBanner)
+      const $phaseTag = $phaseBanner?.querySelector(selectorTag)
+
+      expect($phaseBanner).toBeInTheDocument()
+      expect($phaseTag).toContainHTML(upperFirst(context.config.phase))
+    }
+  )
+
+  it("should not render for 'live' phase (via config)", () => {
+    renderView('layouts/page.njk', {
+      context: {
+        ...contextStub,
+        config: { phase: 'live' }
+      }
+    })
+
+    const $phaseBanner = document.querySelector(selectorPhaseBanner)
+    expect($phaseBanner).not.toBeInTheDocument()
+  })
+
+  it('should not render by default', () => {
+    renderView('layouts/page.njk', { context: contextStub })
+
+    const $phaseBanner = document.querySelector(selectorPhaseBanner)
+    expect($phaseBanner).not.toBeInTheDocument()
+  })
+})

--- a/designer/server/src/common/templates/partials/navigation.njk
+++ b/designer/server/src/common/templates/partials/navigation.njk
@@ -28,12 +28,3 @@
   signOutLink: "/auth/sign-out",
   homepageLink: "/"
 }) }}
-
-{% if ["alpha", "beta"].includes(config.phase) %}
-<div class="govuk-width-container app-width-container--wide">
-  {{ govukPhaseBanner({
-    tag: { text: config.phase | title },
-    html: 'This is a new service. Help us improve it and <a class="govuk-link" href="mailto:defraforms@defra.gov.uk">give your feedback by email</a>.'
-  }) }}
-</div>
-{% endif %}

--- a/designer/server/src/common/templates/partials/navigation.test.js
+++ b/designer/server/src/common/templates/partials/navigation.test.js
@@ -1,5 +1,3 @@
-import upperFirst from 'lodash/upperFirst.js'
-
 import { renderView } from '~/test/helpers/component-helpers.js'
 
 describe('Navigation partial', () => {
@@ -102,53 +100,6 @@ describe('Navigation partial', () => {
       const $navigation = document.querySelector(selectorNavigation)
 
       expect($navigation).not.toBeInTheDocument()
-    })
-  })
-
-  describe('Phase banner', () => {
-    const selectorPhaseBanner = '.govuk-phase-banner'
-    const selectorTag = '.govuk-tag'
-
-    it.each([
-      {
-        context: {
-          config: { phase: 'alpha' }
-        }
-      },
-      {
-        context: {
-          config: { phase: 'beta' }
-        }
-      }
-    ])(
-      "should render for '$context.config.phase' phase (via config)",
-      ({ context }) => {
-        renderView('partials/navigation.njk', { context })
-
-        const $phaseBanner = document.querySelector(selectorPhaseBanner)
-        const $phaseTag = $phaseBanner?.querySelector(selectorTag)
-
-        expect($phaseBanner).toBeInTheDocument()
-        expect($phaseTag).toContainHTML(upperFirst(context.config.phase))
-      }
-    )
-
-    it("should not render for 'live' phase (via config)", () => {
-      renderView('partials/navigation.njk', {
-        context: {
-          config: { phase: 'live' }
-        }
-      })
-
-      const $phaseBanner = document.querySelector(selectorPhaseBanner)
-      expect($phaseBanner).not.toBeInTheDocument()
-    })
-
-    it('should not render by default', () => {
-      renderView('partials/navigation.njk')
-
-      const $phaseBanner = document.querySelector(selectorPhaseBanner)
-      expect($phaseBanner).not.toBeInTheDocument()
     })
   })
 })

--- a/designer/server/src/createServer.test.ts
+++ b/designer/server/src/createServer.test.ts
@@ -87,7 +87,7 @@ describe('Server tests', () => {
 
     await renderResponse(server, options)
 
-    const $phaseBanner = document.querySelector('.govuk-phase-banner')
+    const $phaseBanner = document.querySelector('.govuk-footer__meta-custom')
     const $phaseBannerTag = $phaseBanner?.querySelector('.govuk-tag')
 
     expect($phaseBanner).toBeInTheDocument()
@@ -106,7 +106,7 @@ describe('Server tests', () => {
 
     await renderResponse(server, options)
 
-    const $phaseBanner = document.querySelector('.govuk-phase-banner')
+    const $phaseBanner = document.querySelector('.govuk-footer__meta-custom')
     expect($phaseBanner).not.toBeInTheDocument()
   })
 
@@ -121,7 +121,7 @@ describe('Server tests', () => {
 
     await renderResponse(server, options)
 
-    const $phaseBanner = document.querySelector('.govuk-phase-banner')
+    const $phaseBanner = document.querySelector('.govuk-footer__meta-custom')
     expect($phaseBanner).not.toBeInTheDocument()
   })
 

--- a/designer/server/src/routes/account/__snapshots__/account.test.js.snap
+++ b/designer/server/src/routes/account/__snapshots__/account.test.js.snap
@@ -162,7 +162,6 @@ exports[`Account profile route /auth/account route displays user profile 1`] = `
 
 
 
-
   <main class="govuk-main-wrapper govuk-main-wrapper--masthead" id="main-head-content">
 
 
@@ -219,6 +218,8 @@ exports[`Account profile route /auth/account route displays user profile 1`] = `
 
   
   </main>
+
+
 
   <footer class="govuk-footer">
   <div class="govuk-width-container app-width-container--wide">

--- a/designer/server/src/routes/forms/__snapshots__/create.test.js.snap
+++ b/designer/server/src/routes/forms/__snapshots__/create.test.js.snap
@@ -150,7 +150,6 @@ exports[`Form create routes GET '"/create/organisation"' matches test snapshot 1
 </header>
 
 
-
   <div class="govuk-width-container app-width-container--wide">
     <a href="/create/title" class="govuk-back-link">Back</a>
 
@@ -243,6 +242,8 @@ exports[`Form create routes GET '"/create/organisation"' matches test snapshot 1
   </div>
 
   </main>
+
+
 
   <footer class="govuk-footer">
   <div class="govuk-width-container app-width-container--wide">
@@ -458,7 +459,6 @@ exports[`Form create routes GET '"/create/team"' matches test snapshot 1`] = `
 </header>
 
 
-
   <div class="govuk-width-container app-width-container--wide">
     <a href="/create/organisation" class="govuk-back-link">Back</a>
 
@@ -517,6 +517,8 @@ exports[`Form create routes GET '"/create/team"' matches test snapshot 1`] = `
   </form>
 
   </main>
+
+
 
   <footer class="govuk-footer">
   <div class="govuk-width-container app-width-container--wide">
@@ -732,7 +734,6 @@ exports[`Form create routes GET '"/create/title"' matches test snapshot 1`] = `
 </header>
 
 
-
   <div class="govuk-width-container app-width-container--wide">
     <a href="/library" class="govuk-back-link">Back to forms library</a>
 
@@ -768,6 +769,8 @@ exports[`Form create routes GET '"/create/title"' matches test snapshot 1`] = `
   </div>
 
   </main>
+
+
 
   <footer class="govuk-footer">
   <div class="govuk-width-container app-width-container--wide">

--- a/designer/server/src/routes/manage/__snapshots__/user.test.js.snap
+++ b/designer/server/src/routes/manage/__snapshots__/user.test.js.snap
@@ -162,7 +162,6 @@ exports[`Create and edit user routes GET /manage/users should render view when c
 
 
 
-
   <main class="govuk-main-wrapper govuk-main-wrapper--masthead" id="main-head-content">
 
 
@@ -251,6 +250,8 @@ exports[`Create and edit user routes GET /manage/users should render view when c
 
   
   </main>
+
+
 
   <footer class="govuk-footer">
   <div class="govuk-width-container app-width-container--wide">
@@ -478,7 +479,6 @@ exports[`Create and edit user routes GET /manage/users should render view when d
 
 
 
-
   <main class="govuk-main-wrapper govuk-main-wrapper--masthead" id="main-head-content">
 
   <form method="post" novalidate>
@@ -537,6 +537,8 @@ exports[`Create and edit user routes GET /manage/users should render view when d
   </form>
 
   </main>
+
+
 
   <footer class="govuk-footer">
   <div class="govuk-width-container app-width-container--wide">
@@ -764,7 +766,6 @@ exports[`Create and edit user routes GET /manage/users should render view when e
 
 
 
-
   <main class="govuk-main-wrapper govuk-main-wrapper--masthead" id="main-head-content">
 
 
@@ -862,6 +863,8 @@ exports[`Create and edit user routes GET /manage/users should render view when e
 
   
   </main>
+
+
 
   <footer class="govuk-footer">
   <div class="govuk-width-container app-width-container--wide">


### PR DESCRIPTION
This is because the phase banner does not work with our masthead. See https://vickytnz.github.io/govuk-header-footer/ for our inspiration.

This has been built in collaboration with Dan and Mark.