### PR TITLE
feat/df-1091: Metrics enhancements

### DIFF
--- a/designer/server/src/models/admin/metrics-helper.js
+++ b/designer/server/src/models/admin/metrics-helper.js
@@ -235,7 +235,7 @@ export function mapOverviewMetrics(metrics) {
  */
 export function calcChangePercentage(currCount, prevCount) {
   if (currCount === 0 && prevCount === 0) {
-    return '-'
+    return '0.0'
   }
   if (prevCount === 0) {
     return '100'

--- a/designer/server/src/models/admin/metrics-helper.js
+++ b/designer/server/src/models/admin/metrics-helper.js
@@ -54,7 +54,7 @@ const straplineWording =
 /**
  * @param {string} changeSymbol - '+' or '-' or ''
  * @param {number} changeValue
- * @param {string} changePercentage
+ * @param {number} changePercentage
  * @param {string} periodPhrase
  */
 export function buildAriaLabel(
@@ -232,15 +232,23 @@ export function mapOverviewMetrics(metrics) {
 /**
  * @param {number} currCount
  * @param {number} prevCount
+ * @returns {number}
  */
 export function calcChangePercentage(currCount, prevCount) {
   if (currCount === 0 && prevCount === 0) {
-    return '0.0'
+    return 0
   }
   if (prevCount === 0) {
-    return '100'
+    return 100
   }
-  return (((currCount - prevCount) / prevCount) * 100).toFixed(1)
+  return oneDecimalPlace(((currCount - prevCount) / prevCount) * 100)
+}
+
+/**
+ * @param {number} num
+ */
+export function oneDecimalPlace(num) {
+  return parseFloat(num.toFixed(1))
 }
 
 /**
@@ -268,10 +276,10 @@ export function collateSpecificTileCounts(
 
   const notEqualSymbol = currPeriodCount > prevPeriodCount ? '+' : '-'
   const counts =
-    /** @type {{ count: number, changeSymbol: string, changeValue: number, changePercentage: string, units?: string }} */ ({
-      count: currPeriodCount,
+    /** @type {{ count: number, changeSymbol: string, changeValue: number, changePercentage: number, units?: string }} */ ({
+      count: oneDecimalPlace(currPeriodCount),
       changeSymbol: currPeriodCount === prevPeriodCount ? '' : notEqualSymbol,
-      changeValue: currPeriodCount - prevPeriodCount,
+      changeValue: oneDecimalPlace(currPeriodCount - prevPeriodCount),
       changePercentage: calcChangePercentage(currPeriodCount, prevPeriodCount)
     })
   if (units) {

--- a/designer/server/src/models/admin/metrics-helper.js
+++ b/designer/server/src/models/admin/metrics-helper.js
@@ -248,7 +248,7 @@ export function calcChangePercentage(currCount, prevCount) {
  * @param {number} num
  */
 export function oneDecimalPlace(num) {
-  return parseFloat(num.toFixed(1))
+  return Number.parseFloat(num.toFixed(1))
 }
 
 /**

--- a/designer/server/src/models/admin/metrics-helper.test.js
+++ b/designer/server/src/models/admin/metrics-helper.test.js
@@ -4,6 +4,7 @@ import {
   buildAriaLabel,
   buildChangePhrase,
   calcChangePercentage,
+  componentUsageFormStructures,
   mapOverviewMetrics,
   oneDecimalPlace
 } from '~/src/models/admin/metrics-helper.js'
@@ -138,8 +139,94 @@ describe('metrics model', () => {
       expect(oneDecimalPlace(10 / 0)).toBe(Infinity)
     })
   })
+
+  describe('componentUsageFormStructures', () => {
+    it('should handle no metrics', () => {
+      const metrics =
+        /** @type {{ overview: FormOverviewMetric[], totals: FormTotalsMetric }} */ ({
+          overview: [],
+          totals: {
+            type: FormMetricType.TotalsMetric,
+            updatedAt: new Date()
+          }
+        })
+      expect(componentUsageFormStructures(metrics, FormStatus.Draft)).toEqual(
+        []
+      )
+    })
+
+    it('should calculate min/max/avg', () => {
+      const metrics = {
+        overview: [
+          {
+            type: FormMetricType.OverviewMetric,
+            formId: 'form-id-1',
+            formStatus: FormStatus.Draft,
+            summaryMetrics: {},
+            featureMetrics: {
+              formStructure: /** @type {Record<string, number>} */ ({
+                pages: 5,
+                sections: 3,
+                conditions: 2,
+                questionTypes: 10
+              })
+            },
+            submissionsCount: 0,
+            updatedAt: new Date()
+          },
+          {
+            type: FormMetricType.OverviewMetric,
+            formId: 'form-id-2',
+            formStatus: FormStatus.Draft,
+            summaryMetrics: {},
+            featureMetrics: {
+              formStructure: /** @type {Record<string, number>} */ ({
+                pages: 17,
+                sections: 7,
+                conditions: 4,
+                questionTypes: 11
+              })
+            },
+            submissionsCount: 0,
+            updatedAt: new Date()
+          }
+        ],
+        totals: {
+          type: FormMetricType.TotalsMetric,
+          updatedAt: new Date()
+        }
+      }
+      // @ts-expect-error - partial mock of data
+      expect(componentUsageFormStructures(metrics, FormStatus.Draft)).toEqual([
+        {
+          metricName: 'Pages per form',
+          minimum: 5,
+          maximum: 17,
+          average: '11.0'
+        },
+        {
+          metricName: 'Sections per form',
+          minimum: 3,
+          maximum: 7,
+          average: '5.0'
+        },
+        {
+          metricName: 'Conditions per form',
+          minimum: 2,
+          maximum: 4,
+          average: '3.0'
+        },
+        {
+          metricName: 'Question types per form',
+          minimum: 10,
+          maximum: 11,
+          average: '10.5'
+        }
+      ])
+    })
+  })
 })
 
 /**
- * @import { FormOverviewMetric } from '@defra/forms-model'
+ * @import { FormOverviewMetric, FormTotalsMetric } from '@defra/forms-model'
  */

--- a/designer/server/src/models/admin/metrics-helper.test.js
+++ b/designer/server/src/models/admin/metrics-helper.test.js
@@ -48,7 +48,7 @@ describe('metrics model', () => {
 
   describe('calcChangePercentage', () => {
     it('should handle zero for current and previous', () => {
-      expect(calcChangePercentage(0, 0)).toBe('-')
+      expect(calcChangePercentage(0, 0)).toBe('0.0')
     })
     it('should handle zero for previous', () => {
       expect(calcChangePercentage(1, 0)).toBe('100')

--- a/designer/server/src/models/admin/metrics-helper.test.js
+++ b/designer/server/src/models/admin/metrics-helper.test.js
@@ -4,25 +4,26 @@ import {
   buildAriaLabel,
   buildChangePhrase,
   calcChangePercentage,
-  mapOverviewMetrics
+  mapOverviewMetrics,
+  oneDecimalPlace
 } from '~/src/models/admin/metrics-helper.js'
 
 describe('metrics model', () => {
   describe('buildAriaLabel', () => {
     it('should build label when no change from previous period', () => {
-      const label = buildAriaLabel('', 0, '0.0', 'last 7 days')
+      const label = buildAriaLabel('', 0, 0, 'last 7 days')
       expect(label).toBe('There has been no change compared to the last 7 days')
     })
 
     it('should build label when positive change from previous period', () => {
-      const label = buildAriaLabel('+', 10, '5.1', 'last 7 days')
+      const label = buildAriaLabel('+', 10, 5.1, 'last 7 days')
       expect(label).toBe(
         'There has been an increase of 10 (+5.1%) compared to the last 7 days'
       )
     })
 
     it('should build label when negative change from previous period', () => {
-      const label = buildAriaLabel('-', 7, '-3.1', 'last 7 days')
+      const label = buildAriaLabel('-', 7, -3.1, 'last 7 days')
       expect(label).toBe(
         'There has been a decrease of 7 (-3.1%) compared to the last 7 days'
       )
@@ -48,13 +49,16 @@ describe('metrics model', () => {
 
   describe('calcChangePercentage', () => {
     it('should handle zero for current and previous', () => {
-      expect(calcChangePercentage(0, 0)).toBe('0.0')
+      expect(calcChangePercentage(0, 0)).toBe(0)
     })
     it('should handle zero for previous', () => {
-      expect(calcChangePercentage(1, 0)).toBe('100')
+      expect(calcChangePercentage(1, 0)).toBe(100)
     })
     it('should handle normal percentage', () => {
-      expect(calcChangePercentage(1, 2)).toBe('-50.0')
+      expect(calcChangePercentage(1, 2)).toBe(-50)
+    })
+    it('should truncate to one decimal place', () => {
+      expect(calcChangePercentage(1, 3)).toBe(-66.7)
     })
   })
 
@@ -114,6 +118,24 @@ describe('metrics model', () => {
           republished: 2
         }
       ])
+    })
+  })
+
+  describe('oneDecimalPlace', () => {
+    it('should handle zero', () => {
+      expect(oneDecimalPlace(0)).toBe(0)
+    })
+    it('should handle 1 decimal place', () => {
+      expect(oneDecimalPlace(5.2)).toBe(5.2)
+    })
+    it('should handle 2 decimal places', () => {
+      expect(oneDecimalPlace(5.26)).toBe(5.3)
+    })
+    it('should handle many decimal places', () => {
+      expect(oneDecimalPlace(5.2169034)).toBe(5.2)
+    })
+    it('should handle Infinity', () => {
+      expect(oneDecimalPlace(10 / 0)).toBe(Infinity)
     })
   })
 })

--- a/designer/server/src/models/admin/metrics.js
+++ b/designer/server/src/models/admin/metrics.js
@@ -52,24 +52,18 @@ export function metricsFormActivityViewModel(metrics, filterAndSort) {
       organisationList: Array.from(organisationMap, ([key, count]) => ({
         text: `${key} (${count})`,
         value: key,
-        checked:
-          !filterAndSort.org?.length ||
-          filterAndSort.org.includes(encodeURI(key))
+        checked: filterAndSort.org?.includes(encodeURI(key))
       })),
       statusList: [
         {
           text: 'Draft',
           value: 'draft',
-          checked:
-            !filterAndSort.status?.length ||
-            filterAndSort.status.includes(FormStatus.Draft)
+          checked: filterAndSort.status?.includes(FormStatus.Draft)
         },
         {
           text: 'Live',
           value: 'live',
-          checked:
-            !filterAndSort.status?.length ||
-            filterAndSort.status.includes(FormStatus.Live)
+          checked: filterAndSort.status?.includes(FormStatus.Live)
         }
       ]
     }

--- a/designer/server/src/models/admin/metrics.test.js
+++ b/designer/server/src/models/admin/metrics.test.js
@@ -14,7 +14,7 @@ import {
 function getExpectedTile(title, ariaPeriod, strapline) {
   return {
     ariaLabel: `There has been no change compared to the ${ariaPeriod}`,
-    changePercentage: '0.0',
+    changePercentage: 0,
     changeSymbol: '',
     changeValue: 0,
     count: 0,

--- a/designer/server/src/models/admin/metrics.test.js
+++ b/designer/server/src/models/admin/metrics.test.js
@@ -14,7 +14,7 @@ import {
 function getExpectedTile(title, ariaPeriod, strapline) {
   return {
     ariaLabel: `There has been no change compared to the ${ariaPeriod}`,
-    changePercentage: '-',
+    changePercentage: '0.0',
     changeSymbol: '',
     changeValue: 0,
     count: 0,

--- a/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
+++ b/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
@@ -542,7 +542,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -562,7 +562,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -582,7 +582,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -609,7 +609,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -630,7 +630,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -660,7 +660,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -680,7 +680,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -700,7 +700,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -727,7 +727,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -748,7 +748,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -778,7 +778,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -798,7 +798,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -818,7 +818,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -845,7 +845,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -866,7 +866,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (-%)
+            0 (0.0%)
           </strong>
     
         </div>
@@ -907,7 +907,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
   Apply filters
 </button>
 
-        <button type="submit" name="action" value="clear" class="govuk-link govuk-link--no-visited-state pull-right govuk-!-padding-top-2">Clear filters</button>
+        <button type="submit" name="action" value="clear" class="govuk-button govuk-button--secondary pull-right govuk-!-padding-top-2">Clear filters</button>
 
   <div class="govuk-form-group">
   <label class="govuk-label govuk-label--m" for="searchText">
@@ -924,13 +924,13 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
   </legend>
   <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="status" name="status" type="checkbox" value="draft" checked>
+      <input class="govuk-checkboxes__input" id="status" name="status" type="checkbox" value="draft">
       <label class="govuk-label govuk-checkboxes__label" for="status">
         Draft
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="status-2" name="status" type="checkbox" value="live" checked>
+      <input class="govuk-checkboxes__input" id="status-2" name="status" type="checkbox" value="live">
       <label class="govuk-label govuk-checkboxes__label" for="status-2">
         Live
       </label>
@@ -947,55 +947,55 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
   </legend>
   <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org" name="org" type="checkbox" value="Animal and Plant Health Agency – APHA" checked>
+      <input class="govuk-checkboxes__input" id="org" name="org" type="checkbox" value="Animal and Plant Health Agency – APHA">
       <label class="govuk-label govuk-checkboxes__label" for="org">
         Animal and Plant Health Agency – APHA (0)
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org-2" name="org" type="checkbox" value="Centre for Environment, Fisheries and Aquaculture Science – Cefas" checked>
+      <input class="govuk-checkboxes__input" id="org-2" name="org" type="checkbox" value="Centre for Environment, Fisheries and Aquaculture Science – Cefas">
       <label class="govuk-label govuk-checkboxes__label" for="org-2">
         Centre for Environment, Fisheries and Aquaculture Science – Cefas (0)
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org-3" name="org" type="checkbox" value="Defra" checked>
+      <input class="govuk-checkboxes__input" id="org-3" name="org" type="checkbox" value="Defra">
       <label class="govuk-label govuk-checkboxes__label" for="org-3">
         Defra (0)
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org-4" name="org" type="checkbox" value="Environment Agency" checked>
+      <input class="govuk-checkboxes__input" id="org-4" name="org" type="checkbox" value="Environment Agency">
       <label class="govuk-label govuk-checkboxes__label" for="org-4">
         Environment Agency (0)
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org-5" name="org" type="checkbox" value="Forestry Commission" checked>
+      <input class="govuk-checkboxes__input" id="org-5" name="org" type="checkbox" value="Forestry Commission">
       <label class="govuk-label govuk-checkboxes__label" for="org-5">
         Forestry Commission (0)
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org-6" name="org" type="checkbox" value="Marine Management Organisation – MMO" checked>
+      <input class="govuk-checkboxes__input" id="org-6" name="org" type="checkbox" value="Marine Management Organisation – MMO">
       <label class="govuk-label govuk-checkboxes__label" for="org-6">
         Marine Management Organisation – MMO (0)
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org-7" name="org" type="checkbox" value="Natural England" checked>
+      <input class="govuk-checkboxes__input" id="org-7" name="org" type="checkbox" value="Natural England">
       <label class="govuk-label govuk-checkboxes__label" for="org-7">
         Natural England (0)
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org-8" name="org" type="checkbox" value="Rural Payments Agency – RPA" checked>
+      <input class="govuk-checkboxes__input" id="org-8" name="org" type="checkbox" value="Rural Payments Agency – RPA">
       <label class="govuk-label govuk-checkboxes__label" for="org-8">
         Rural Payments Agency – RPA (0)
       </label>
     </div>
     <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="org-9" name="org" type="checkbox" value="Veterinary Medicines Directorate – VMD" checked>
+      <input class="govuk-checkboxes__input" id="org-9" name="org" type="checkbox" value="Veterinary Medicines Directorate – VMD">
       <label class="govuk-label govuk-checkboxes__label" for="org-9">
         Veterinary Medicines Directorate – VMD (0)
       </label>

--- a/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
+++ b/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
@@ -542,7 +542,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -562,7 +562,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -582,7 +582,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -609,7 +609,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -630,7 +630,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 7 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -660,7 +660,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -680,7 +680,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -700,7 +700,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -727,7 +727,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -748,7 +748,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous 30 days">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -778,7 +778,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -798,7 +798,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -818,7 +818,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -845,7 +845,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -866,7 +866,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
           <strong class="govuk-tag " aria-label="There has been no change compared to the previous year">
-            0 (0.0%)
+            0 (0%)
           </strong>
     
         </div>
@@ -1033,7 +1033,7 @@ exports[`Form metrics routes form-metrics should render report form 1`] = `
               <th scope="col" class="govuk-table__header" aria-sort="none">Question types</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Conditions</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Sections</th>
-              <th scope="col" class="govuk-table__header" aria-sort="none">Re-published</th>
+              <th scope="col" class="govuk-table__header" aria-sort="none">Repub-lished</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Days to publish</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Features</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Submissions</th>

--- a/designer/server/src/views/admin/form-metrics-form-activity.njk
+++ b/designer/server/src/views/admin/form-metrics-form-activity.njk
@@ -70,7 +70,7 @@
   }) }}
 
 {%- set filterOptionsHtml %}
-  <button type="submit" name="action" value="clear" class="govuk-link govuk-link--no-visited-state pull-right govuk-!-padding-top-2">Clear filters</button>
+  <button type="submit" name="action" value="clear" class="govuk-button govuk-button--secondary pull-right govuk-!-padding-top-2">Clear filters</button>
 
   {{ govukInput({
     id: "searchText",

--- a/designer/server/src/views/admin/form-metrics-form-activity.njk
+++ b/designer/server/src/views/admin/form-metrics-form-activity.njk
@@ -149,7 +149,7 @@
               <th scope="col" class="govuk-table__header" aria-sort="none">Question types</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Conditions</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Sections</th>
-              <th scope="col" class="govuk-table__header" aria-sort="none">Re-published</th>
+              <th scope="col" class="govuk-table__header" aria-sort="none">Repub-lished</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Days to publish</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Features</th>
               <th scope="col" class="govuk-table__header" aria-sort="none">Submissions</th>

--- a/designer/server/src/views/admin/index.njk
+++ b/designer/server/src/views/admin/index.njk
@@ -113,12 +113,12 @@
       </ul>
 
       {% if supports.formMetricsRegen %}
-      <h2 class="govuk-heading-m">System tools</h2>
-      <ul class="govuk-list">
-          <li>
-            <a href="/admin/form-metrics-regenerate" class="govuk-link govuk-link--no-visited-state">Regenerate all form metrics</a>
-          </li>
-      </ul>
+        <h2 class="govuk-heading-m">System tools</h2>
+        <ul class="govuk-list">
+            <li>
+              <a href="/admin/form-metrics-regenerate" class="govuk-link govuk-link--no-visited-state">Regenerate all form metrics</a>
+            </li>
+        </ul>
       {% endif %}
 
     {% endif %}

--- a/designer/server/src/views/admin/index.njk
+++ b/designer/server/src/views/admin/index.njk
@@ -111,17 +111,17 @@
           </li>
         {% endif %}
       </ul>
-
-      {% if supports.formMetricsRegen %}
-        <h2 class="govuk-heading-m">System tools</h2>
-        <ul class="govuk-list">
-            <li>
-              <a href="/admin/form-metrics-regenerate" class="govuk-link govuk-link--no-visited-state">Regenerate all form metrics</a>
-            </li>
-        </ul>
-      {% endif %}
-
     {% endif %}
+
+    {% if supports.formMetricsRegen %}
+      <h2 class="govuk-heading-m">System tools</h2>
+      <ul class="govuk-list">
+          <li>
+            <a href="/admin/form-metrics-regenerate" class="govuk-link govuk-link--no-visited-state">Regenerate all form metrics</a>
+          </li>
+      </ul>
+    {% endif %}
+
   {% endcall %}
 {% endblock %}
 

--- a/designer/server/src/views/admin/index.njk
+++ b/designer/server/src/views/admin/index.njk
@@ -112,14 +112,14 @@
         {% endif %}
       </ul>
 
+      {% if supports.formMetricsRegen %}
       <h2 class="govuk-heading-m">System tools</h2>
       <ul class="govuk-list">
-        {% if supports.formMetricsRegen %}
           <li>
             <a href="/admin/form-metrics-regenerate" class="govuk-link govuk-link--no-visited-state">Regenerate all form metrics</a>
           </li>
-        {% endif %}
       </ul>
+      {% endif %}
 
     {% endif %}
   {% endcall %}

--- a/designer/server/src/views/admin/index.njk
+++ b/designer/server/src/views/admin/index.njk
@@ -87,7 +87,7 @@
       }}
     </form>
 
-    {% if supports.resetSaveAndExit or supports.deadLetterQueues or supports.formInspect %}
+    {% if supports.resetSaveAndExit or supports.deadLetterQueues or supports.formInspect or supports.formMetrics %}
       <h2 class="govuk-heading-m">Developer tools</h2>
       <ul class="govuk-list">
         {% if supports.resetSaveAndExit %}

--- a/model/src/pages/helpers.test.ts
+++ b/model/src/pages/helpers.test.ts
@@ -2,7 +2,8 @@ import {
   buildCheckboxComponent,
   buildMarkdownComponent,
   buildPaymentComponent,
-  buildTextFieldComponent
+  buildTextFieldComponent,
+  buildUkAddressFieldComponent
 } from '~/src/__stubs__/components.js'
 import { buildDefinition } from '~/src/__stubs__/form-definition.js'
 import {
@@ -30,6 +31,7 @@ import {
   hasFormComponents,
   hasNext,
   hasPaymentQuestionInForm,
+  hasPostcodeLookupInForm,
   hasRepeater,
   hasSpecificQuestionTypeInForm,
   isEndPage,
@@ -715,6 +717,79 @@ describe('helpers', () => {
       expect(
         hasSpecificQuestionTypeInForm(definition, ComponentType.PaymentField)
       ).toBe(false)
+    })
+  })
+
+  describe('hasPostcodeLookupInForm', () => {
+    it('should return true if form contains address question with postcode lookup turned on', () => {
+      const textFieldComponent = buildTextFieldComponent()
+      const page1 = buildQuestionPage({
+        components: [textFieldComponent]
+      })
+      const addressFieldComponent = buildUkAddressFieldComponent({
+        options: { usePostcodeLookup: true }
+      })
+      const page2 = buildQuestionPage({
+        components: [addressFieldComponent]
+      })
+      const definition = buildDefinition({
+        pages: [page1, page2]
+      })
+      expect(hasPostcodeLookupInForm(definition)).toBe(true)
+    })
+
+    it('should return false if form contains address question but postcode lookup turned off', () => {
+      const textFieldComponent = buildTextFieldComponent()
+      const page1 = buildQuestionPage({
+        components: [textFieldComponent]
+      })
+      const addressFieldComponent = buildUkAddressFieldComponent({
+        options: { usePostcodeLookup: false }
+      })
+      const page2 = buildQuestionPage({
+        components: [addressFieldComponent]
+      })
+      const definition = buildDefinition({
+        pages: [page1, page2]
+      })
+      expect(hasPostcodeLookupInForm(definition)).toBe(false)
+    })
+
+    it('should return false if form contains address question but postcode lookup missing', () => {
+      const textFieldComponent = buildTextFieldComponent()
+      const page1 = buildQuestionPage({
+        components: [textFieldComponent]
+      })
+      const addressFieldComponent = buildUkAddressFieldComponent()
+      const page2 = buildQuestionPage({
+        components: [addressFieldComponent]
+      })
+      const definition = buildDefinition({
+        pages: [page1, page2]
+      })
+      expect(hasPostcodeLookupInForm(definition)).toBe(false)
+    })
+
+    it('should return false if form doesnt contain address question', () => {
+      const textFieldComponent1 = buildTextFieldComponent()
+      const page1 = buildQuestionPage({
+        components: [textFieldComponent1]
+      })
+      const textFieldComponent2 = buildTextFieldComponent()
+      const page2 = buildQuestionPage({
+        components: [textFieldComponent2]
+      })
+      const definition = buildDefinition({
+        pages: [page1, page2]
+      })
+      expect(hasPostcodeLookupInForm(definition)).toBe(false)
+    })
+
+    it('should return false if form has no pages', () => {
+      const definition = buildDefinition({
+        pages: []
+      })
+      expect(hasPostcodeLookupInForm(definition)).toBe(false)
     })
   })
 })

--- a/model/src/pages/helpers.ts
+++ b/model/src/pages/helpers.ts
@@ -155,6 +155,27 @@ export function hasPaymentQuestionInForm(definition: FormDefinition) {
 }
 
 /**
+ * Helper function to determine if the form uses postcode lookup
+ */
+export function hasPostcodeLookupInForm(definition: FormDefinition) {
+  if (definition.pages.length === 0) {
+    return false
+  }
+
+  for (const page of definition.pages) {
+    const addressField = hasComponents(page)
+      ? page.components.find(
+          (component) => component.type === ComponentType.UkAddressField
+        )
+      : undefined
+    if (addressField?.options.usePostcodeLookup) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Helper function to determine if a specific question type exists in the form
  */
 export function hasSpecificQuestionTypeInForm(
@@ -166,10 +187,10 @@ export function hasSpecificQuestionTypeInForm(
   }
 
   for (const page of definition.pages) {
-    const hasPayment = hasComponents(page)
+    const hasSpecificComponent = hasComponents(page)
       ? page.components.some((component) => component.type === componentType)
       : false
-    if (hasPayment) {
+    if (hasSpecificComponent) {
       return true
     }
   }

--- a/model/src/pages/index.ts
+++ b/model/src/pages/index.ts
@@ -15,6 +15,7 @@ export {
   hasFormComponents,
   hasNext,
   hasPaymentQuestionInForm,
+  hasPostcodeLookupInForm,
   hasRepeater,
   hasSpecificQuestionTypeInForm,
   includesFileUploadField,


### PR DESCRIPTION
Adds the following features:

- Declaration field
- Declaration in CYA (if the Markdown component is in the Summary page denoting a Declaration, the count subtracts 1 from Markdown)
- Reference number
- Postcode lookup


Ticket [DF-1091](https://eaflood.atlassian.net/browse/DF-1091)

[DF-1091]: https://eaflood.atlassian.net/browse/DF-1091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ