### PR TITLE
DF-990: Update GeospatialFieldComponent to support multiple countries

### DIFF
--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -278,7 +278,7 @@ export interface GeospatialFieldComponent extends FormFieldBase {
   type: ComponentType.GeospatialField
   options: FormFieldBase['options'] & {
     condition?: string
-    country?: GeospatialFieldOptionsCountry
+    countries?: GeospatialFieldOptionsCountry[]
   }
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DF-990

Change GeospatialField options from:

```
{
  options: {
    country: 'england' | 'wales' | 'northern-ireland' | 'scotland'
  }
}
```

to


```
{
  options: {
    countries: ('england' | 'wales' | 'northern-ireland' | 'scotland')[]
  }
}
```

In case we need to support multiple countries in the future
