### PR TITLE
fix/df-912: Dedupe DLQ messages/counts

### DIFF
--- a/designer/server/src/lib/dead-letter-queue.js
+++ b/designer/server/src/lib/dead-letter-queue.js
@@ -57,7 +57,14 @@ export async function getDeadLetterQueueMessages(dlq, token) {
 
   const { body } = await getJsonByType(requestUrl, getHeaders(token))
 
-  return body
+  // Dedupe in case of duplicate messages
+  // Ensure the last occurrence of the same MessageId is used as this will contain the valid ReceiptHandle
+  // (older ReceiptHandles for the same message will not be valid)
+  const uniqueMessages = new Map()
+  for (const message of body.messages) {
+    uniqueMessages.set(message.MessageId, message)
+  }
+  return uniqueMessages.values().toArray()
 }
 
 /**

--- a/designer/server/src/lib/dead-letter-queue.test.js
+++ b/designer/server/src/lib/dead-letter-queue.test.js
@@ -57,7 +57,7 @@ describe('dead-letter queue lib functions', () => {
         new URL('http://localhost:3002/admin/deadletter/form-submissions/view'),
         expect.anything()
       )
-      expect(res.messages).toEqual(['message1'])
+      expect(res).toEqual(['message1'])
     })
   })
 

--- a/designer/server/src/routes/admin/dead-letter-queues.js
+++ b/designer/server/src/routes/admin/dead-letter-queues.js
@@ -88,7 +88,7 @@ export async function getMessageCounts(token) {
   const radioItems = []
   for (const dlq of Object.values(DeadLetterQueues)) {
     try {
-      const { messages } = await getDeadLetterQueueMessages(dlq, token)
+      const messages = await getDeadLetterQueueMessages(dlq, token)
       const countSuffix = messages.length === 1 ? 'message' : 'messages'
       radioItems.push({
         value: dlq,
@@ -217,7 +217,7 @@ export default [
 
       const navigation = buildAdminNavigation(ADMIN_TOOLS)
 
-      const { messages } = await getDeadLetterQueueMessages(dlq, token)
+      const messages = await getDeadLetterQueueMessages(dlq, token)
 
       const mappedMessages = dlqMessageMapper(messages)
 

--- a/designer/server/src/routes/admin/dead-letter-queues.test.js
+++ b/designer/server/src/routes/admin/dead-letter-queues.test.js
@@ -35,12 +35,12 @@ describe('Dead-letter queues routes', () => {
     test('should render form with radio options with counts', async () => {
       jest
         .mocked(getDeadLetterQueueMessages)
-        .mockResolvedValueOnce({ messages: [] })
+        .mockResolvedValueOnce([])
         // @ts-expect-error - invalid response to throw error
         .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce({ messages: [{}, {}] })
-        .mockResolvedValueOnce({ messages: [{}, {}, {}] })
-        .mockResolvedValueOnce({ messages: [{}, {}, {}, {}] })
+        .mockResolvedValueOnce([{}, {}])
+        .mockResolvedValueOnce([{}, {}, {}])
+        .mockResolvedValueOnce([{}, {}, {}, {}])
       const options = {
         method: 'get',
         url: '/admin/dead-letter-queues',
@@ -121,15 +121,13 @@ describe('Dead-letter queues routes', () => {
     })
 
     test('should redirect to next screen if valid queue selected and display queue messages', async () => {
-      jest.mocked(getDeadLetterQueueMessages).mockResolvedValue({
-        messages: [
-          {
-            MessageId: 'message-id',
-            Body: '{ "field1": "value1" }',
-            ReceiptHandle: 'rec-handle'
-          }
-        ]
-      })
+      jest.mocked(getDeadLetterQueueMessages).mockResolvedValue([
+        {
+          MessageId: 'message-id',
+          Body: '{ "field1": "value1" }',
+          ReceiptHandle: 'rec-handle'
+        }
+      ])
       const options = {
         method: 'post',
         url: '/admin/dead-letter-queues',
@@ -146,15 +144,13 @@ describe('Dead-letter queues routes', () => {
     })
 
     test('should render form with messages and redrive button', async () => {
-      jest.mocked(getDeadLetterQueueMessages).mockResolvedValue({
-        messages: [
-          {
-            MessageId: 'message-id',
-            Body: '{ "field1": "value1" }',
-            ReceiptHandle: 'rec-handle'
-          }
-        ]
-      })
+      jest.mocked(getDeadLetterQueueMessages).mockResolvedValue([
+        {
+          MessageId: 'message-id',
+          Body: '{ "field1": "value1" }',
+          ReceiptHandle: 'rec-handle'
+        }
+      ])
 
       const options = {
         method: 'get',


### PR DESCRIPTION
We have found deployed environments can show duplicate counts/messages when VisibilityTimeout is set to zero.
Rather than changing the VisibilityTimeout, this fix dedupes any messages based on MessageId (retaining the latest message since its ReceiptHandle will be the valid one compared to older ones)