### PR TITLE
fix(DF-831): update paymentAmountSchema min to 0 (DF-832 follow-up)

### DIFF
--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -421,7 +421,7 @@ export const paymentDescriptionSchema = Joi.string()
 
 export const paymentAmountSchema = Joi.number()
   .empty('')
-  .min(0.3)
+  .min(0)
   .max(100000)
   .description('Amount of payment in pounds')
 


### PR DESCRIPTION
Follow-up to #1384 (DF-831).

The exported `paymentAmountSchema` in `model/src/form/form-editor/index.ts` was not updated alongside the inline base amount schema change in `model/src/form/form-definition/index.ts`.

`forms-manager` imports `paymentAmountSchema` and uses it in `postSchemaValidation` via `validatePaymentAmount()` as a secondary check on the base `options.amount` of a PaymentField ([definition.js:136](https://github.com/DEFRA/forms-manager/blob/main/src/api/forms/service/helpers/definition.js#L136)). Without this change, saving a form with `options.amount: 0` (the "no payment by default" case introduced in DF-832) fails validation in forms-manager with `"value" must be greater than or equal to 0.3` even though the form-definition schema itself accepts it.

Conditional amounts remain `min(0.3)` (enforced inline in `form-definition/index.ts`) — only the base amount / default is relaxed, matching the locked-in DF-832 design ("base schema min 0, payment schema min 0.3").

[DF-831](https://eaflood.atlassian.net/browse/DF-831?atlOrigin=eyJpIjoiZTRhNWRhNGExZjE0NDMxNWEwMWZiMmQ3YzU1YWNmOWYiLCJwIjoiaiJ9)

[DF-831]: https://eaflood.atlassian.net/browse/DF-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ