### PR TITLE
fix/DF-531: Error stack traces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@babel/core": "^7.26.10",
         "@babel/preset-env": "^7.26.9",
         "@babel/preset-typescript": "^7.26.0",
+        "@hapi/hoek": "^11.0.7",
         "@types/eslint": "^8.56.12",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.29",
@@ -2974,12 +2975,6 @@
         "npm": "^10.9.0"
       }
     },
-    "node_modules/@defra/forms-engine-plugin/node_modules/@hapi/hoek": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@defra/forms-engine-plugin/node_modules/govuk-frontend": {
       "version": "5.11.2",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
@@ -3699,11 +3694,6 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@hapi/accept/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/address": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
@@ -3714,6 +3704,12 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@hapi/address/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hapi/ammo": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.1.tgz",
@@ -3721,11 +3717,6 @@
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
       }
-    },
-    "node_modules/@hapi/ammo/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/b64": {
       "version": "6.0.1",
@@ -3735,11 +3726,6 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@hapi/b64/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/basic": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/basic/-/basic-7.0.2.tgz",
@@ -3748,11 +3734,6 @@
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
       }
-    },
-    "node_modules/@hapi/basic/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/bell": {
       "version": "13.1.0",
@@ -3771,11 +3752,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@hapi/bell/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/boom": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
@@ -3783,11 +3759,6 @@
       "dependencies": {
         "@hapi/hoek": "^11.0.2"
       }
-    },
-    "node_modules/@hapi/boom/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/bounce": {
       "version": "3.0.2",
@@ -3797,11 +3768,6 @@
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
       }
-    },
-    "node_modules/@hapi/bounce/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
@@ -3816,11 +3782,6 @@
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
       }
-    },
-    "node_modules/@hapi/call/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/catbox": {
       "version": "12.1.1",
@@ -3842,11 +3803,6 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@hapi/catbox-memory/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/catbox-object": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/catbox-object/-/catbox-object-3.0.1.tgz",
@@ -3855,11 +3811,6 @@
         "@hapi/boom": "^10.0.1",
         "@hapi/hoek": "^11.0.2"
       }
-    },
-    "node_modules/@hapi/catbox-object/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/catbox-redis": {
       "version": "7.0.2",
@@ -3874,16 +3825,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@hapi/catbox-redis/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
-    "node_modules/@hapi/catbox/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/content": {
       "version": "6.0.0",
@@ -3904,11 +3845,6 @@
         "@hapi/validate": "^2.0.1"
       }
     },
-    "node_modules/@hapi/cookie/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/crumb": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/crumb/-/crumb-9.0.1.tgz",
@@ -3919,11 +3855,6 @@
         "@hapi/hoek": "^11.0.2",
         "@hapi/validate": "^2.0.1"
       }
-    },
-    "node_modules/@hapi/crumb/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/cryptiles": {
       "version": "6.0.1",
@@ -3977,11 +3908,6 @@
         "node": ">=14.15.0"
       }
     },
-    "node_modules/@hapi/hapi/node_modules/@hapi/hoek": {
-      "version": "11.0.6",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.6.tgz",
-      "integrity": "sha512-mu8He+jghTDJ+la/uGBT4b1rqQdqFADZiXhzd98b3XW5nb/c+5woXx3FiNco2nm4wPJFHQVRGxYeWeSDPIYpYw=="
-    },
     "node_modules/@hapi/hapi/node_modules/@hapi/topo": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
@@ -4000,15 +3926,11 @@
         "@hapi/validate": "^2.0.1"
       }
     },
-    "node_modules/@hapi/heavy/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/inert": {
       "version": "7.1.0",
@@ -4022,11 +3944,6 @@
         "@hapi/validate": "^2.0.1",
         "lru-cache": "^7.14.1"
       }
-    },
-    "node_modules/@hapi/inert/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/inert/node_modules/lru-cache": {
       "version": "7.18.3",
@@ -4048,11 +3965,6 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@hapi/iron/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/joi": {
       "version": "17.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
@@ -4066,6 +3978,12 @@
         "@hapi/pinpoint": "^2.0.0",
         "@hapi/topo": "^5.0.0"
       }
+    },
+    "node_modules/@hapi/joi/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/jwt": {
       "version": "3.2.0",
@@ -4098,11 +4016,6 @@
         "mime-db": "^1.52.0"
       }
     },
-    "node_modules/@hapi/mimos/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/nigel": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.1.tgz",
@@ -4115,11 +4028,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@hapi/nigel/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/pez": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.1.0.tgz",
@@ -4131,11 +4039,6 @@
         "@hapi/hoek": "^11.0.2",
         "@hapi/nigel": "^5.0.1"
       }
-    },
-    "node_modules/@hapi/pez/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/pinpoint": {
       "version": "2.0.1",
@@ -4152,11 +4055,6 @@
         "@hapi/teamwork": "^6.0.0",
         "@hapi/validate": "^2.0.1"
       }
-    },
-    "node_modules/@hapi/podium/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/scooter": {
       "version": "7.0.0",
@@ -4177,11 +4075,6 @@
         "@hapi/validate": "^2.0.1"
       }
     },
-    "node_modules/@hapi/shot/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/somever": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.1.tgz",
@@ -4190,11 +4083,6 @@
         "@hapi/bounce": "^3.0.1",
         "@hapi/hoek": "^11.0.2"
       }
-    },
-    "node_modules/@hapi/somever/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/statehood": {
       "version": "8.2.0",
@@ -4211,11 +4099,6 @@
         "@hapi/validate": "^2.0.1"
       }
     },
-    "node_modules/@hapi/statehood/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/subtext": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.1.0.tgz",
@@ -4229,11 +4112,6 @@
         "@hapi/pez": "^6.1.0",
         "@hapi/wreck": "^18.0.1"
       }
-    },
-    "node_modules/@hapi/subtext/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/teamwork": {
       "version": "6.0.0",
@@ -4251,6 +4129,12 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@hapi/topo/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hapi/validate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
@@ -4259,11 +4143,6 @@
         "@hapi/hoek": "^11.0.2",
         "@hapi/topo": "^6.0.1"
       }
-    },
-    "node_modules/@hapi/validate/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@hapi/validate/node_modules/@hapi/topo": {
       "version": "6.0.2",
@@ -4281,11 +4160,6 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@hapi/vise/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/vision": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@hapi/vision/-/vision-7.0.3.tgz",
@@ -4297,11 +4171,6 @@
         "@hapi/validate": "^2.0.1"
       }
     },
-    "node_modules/@hapi/vision/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/wreck": {
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.0.tgz",
@@ -4312,11 +4181,6 @@
         "@hapi/hoek": "^11.0.2"
       }
     },
-    "node_modules/@hapi/wreck/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
-    },
     "node_modules/@hapi/yar": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/@hapi/yar/-/yar-11.0.2.tgz",
@@ -4325,11 +4189,6 @@
         "@hapi/hoek": "^11.0.2",
         "@hapi/statehood": "^8.0.1"
       }
-    },
-    "node_modules/@hapi/yar/node_modules/@hapi/hoek": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
-      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -5169,6 +5028,12 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
+    },
+    "node_modules/@sideway/address/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sideway/formula": {
       "version": "3.0.1",
@@ -8099,6 +7964,12 @@
         "node": ">= 8.9.0"
       }
     },
+    "node_modules/blankie/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/blipp": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/blipp/-/blipp-4.0.2.tgz",
@@ -8110,6 +7981,12 @@
         "easy-table": "1.x.x",
         "joi": "17.x.x"
       }
+    },
+    "node_modules/blipp/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/blipp/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -11907,12 +11784,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/hapi-pino/node_modules/@hapi/hoek": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/hapi-pulse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/hapi-pulse/-/hapi-pulse-3.0.1.tgz",
@@ -11924,6 +11795,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/hapi-pulse/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/hapi-pulse/node_modules/joi": {
       "version": "17.9.2",
@@ -14515,6 +14392,12 @@
         "lodash": "^4.17.21",
         "semver-compare": "^1.0.0"
       }
+    },
+    "node_modules/joi/node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/joycon": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/core": "^7.26.10",
     "@babel/preset-env": "^7.26.9",
     "@babel/preset-typescript": "^7.26.0",
+    "@hapi/hoek": "^11.0.7",
     "@types/eslint": "^8.56.12",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.29",


### PR DESCRIPTION
This should fix missing stack traces when an unhandled exception is encountered in a route handler.

[More info](https://discord.com/channels/1031830080109957162/1031830081242415106/threads/1423251797040042065)
---

Hi all 👋 

I'm looking for a way to capture and log stack traces when an unhandled exception is encountered in a route.

I have a generic onPreResponse handler for error logging that looks something like:

```
server.ext('onPreResponse', (request, h) => {
  const response = request.response

  if (Boom.isBoom(response)) {
    // Stack trace is undefined for unhandled system errors
    console.log(response.stack)
    
    return h.response({}).code(500)
  }
  
  return h.continue
})
```

If I have a route that generates an unhandled error e.g.

```
{
    method: 'GET',
    path: '/generate-error',
    async handler(request, h) {
      const o = undefined
      
      // Generate a TypeError
      const val = o.val
      
      return { some: 'thing' }
    }
}
```

The `response.stack` in `onPreResponse` is always undefined.

Stepping through the code it is because of [this line](https://github.com/hapijs/hapi/blob/master/lib/toolkit.js#L64) in toolkit.js uses Boom.badImplementation which is stripping out the stack [here](https://github.com/hapijs/boom/blob/master/lib/index.js#L74) in Hoek.clone

Is this by design? Has anyone overcome this and found a way to access the err.stack in an onPreResponse for unhandled system errors?

TIA

djs — 11:25 AM
Hoek is stripping it [here](https://github.com/hapijs/hoek/blob/master/lib/clone.js#L105) when cloning the error, it gets the descriptor with key "stack" and redefines the property on the cloned error Object.defineProperty(newObj, key, descriptor) but the descriptor value is lost

djs — 12:16 PM
Looking at the most recent version of Hoek (11.0.7) it looks like stack now gets [special](https://github.com/hapijs/hoek/blob/master/lib/clone.js#L179) [handling](https://github.com/hapijs/hoek/blob/master/lib/clone.js#L92) (in node 21+). If I force Boom to use Hoek version 11.0.7, I see a stack trace in onPreResponse.

Latest Boom [uses](https://github.com/hapijs/boom/blob/master/package.json#L21) Hoek@^11.0.2.

Ok, I've now just seen [this](https://github.com/hapijs/boom/issues/302) issue.
Given https://github.com/hapijs/hoek/pull/390 is now merged, can we get a new version of Boom published? Or is it awaiting [this](https://github.com/hapijs/boom/pull/304)? 

djs — 1:12 PM
Node was installing hoek@11.0.2 for boom. I fixed this by adding an explicit dependency to hoek@11.0.7 in my package.json. 