### PR TITLE
feat/df-758: Shows workflow tiles and columns

### DIFF
--- a/designer/client/src/javascripts/preview/payment.js
+++ b/designer/client/src/javascripts/preview/payment.js
@@ -55,7 +55,8 @@ export class PaymentDomElements extends QuestionDomElements {
     return {
       ...this.constructValues(),
       paymentAmount: this._paymentAmount,
-      paymentDescription: this._paymentDescription
+      paymentDescription: this._paymentDescription,
+      paymentConditionalAmounts: []
     }
   }
 

--- a/designer/server/src/common/components/metrics-overview/template.njk
+++ b/designer/server/src/common/components/metrics-overview/template.njk
@@ -22,7 +22,7 @@
   </div>
 </div>
 
-{# <!-- Publishing Workflow Section -->
+<!-- Publishing Workflow Section -->
 <div class="govuk-!-margin-bottom-0">
   <h2 class="govuk-heading-m govuk-!-margin-bottom-4">Publishing workflow</h2>
   <div class="govuk-grid-row">
@@ -33,4 +33,4 @@
     <!-- Average Time to Publish -->
     {{ appMetricsTile(params.timeToPublish) }}
   </div>
-</div> #}
+</div>

--- a/designer/server/src/common/components/metrics-tile/template.njk
+++ b/designer/server/src/common/components/metrics-tile/template.njk
@@ -11,7 +11,11 @@
   <div class="app-metric-tile">
     <div class="gem-c-big-number">
       <span class="gem-c-big-number__label">{{ params.title }}</span>
-      <span class="gem-c-big-number__value">{{ params.count | formatNumber }}</span>
+      <span class="gem-c-big-number__value">{{ params.count | formatNumber }}
+      {% if params.units %}
+      <span class="app-big-number-unit">{{ params.units }}</span>
+      {% endif %}
+      </span>
     </div>
     <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
       <strong class="govuk-tag {{ directionSymbolClasses }}" aria-label="{{ params.ariaLabel }}">

--- a/designer/server/src/models/admin/metrics-helper.js
+++ b/designer/server/src/models/admin/metrics-helper.js
@@ -229,7 +229,7 @@ export function mapOverviewMetrics(
  * @param {number} currCount
  * @param {number} prevCount
  */
-function calcChangePercentage(currCount, prevCount) {
+export function calcChangePercentage(currCount, prevCount) {
   if (currCount === 0 && prevCount === 0) {
     return '-'
   }

--- a/designer/server/src/models/admin/metrics-helper.js
+++ b/designer/server/src/models/admin/metrics-helper.js
@@ -214,8 +214,14 @@ export function mapOverviewMetrics(
       (metric.formStatus === FormStatus.Live
         ? submissionCountsLive.get(metric.formId)
         : submissionCountsDraft.get(metric.formId)) ?? 0,
-    daysToPublish: formDaysToPublish.get(metric.formId) ?? 0,
-    republished: formRepublished.get(metric.formId) ?? 0
+    daysToPublish:
+      metric.formStatus === FormStatus.Live
+        ? (formDaysToPublish.get(metric.formId) ?? 0)
+        : '-',
+    republished:
+      metric.formStatus === FormStatus.Live
+        ? (formRepublished.get(metric.formId) ?? 0)
+        : '-'
   }))
 }
 
@@ -238,7 +244,7 @@ function calcChangePercentage(currCount, prevCount) {
  * @param { Record<FormMetricName, { count?: number }> | undefined } prevPeriod
  * @param {FormMetricName} metricName
  * @param {{ ariaPeriodName: string, straplinePeriodName: string }} periodNames
- * @param {string} [units]
+ * @param { string | undefined } [units]
  */
 export function collateSpecificTileCounts(
   currPeriod,
@@ -257,12 +263,15 @@ export function collateSpecificTileCounts(
       : 0
 
   const notEqualSymbol = currPeriodCount > prevPeriodCount ? '+' : '-'
-  const counts = {
-    count: currPeriodCount,
-    changeSymbol: currPeriodCount === prevPeriodCount ? '' : notEqualSymbol,
-    changeValue: currPeriodCount - prevPeriodCount,
-    changePercentage: calcChangePercentage(currPeriodCount, prevPeriodCount),
-    units: units ?? ''
+  const counts =
+    /** @type {{ count: number, changeSymbol: string, changeValue: number, changePercentage: string, units?: string }} */ ({
+      count: currPeriodCount,
+      changeSymbol: currPeriodCount === prevPeriodCount ? '' : notEqualSymbol,
+      changeValue: currPeriodCount - prevPeriodCount,
+      changePercentage: calcChangePercentage(currPeriodCount, prevPeriodCount)
+    })
+  if (units) {
+    counts.units = units
   }
 
   const changePhrase = buildChangePhrase(counts)
@@ -284,6 +293,25 @@ export function collateSpecificTileCounts(
 }
 
 /**
+ * @param {string} title
+ * @param {FormMetricName} metricName
+ * @param {{ currPeriod: Record<FormMetricName, { count?: number }> | undefined, prevPeriod: Record<FormMetricName, { count?: number }> | undefined, periodNames: { ariaPeriodName: string, straplinePeriodName: string } }} commonParams
+ * @param {string} [units]
+ */
+function createTile(title, metricName, commonParams, units) {
+  return {
+    title,
+    ...collateSpecificTileCounts(
+      commonParams.currPeriod,
+      commonParams.prevPeriod,
+      metricName,
+      commonParams.periodNames,
+      units
+    )
+  }
+}
+
+/**
  * @param { Date | undefined } fromDate
  * @param { Date | undefined } toDate
  * @param {string} title
@@ -299,56 +327,41 @@ export function mapOverviewTiles(
   prevPeriod,
   periodNames
 ) {
+  const commonParams = {
+    currPeriod,
+    prevPeriod,
+    periodNames
+  }
   return {
     fromDate: fromDate ? format(fromDate, FULL_DATE_MASK) : undefined,
     toDate: toDate ? format(toDate, FULL_DATE_MASK) : undefined,
     title,
-    newFormsCreated: {
-      title: NEW_FORMS_CREATED_TITLE,
-      ...collateSpecificTileCounts(
-        currPeriod,
-        prevPeriod,
-        FormMetricName.NewFormsCreated,
-        periodNames
-      )
-    },
-    formsPublished: {
-      title: FORMS_PUBLISHED_TITLE,
-      ...collateSpecificTileCounts(
-        currPeriod,
-        prevPeriod,
-        FormMetricName.FormsPublished,
-        periodNames
-      )
-    },
-    formSubmissions: {
-      title: FORM_SUBMISSIONS_TITLE,
-      ...collateSpecificTileCounts(
-        currPeriod,
-        prevPeriod,
-        FormMetricName.Submissions,
-        periodNames
-      )
-    },
-    formsInDraft: {
-      title: FORMS_IN_DRAFT_TITLE,
-      ...collateSpecificTileCounts(
-        currPeriod,
-        prevPeriod,
-        FormMetricName.FormsInDraft,
-        periodNames
-      )
-    },
-    timeToPublish: {
-      title: TIME_TO_PUBLISH_TITLE,
-      ...collateSpecificTileCounts(
-        currPeriod,
-        prevPeriod,
-        FormMetricName.TimeToPublish,
-        periodNames,
-        'days'
-      )
-    }
+    newFormsCreated: createTile(
+      NEW_FORMS_CREATED_TITLE,
+      FormMetricName.NewFormsCreated,
+      commonParams
+    ),
+    formsPublished: createTile(
+      FORMS_PUBLISHED_TITLE,
+      FormMetricName.FormsPublished,
+      commonParams
+    ),
+    formSubmissions: createTile(
+      FORM_SUBMISSIONS_TITLE,
+      FormMetricName.Submissions,
+      commonParams
+    ),
+    formsInDraft: createTile(
+      FORMS_IN_DRAFT_TITLE,
+      FormMetricName.FormsInDraft,
+      commonParams
+    ),
+    timeToPublish: createTile(
+      TIME_TO_PUBLISH_TITLE,
+      FormMetricName.TimeToPublish,
+      commonParams,
+      'days'
+    )
   }
 }
 

--- a/designer/server/src/models/admin/metrics-helper.js
+++ b/designer/server/src/models/admin/metrics-helper.js
@@ -7,6 +7,8 @@ const FULL_DATE_MASK = 'd MMMM yyyy'
 const NEW_FORMS_CREATED_TITLE = 'New forms created'
 const FORMS_PUBLISHED_TITLE = 'Forms published'
 const FORM_SUBMISSIONS_TITLE = 'Form submissions'
+const FORMS_IN_DRAFT_TITLE = 'Forms in draft'
+const TIME_TO_PUBLISH_TITLE = 'Average time to publish'
 
 const formStructureMetricNames =
   /** @type {Partial<Record<string, string>>} */ ({
@@ -21,8 +23,11 @@ const straplineWording =
   /** @type {Record<FormMetricName, { noun: string, verb: string}>} */ ({
     [FormMetricName.NewFormsCreated]: { noun: 'form', verb: 'created' },
     [FormMetricName.FormsPublished]: { noun: 'form', verb: 'published' },
-    [FormMetricName.Submissions]: { noun: 'submission', verb: '' }
+    [FormMetricName.Submissions]: { noun: 'submission', verb: '' },
+    [FormMetricName.FormsInDraft]: { noun: 'form', verb: '' },
+    [FormMetricName.TimeToPublish]: { noun: 'day', verb: '' }
   })
+
 /**
  * @typedef PeriodName
  * @property {string} ariaPeriodName - period name within aria label
@@ -189,11 +194,15 @@ export function componentUsageFormStructures(metrics, formStatus) {
  * @param {FormOverviewMetric[]} metrics
  * @param {Map<string, number>} submissionCountsDraft
  * @param {Map<string, number>} submissionCountsLive
+ * @param {Map<string, number>} formDaysToPublish
+ * @param {Map<string, number>} formRepublished
  */
 export function mapOverviewMetrics(
   metrics,
   submissionCountsDraft,
-  submissionCountsLive
+  submissionCountsLive,
+  formDaysToPublish,
+  formRepublished
 ) {
   return metrics.map((metric) => ({
     ...metric.summaryMetrics,
@@ -205,7 +214,8 @@ export function mapOverviewMetrics(
       (metric.formStatus === FormStatus.Live
         ? submissionCountsLive.get(metric.formId)
         : submissionCountsDraft.get(metric.formId)) ?? 0,
-    daysToPublish: '-'
+    daysToPublish: formDaysToPublish.get(metric.formId) ?? 0,
+    republished: formRepublished.get(metric.formId) ?? 0
   }))
 }
 
@@ -228,12 +238,14 @@ function calcChangePercentage(currCount, prevCount) {
  * @param { Record<FormMetricName, { count?: number }> | undefined } prevPeriod
  * @param {FormMetricName} metricName
  * @param {{ ariaPeriodName: string, straplinePeriodName: string }} periodNames
+ * @param {string} [units]
  */
 export function collateSpecificTileCounts(
   currPeriod,
   prevPeriod,
   metricName,
-  periodNames
+  periodNames,
+  units
 ) {
   const currPeriodCount =
     currPeriod && metricName in currPeriod
@@ -249,7 +261,8 @@ export function collateSpecificTileCounts(
     count: currPeriodCount,
     changeSymbol: currPeriodCount === prevPeriodCount ? '' : notEqualSymbol,
     changeValue: currPeriodCount - prevPeriodCount,
-    changePercentage: calcChangePercentage(currPeriodCount, prevPeriodCount)
+    changePercentage: calcChangePercentage(currPeriodCount, prevPeriodCount),
+    units: units ?? ''
   }
 
   const changePhrase = buildChangePhrase(counts)
@@ -315,6 +328,25 @@ export function mapOverviewTiles(
         prevPeriod,
         FormMetricName.Submissions,
         periodNames
+      )
+    },
+    formsInDraft: {
+      title: FORMS_IN_DRAFT_TITLE,
+      ...collateSpecificTileCounts(
+        currPeriod,
+        prevPeriod,
+        FormMetricName.FormsInDraft,
+        periodNames
+      )
+    },
+    timeToPublish: {
+      title: TIME_TO_PUBLISH_TITLE,
+      ...collateSpecificTileCounts(
+        currPeriod,
+        prevPeriod,
+        FormMetricName.TimeToPublish,
+        periodNames,
+        'days'
       )
     }
   }

--- a/designer/server/src/models/admin/metrics-helper.test.js
+++ b/designer/server/src/models/admin/metrics-helper.test.js
@@ -1,7 +1,10 @@
+import { FormMetricType, FormStatus } from '@defra/forms-model'
+
 import {
   buildAriaLabel,
   buildChangePhrase,
-  calcChangePercentage
+  calcChangePercentage,
+  mapOverviewMetrics
 } from '~/src/models/admin/metrics-helper.js'
 
 describe('metrics model', () => {
@@ -54,4 +57,88 @@ describe('metrics model', () => {
       expect(calcChangePercentage(1, 2)).toBe('-50.0')
     })
   })
+
+  describe('mapOverviewMetrics', () => {
+    it('should map all metric types when maps empty and draft', () => {
+      const metrics = /** @type {FormOverviewMetric[]} */ ([
+        {
+          type: FormMetricType.OverviewMetric,
+          formStatus: FormStatus.Draft,
+          formId: 'form-id',
+          summaryMetrics: {
+            name: 'form-name',
+            features: []
+          },
+          featureMetrics: {},
+          submissionsCount: 0,
+          updatedAt: new Date('2026-01-01')
+        }
+      ])
+      const submissionCountsDraft = new Map()
+      const submissionCountsLive = new Map()
+      const formDaysToPublish = new Map()
+      const formRepublished = new Map()
+      expect(
+        mapOverviewMetrics(
+          metrics,
+          submissionCountsDraft,
+          submissionCountsLive,
+          formDaysToPublish,
+          formRepublished
+        )
+      ).toEqual([
+        {
+          daysToPublish: '-',
+          features: '',
+          name: 'form-name',
+          formName: 'form-name',
+          republished: '-',
+          submissions: 0
+        }
+      ])
+    })
+
+    it('should map all metric types when live', () => {
+      const metrics = /** @type {FormOverviewMetric[]} */ ([
+        {
+          type: FormMetricType.OverviewMetric,
+          formStatus: FormStatus.Live,
+          formId: 'form-id',
+          summaryMetrics: {
+            name: 'form-name',
+            features: ['Email', 'File upload']
+          },
+          featureMetrics: {},
+          submissionsCount: 0,
+          updatedAt: new Date('2026-01-01')
+        }
+      ])
+      const submissionCountsDraft = new Map([['form-id', 3]])
+      const submissionCountsLive = new Map([['form-id', 7]])
+      const formDaysToPublish = new Map([['form-id', 17]])
+      const formRepublished = new Map([['form-id', 2]])
+      expect(
+        mapOverviewMetrics(
+          metrics,
+          submissionCountsDraft,
+          submissionCountsLive,
+          formDaysToPublish,
+          formRepublished
+        )
+      ).toEqual([
+        {
+          features: 'Email, File upload',
+          name: 'form-name',
+          formName: 'form-name',
+          submissions: 7,
+          daysToPublish: 17,
+          republished: 2
+        }
+      ])
+    })
+  })
 })
+
+/**
+ * @import { FormOverviewMetric } from '@defra/forms-model'
+ */

--- a/designer/server/src/models/admin/metrics-helper.test.js
+++ b/designer/server/src/models/admin/metrics-helper.test.js
@@ -1,6 +1,7 @@
 import {
   buildAriaLabel,
-  buildChangePhrase
+  buildChangePhrase,
+  calcChangePercentage
 } from '~/src/models/admin/metrics-helper.js'
 
 describe('metrics model', () => {
@@ -39,6 +40,18 @@ describe('metrics model', () => {
     it('should build label when negative change from previous period', () => {
       const phrase = buildChangePhrase({ changeSymbol: '-', changeValue: 3 })
       expect(phrase).toBe('3 fewer')
+    })
+  })
+
+  describe('calcChangePercentage', () => {
+    it('should handle zero for current and previous', () => {
+      expect(calcChangePercentage(0, 0)).toBe('-')
+    })
+    it('should handle zero for previous', () => {
+      expect(calcChangePercentage(1, 0)).toBe('100')
+    })
+    it('should handle normal percentage', () => {
+      expect(calcChangePercentage(1, 2)).toBe('-50.0')
     })
   })
 })

--- a/designer/server/src/models/admin/metrics.js
+++ b/designer/server/src/models/admin/metrics.js
@@ -36,29 +36,35 @@ export function metricsFormActivityViewModel(metrics) {
     )
   })
 
-  // Create a map of submission counts per form for quicker lookups
-  // (one for draft and one for live)
-  const formSubmissionCountsLive = new Map()
-  for (const [formId, count] of Object.entries(
-    metrics.totals.liveSubmissions ?? {}
-  )) {
-    formSubmissionCountsLive.set(formId, count)
-  }
-  const formSubmissionCountsDraft = new Map()
-  for (const [formId, count] of Object.entries(
-    metrics.totals.draftSubmissions ?? {}
-  )) {
-    formSubmissionCountsDraft.set(formId, count)
-  }
+  // Create a map of certain counts per form for quicker lookups
+  const formSubmissionCountsLive = createFormMap(metrics.totals.liveSubmissions)
+  const formSubmissionCountsDraft = createFormMap(
+    metrics.totals.draftSubmissions
+  )
+  const formDaysToPublish = createFormMap(metrics.totals.daysToPublish)
+  const formRepublished = createFormMap(metrics.totals.republished)
 
   return {
     overviewMetrics: mapTotalMetrics(metrics.totals, tilePeriodNames),
     formMetricRows: mapOverviewMetrics(
       overviewsSorted,
       formSubmissionCountsDraft,
-      formSubmissionCountsLive
+      formSubmissionCountsLive,
+      formDaysToPublish,
+      formRepublished
     )
   }
+}
+
+/**
+ * @param {Record<string, number> | undefined} metricValues
+ */
+function createFormMap(metricValues) {
+  const formMap = new Map()
+  for (const [formId, count] of Object.entries(metricValues ?? {})) {
+    formMap.set(formId, count)
+  }
+  return formMap
 }
 
 /**

--- a/designer/server/src/models/admin/metrics.test.js
+++ b/designer/server/src/models/admin/metrics.test.js
@@ -82,14 +82,16 @@ describe('metrics models', () => {
             features: [],
             formName: 'form1',
             name: 'form1',
-            submissions: 5
+            submissions: 5,
+            republished: '-'
           },
           {
             daysToPublish: '-',
             features: [],
             formName: 'form2',
             name: 'form2',
-            submissions: 2
+            submissions: 2,
+            republished: '-'
           }
         ],
         overviewMetrics: {
@@ -111,7 +113,20 @@ describe('metrics models', () => {
               'Form submissions',
               'previous 7 days',
               'No difference in submissions  than last week'
-            )
+            ),
+            formsInDraft: getExpectedTile(
+              'Forms in draft',
+              'previous 7 days',
+              'No difference in forms  than last week'
+            ),
+            timeToPublish: {
+              ...getExpectedTile(
+                'Average time to publish',
+                'previous 7 days',
+                'No difference in days  than last week'
+              ),
+              units: 'days'
+            }
           },
           last30Days: {
             fromDate: '2 December 2025',
@@ -131,7 +146,20 @@ describe('metrics models', () => {
               'Form submissions',
               'previous 30 days',
               'No difference in submissions  than last month'
-            )
+            ),
+            formsInDraft: getExpectedTile(
+              'Forms in draft',
+              'previous 30 days',
+              'No difference in forms  than last month'
+            ),
+            timeToPublish: {
+              ...getExpectedTile(
+                'Average time to publish',
+                'previous 30 days',
+                'No difference in days  than last month'
+              ),
+              units: 'days'
+            }
           },
           allTime: {
             fromDate: undefined,
@@ -151,7 +179,20 @@ describe('metrics models', () => {
               'Form submissions',
               'previous year',
               'No difference in submissions  than last year'
-            )
+            ),
+            formsInDraft: getExpectedTile(
+              'Forms in draft',
+              'previous year',
+              'No difference in forms  than last year'
+            ),
+            timeToPublish: {
+              ...getExpectedTile(
+                'Average time to publish',
+                'previous year',
+                'No difference in days  than last year'
+              ),
+              units: 'days'
+            }
           }
         }
       })

--- a/designer/server/src/models/forms/editor-v2/payment-conditional-amounts.test.js
+++ b/designer/server/src/models/forms/editor-v2/payment-conditional-amounts.test.js
@@ -1,5 +1,8 @@
 import { ConditionType, OperatorName } from '@defra/forms-model'
-import { buildQuestionPage, buildTextFieldComponent  } from '@defra/forms-model/stubs'
+import {
+  buildQuestionPage,
+  buildTextFieldComponent
+} from '@defra/forms-model/stubs'
 
 import { buildDefinition } from '~/src/__stubs__/form-definition.js'
 import { getPaymentConditionalAmountsViewModel } from '~/src/models/forms/editor-v2/payment-conditional-amounts.js'

--- a/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
+++ b/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
@@ -206,7 +206,16 @@ exports[`Form metrics routes form-metrics should render regenerate form 1`] = `
       <h2 class="govuk-heading-l">Regenerating metrics</h2>
       <p class="govuk-body">This will clear out the 'metrics' collection in the 'forms-audit-api' database, and regenerate a full history of metrics.</p>
 
-      <button type="submit" class="govuk-button" data-module="govuk-button">
+      <div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-visually-hidden">Warning</span>
+    This operation will remove existing metrics.
+  </strong>
+</div>
+
+
+      <button type="submit" class="govuk-button govuk-button--warning" data-module="govuk-button">
   Regenerate metrics
 </button>
     </form>

--- a/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
+++ b/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
@@ -528,7 +528,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">New forms created</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
@@ -547,7 +548,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Forms published</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
@@ -566,7 +568,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Form submissions</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
@@ -575,6 +578,54 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
     
         </div>
         <p class="govuk-body-xs app-metric-caption">No difference in submissions  than last week</p>
+      </div>
+    </div>
+    
+      </div>
+    </div>
+    
+    <!-- Publishing Workflow Section -->
+    <div class="govuk-!-margin-bottom-0">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-4">Publishing workflow</h2>
+      <div class="govuk-grid-row">
+    
+        <!-- Forms in Draft -->
+        <!-- Metrics tile -->
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-tablet govuk-grid-column-one-third-from-desktop" data-testid="headline-column-forms-in-draft">
+      <div class="app-metric-tile">
+        <div class="gem-c-big-number">
+          <span class="gem-c-big-number__label">Forms in draft</span>
+          <span class="gem-c-big-number__value">0
+          </span>
+        </div>
+        <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+          <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
+            0 (-%)
+          </strong>
+    
+        </div>
+        <p class="govuk-body-xs app-metric-caption">No difference in forms  than last week</p>
+      </div>
+    </div>
+    
+    
+        <!-- Average Time to Publish -->
+        <!-- Metrics tile -->
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-tablet govuk-grid-column-one-third-from-desktop" data-testid="headline-column-average-time-to-publish">
+      <div class="app-metric-tile">
+        <div class="gem-c-big-number">
+          <span class="gem-c-big-number__label">Average time to publish</span>
+          <span class="gem-c-big-number__value">0
+          <span class="app-big-number-unit">days</span>
+          </span>
+        </div>
+        <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+          <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
+            0 (-%)
+          </strong>
+    
+        </div>
+        <p class="govuk-body-xs app-metric-caption">No difference in days  than last week</p>
       </div>
     </div>
     
@@ -595,7 +646,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">New forms created</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
@@ -614,7 +666,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Forms published</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
@@ -633,7 +686,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Form submissions</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
@@ -642,6 +696,54 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
     
         </div>
         <p class="govuk-body-xs app-metric-caption">No difference in submissions  than last month</p>
+      </div>
+    </div>
+    
+      </div>
+    </div>
+    
+    <!-- Publishing Workflow Section -->
+    <div class="govuk-!-margin-bottom-0">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-4">Publishing workflow</h2>
+      <div class="govuk-grid-row">
+    
+        <!-- Forms in Draft -->
+        <!-- Metrics tile -->
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-tablet govuk-grid-column-one-third-from-desktop" data-testid="headline-column-forms-in-draft">
+      <div class="app-metric-tile">
+        <div class="gem-c-big-number">
+          <span class="gem-c-big-number__label">Forms in draft</span>
+          <span class="gem-c-big-number__value">0
+          </span>
+        </div>
+        <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+          <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
+            0 (-%)
+          </strong>
+    
+        </div>
+        <p class="govuk-body-xs app-metric-caption">No difference in forms  than last month</p>
+      </div>
+    </div>
+    
+    
+        <!-- Average Time to Publish -->
+        <!-- Metrics tile -->
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-tablet govuk-grid-column-one-third-from-desktop" data-testid="headline-column-average-time-to-publish">
+      <div class="app-metric-tile">
+        <div class="gem-c-big-number">
+          <span class="gem-c-big-number__label">Average time to publish</span>
+          <span class="gem-c-big-number__value">0
+          <span class="app-big-number-unit">days</span>
+          </span>
+        </div>
+        <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+          <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
+            0 (-%)
+          </strong>
+    
+        </div>
+        <p class="govuk-body-xs app-metric-caption">No difference in days  than last month</p>
       </div>
     </div>
     
@@ -662,7 +764,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">New forms created</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
@@ -681,7 +784,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Forms published</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
@@ -700,7 +804,8 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Form submissions</span>
-          <span class="gem-c-big-number__value">0</span>
+          <span class="gem-c-big-number__value">0
+          </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
@@ -709,6 +814,54 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
     
         </div>
         <p class="govuk-body-xs app-metric-caption">No difference in submissions  than last year</p>
+      </div>
+    </div>
+    
+      </div>
+    </div>
+    
+    <!-- Publishing Workflow Section -->
+    <div class="govuk-!-margin-bottom-0">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-4">Publishing workflow</h2>
+      <div class="govuk-grid-row">
+    
+        <!-- Forms in Draft -->
+        <!-- Metrics tile -->
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-tablet govuk-grid-column-one-third-from-desktop" data-testid="headline-column-forms-in-draft">
+      <div class="app-metric-tile">
+        <div class="gem-c-big-number">
+          <span class="gem-c-big-number__label">Forms in draft</span>
+          <span class="gem-c-big-number__value">0
+          </span>
+        </div>
+        <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+          <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
+            0 (-%)
+          </strong>
+    
+        </div>
+        <p class="govuk-body-xs app-metric-caption">No difference in forms  than last year</p>
+      </div>
+    </div>
+    
+    
+        <!-- Average Time to Publish -->
+        <!-- Metrics tile -->
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-tablet govuk-grid-column-one-third-from-desktop" data-testid="headline-column-average-time-to-publish">
+      <div class="app-metric-tile">
+        <div class="gem-c-big-number">
+          <span class="gem-c-big-number__label">Average time to publish</span>
+          <span class="gem-c-big-number__value">0
+          <span class="app-big-number-unit">days</span>
+          </span>
+        </div>
+        <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
+          <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
+            0 (-%)
+          </strong>
+    
+        </div>
+        <p class="govuk-body-xs app-metric-caption">No difference in days  than last year</p>
       </div>
     </div>
     
@@ -728,6 +881,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         <th scope="col" class="govuk-table__header">Question types</th>
         <th scope="col" class="govuk-table__header">Conditions</th>
         <th scope="col" class="govuk-table__header">Sections</th>
+        <th scope="col" class="govuk-table__header">Re-published</th>
         <th scope="col" class="govuk-table__header">Days to publish</th>
         <th scope="col" class="govuk-table__header">Features</th>
         <th scope="col" class="govuk-table__header">Submissions</th>

--- a/designer/server/src/routes/admin/index.js
+++ b/designer/server/src/routes/admin/index.js
@@ -87,7 +87,8 @@ export default [
           resetSaveAndExit: scopes.includes(Scopes.ResetSaveAndExit),
           deadLetterQueues: scopes.includes(Scopes.DeadLetterQueues),
           formInspect: scopes.includes(Scopes.FormsInspect),
-          formMetrics: scopes.includes(Scopes.FormsInspect) // Scopes.FormsReport
+          formMetrics: scopes.includes(Scopes.FormsReport),
+          formMetricsRegen: scopes.includes(Scopes.RegenerateMetrics)
         }
       })
     },

--- a/designer/server/src/views/admin/form-metrics-form-activity.njk
+++ b/designer/server/src/views/admin/form-metrics-form-activity.njk
@@ -76,6 +76,7 @@
         <th scope="col" class="govuk-table__header">Question types</th>
         <th scope="col" class="govuk-table__header">Conditions</th>
         <th scope="col" class="govuk-table__header">Sections</th>
+        <th scope="col" class="govuk-table__header">Re-published</th>
         <th scope="col" class="govuk-table__header">Days to publish</th>
         <th scope="col" class="govuk-table__header">Features</th>
         <th scope="col" class="govuk-table__header">Submissions</th>
@@ -99,6 +100,7 @@
         <td class="govuk-table__cell">{{ row.questionTypes }}</td>
         <td class="govuk-table__cell">{{ row.conditions }}</td>
         <td class="govuk-table__cell">{{ row.sections }}</td>
+        <td class="govuk-table__cell">{{ row.republished }}</td>
         <td class="govuk-table__cell">{{ row.daysToPublish }}</td>
         <td class="govuk-table__cell">{{ row.features }}</td>
         <td class="govuk-table__cell">{{ row.submissions }}</td>

--- a/designer/server/src/views/admin/form-metrics-regenerate.njk
+++ b/designer/server/src/views/admin/form-metrics-regenerate.njk
@@ -2,6 +2,7 @@
 
 {% from "page-body/macro.njk" import appPageBody %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set mainClasses = "govuk-main-wrapper--masthead" %}
 
@@ -18,8 +19,14 @@
       <h2 class="govuk-heading-l">Regenerating metrics</h2>
       <p class="govuk-body">This will clear out the 'metrics' collection in the 'forms-audit-api' database, and regenerate a full history of metrics.</p>
 
+      {{ govukWarningText({
+        text: "This operation will remove existing metrics.",
+        iconFallbackText: "Warning"
+      }) }}
+
       {{ govukButton({
-        text: 'Regenerate metrics'
+        text: 'Regenerate metrics',
+        classes: 'govuk-button--warning'
       }) }}
     </form>
 

--- a/designer/server/src/views/admin/index.njk
+++ b/designer/server/src/views/admin/index.njk
@@ -110,6 +110,11 @@
             <a href="/admin/form-metrics" class="govuk-link govuk-link--no-visited-state">Form metrics</a>
           </li>
         {% endif %}
+        {% if supports.formMetricsRegen %}
+          <li>
+            <a href="/admin/form-metrics-regenerate" class="govuk-link govuk-link--no-visited-state">Regenerate all form metrics</a>
+          </li>
+        {% endif %}
       </ul>
     {% endif %}
   {% endcall %}

--- a/designer/server/src/views/admin/index.njk
+++ b/designer/server/src/views/admin/index.njk
@@ -110,12 +110,17 @@
             <a href="/admin/form-metrics" class="govuk-link govuk-link--no-visited-state">Form metrics</a>
           </li>
         {% endif %}
+      </ul>
+
+      <h2 class="govuk-heading-m">System tools</h2>
+      <ul class="govuk-list">
         {% if supports.formMetricsRegen %}
           <li>
             <a href="/admin/form-metrics-regenerate" class="govuk-link govuk-link--no-visited-state">Regenerate all form metrics</a>
           </li>
         {% endif %}
       </ul>
+
     {% endif %}
   {% endcall %}
 {% endblock %}

--- a/model/src/form/form-metrics/types.ts
+++ b/model/src/form/form-metrics/types.ts
@@ -19,6 +19,8 @@ export interface FormTotalsMetric {
   allTime?: Record<FormMetricName, FormTotalMetric>
   liveSubmissions?: Record<string, number>
   draftSubmissions?: Record<string, number>
+  daysToPublish?: Record<string, number>
+  republished?: Record<string, number>
   updatedAt: Date
 }
 


### PR DESCRIPTION
Ticket [DF-758](https://eaflood.atlassian.net/browse/DF-758)[DF-758]

Adds extra Workflow tiles
Adds columns 'Re-published' and 'Days to publish' in per form table

<img width="1815" height="550" alt="image" src="https://github.com/user-attachments/assets/30c8823c-cadc-4c10-9017-533e6cc64d18" />

[DF-758]: https://eaflood.atlassian.net/browse/DF-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ