### PR TITLE
feat(DF-789): add offline flag to form metadata

### DIFF
--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -136,6 +136,10 @@ export const notificationEmailAddressSchema =
     'Email address to receive form submission notifications'
   )
 
+export const offlineSchema = Joi.boolean().description(
+  'Whether the form has been taken offline; runtime renders an unavailable page when true'
+)
+
 export const authoredAtSchema = Joi.date()
   .iso()
   .required()
@@ -170,7 +174,8 @@ export const formMetadataInputKeys = {
     otherwise: privacyNoticeUrlSchema.allow('')
   }),
   termsAndConditionsAgreed: termsAndConditionsAgreedSchema,
-  notificationEmail: notificationEmailAddressSchema
+  notificationEmail: notificationEmailAddressSchema,
+  offline: offlineSchema
 }
 
 /**

--- a/model/src/form/form-metadata/types.ts
+++ b/model/src/form/form-metadata/types.ts
@@ -175,6 +175,12 @@ export interface FormMetadata {
   notificationEmail?: string
 
   /**
+   * Whether the form has been taken offline. When true, the runtime renders
+   * an unavailable page instead of the form.
+   */
+  offline?: boolean
+
+  /**
    * The draft state of the form
    */
   draft?: FormMetadataState
@@ -236,6 +242,7 @@ export type FormMetadataInput = Pick<
   | 'privacyNoticeUrl'
   | 'termsAndConditionsAgreed'
   | 'notificationEmail'
+  | 'offline'
 >
 
 export interface FormResponse {


### PR DESCRIPTION
## Summary
- Adds `offline?: boolean` to `FormMetadata` and `FormMetadataInput`.
- Adds `offlineSchema` (no Joi default) and registers it in `formMetadataInputKeys`.
