### PR TITLE
feat(DF-832): add conditional amounts and email prepopulation to PaymentField

### DIFF
--- a/model/src/components/component-types.ts
+++ b/model/src/components/component-types.ts
@@ -198,7 +198,8 @@ export const ComponentTypes: readonly ComponentDef[] = Object.freeze([
     hint: '',
     options: {
       amount: 1,
-      description: 'payment desc'
+      description: 'payment desc',
+      conditionalAmounts: []
     }
   } as PaymentFieldComponent,
   {

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -260,6 +260,11 @@ export interface PaymentFieldComponent extends FormFieldBase {
   options: FormFieldBase['options'] & {
     amount: number
     description: string
+    conditionalAmounts?: {
+      condition: string
+      amount: number
+    }[]
+    emailField?: string
   }
 }
 

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -578,10 +578,10 @@ export const componentSchema = Joi.object<ComponentDef>()
       amount: Joi.when('type', {
         is: Joi.string().trim().valid(ComponentType.PaymentField).required(),
         then: Joi.number()
-          .min(0.3)
+          .min(0)
           .max(100000)
           .required()
-          .description('Payment amount in GBP (£0.30 - £100,000)')
+          .description('Payment amount in GBP (£0 - £100,000)')
       }).description('Payment amount - for PaymentField only'),
       description: Joi.when('type', {
         is: Joi.string().trim().valid(ComponentType.PaymentField).required(),
@@ -589,7 +589,35 @@ export const componentSchema = Joi.object<ComponentDef>()
           .max(230)
           .required()
           .description('Payment description (max 230 chars)')
-      }).description('Payment description - for PaymentField only')
+      }).description('Payment description - for PaymentField only'),
+      conditionalAmounts: Joi.when('type', {
+        is: Joi.string().trim().valid(ComponentType.PaymentField).required(),
+        then: Joi.array()
+          .items(
+            Joi.object({
+              condition: Joi.string()
+                .trim()
+                .required()
+                .description('Condition ID for this amount'),
+              amount: Joi.number()
+                .min(0.3)
+                .max(100000)
+                .required()
+                .description('Amount in GBP when condition is true (min £0.30)')
+            })
+          )
+          .optional()
+          .description('Conditional payment amounts evaluated in order')
+      }).description('Conditional amounts - for PaymentField only'),
+      emailField: Joi.when('type', {
+        is: Joi.string().trim().valid(ComponentType.PaymentField).required(),
+        then: Joi.string()
+          .trim()
+          .optional()
+          .description(
+            'Name of EmailAddressField to prepopulate GOV.UK Pay email'
+          )
+      }).description('Email field reference - for PaymentField only')
     })
       .default({})
       .unknown(true)


### PR DESCRIPTION
- Add `conditionalAmounts` option to `PaymentFieldComponent` for condition-based payment amounts (first match wins, evaluated in order)
- Add `emailField` option to reference an `EmailAddressField` for GOV.UK Pay email prepopulation
- Update default amount minimum from £0.30 to £0 to support zero-amount bypass (no payment required when no conditions match)
- Conditional amounts enforce £0.30 minimum (GOV.UK Pay constraint)
- Update component-types fixture with empty `conditionalAmounts` default
