### PR TITLE
DF-1084: Add geospatial field min, max, and exact features schema settings

### DIFF
--- a/designer/server/src/common/constants/editor.js
+++ b/designer/server/src/common/constants/editor.js
@@ -135,7 +135,10 @@ export const QuestionAdvancedSettings =
     MinChecks: 'minChecks',
     MaxChecks: 'maxChecks',
     ExactChecks: 'exactChecks',
-    Countries: 'countries'
+    Countries: 'countries',
+    MinFeatures: 'minFeatures',
+    MaxFeatures: 'maxFeatures',
+    ExactFeatures: 'exactFeatures'
   }
 
 /**

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
@@ -81,7 +81,12 @@ export const advancedSettingsPerComponentType =
       QuestionAdvancedSettings.Classes
     ],
     HiddenField: [],
-    GeospatialField: [QuestionAdvancedSettings.Countries]
+    GeospatialField: [
+      QuestionAdvancedSettings.Countries,
+      QuestionAdvancedSettings.MinFeatures,
+      QuestionAdvancedSettings.MaxFeatures,
+      QuestionAdvancedSettings.ExactFeatures
+    ]
   })
 
 /**
@@ -366,6 +371,42 @@ export const allAdvancedSettingsFields =
           text: 'Any'
         }
       ]
+    },
+    [QuestionAdvancedSettings.ExactFeatures]: {
+      name: 'exactFeatures',
+      id: 'exactFeatures',
+      label: {
+        text: 'Exact items (optional)',
+        classes: GOVUK_LABEL__M
+      },
+      hint: {
+        text: 'The exact number of features a user must define'
+      },
+      classes: GOVUK_INPUT_WIDTH_3
+    },
+    [QuestionAdvancedSettings.MinFeatures]: {
+      name: 'minFeatures',
+      id: 'minFeatures',
+      label: {
+        text: 'Minimum items (optional)',
+        classes: GOVUK_LABEL__M
+      },
+      hint: {
+        text: 'The minimum number of features a user can define'
+      },
+      classes: GOVUK_INPUT_WIDTH_3
+    },
+    [QuestionAdvancedSettings.MaxFeatures]: {
+      name: 'maxFeatures',
+      id: 'maxFeatures',
+      label: {
+        text: 'Maximum items (optional)',
+        classes: GOVUK_LABEL__M
+      },
+      hint: {
+        text: 'The maximum number of features a user can define'
+      },
+      classes: GOVUK_INPUT_WIDTH_3
     }
   })
 

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.js
@@ -135,37 +135,43 @@ export function getAdditionalSchema(payload) {
   const schemaMapping = [
     {
       key: 'min',
-      sources: ['minLength', 'min', 'minFiles', 'minChecks'],
+      sources: ['minLength', 'min', 'minFiles', 'minChecks', 'minFeatures'],
       getValue: () =>
         payload.minLength ??
         payload.min ??
         payload.minFiles ??
-        payload.minChecks,
+        payload.minChecks ??
+        payload.minFeatures,
       shouldInclude: () =>
         payload.minLength ??
         isValueOrZero(payload.min) ??
         isValueOrZero(payload.minFiles) ??
-        isValueOrZero(payload.minChecks)
+        isValueOrZero(payload.minChecks) ??
+        isValueOrZero(payload.minFeatures)
     },
     {
       key: 'max',
-      sources: ['maxLength', 'max', 'maxFiles', 'maxChecks'],
+      sources: ['maxLength', 'max', 'maxFiles', 'maxChecks', 'maxFeatures'],
       getValue: () =>
         payload.maxLength ??
         payload.max ??
         payload.maxFiles ??
-        payload.maxChecks,
+        payload.maxChecks ??
+        payload.maxFeatures,
       shouldInclude: () =>
         payload.maxLength ??
         isValueOrZero(payload.max) ??
         payload.maxFiles ??
-        isValueOrZero(payload.maxChecks)
+        isValueOrZero(payload.maxChecks) ??
+        isValueOrZero(payload.maxFeatures)
     },
     {
       key: 'length',
-      sources: ['exactFiles', 'exactChecks'],
-      getValue: () => payload.exactFiles ?? payload.exactChecks,
-      shouldInclude: () => payload.exactFiles ?? payload.exactChecks
+      sources: ['exactFiles', 'exactChecks', 'exactFeatures'],
+      getValue: () =>
+        payload.exactFiles ?? payload.exactChecks ?? payload.exactFeatures,
+      shouldInclude: () =>
+        payload.exactFiles ?? payload.exactChecks ?? payload.exactFeatures
     },
     {
       key: 'regex',

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.test.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.test.js
@@ -299,6 +299,21 @@ describe('advanced-settings-helpers', () => {
       expect(result).toEqual({ length: '3' })
     })
 
+    it('should map minFeatures to min', () => {
+      const result = getAdditionalSchema({ minFeatures: '2' })
+      expect(result).toEqual({ min: '2' })
+    })
+
+    it('should map maxFeatures to max', () => {
+      const result = getAdditionalSchema({ maxFeatures: '5' })
+      expect(result).toEqual({ max: '5' })
+    })
+
+    it('should map exactFeatures to length', () => {
+      const result = getAdditionalSchema({ exactFeatures: '3' })
+      expect(result).toEqual({ length: '3' })
+    })
+
     it('should include regex when provided', () => {
       const result = getAdditionalSchema({ regex: '^[A-Z]{2}[0-9]{4}$' })
       expect(result).toEqual({ regex: '^[A-Z]{2}[0-9]{4}$' })

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-schemas.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-schemas.js
@@ -19,6 +19,12 @@ const EXACT_CHECKS_ERROR_MESSAGE =
   'Exact number of checkboxes must be a whole number greater than or equal to 2'
 const MINMAX_OR_EXACT_ERROR_MESSAGE =
   'Enter an exact amount or choose the minimum and maximum range allowed'
+const MIN_FEATURES_ERROR_MESSAGE =
+  'Minimum number of features must be a whole number greater than or equal to 1'
+const MAX_FEATURES_ERROR_MESSAGE =
+  'Maximum number of features must be a whole number greater than or equal to 1'
+const EXACT_FEATURES_ERROR_MESSAGE =
+  'Exact number of features must be a whole number greater than or equal to 1'
 const MAX_PRECISION = 5
 
 /**
@@ -151,5 +157,37 @@ export const allSpecificSchemas = Joi.object().keys({
     }),
     otherwise: Joi.string().optional().allow('')
   }),
-  countries: questionDetailsFullSchema.countriesSchema
+  countries: questionDetailsFullSchema.countriesSchema,
+  exactFeatures: questionDetailsFullSchema.exactFeaturesSchema
+    .when('minFeatures', {
+      is: Joi.exist(),
+      then: Joi.number().forbidden(),
+      otherwise: Joi.number().empty('').integer()
+    })
+    .messages({
+      'any.unknown': MINMAX_OR_EXACT_ERROR_MESSAGE,
+      '*': EXACT_FEATURES_ERROR_MESSAGE
+    })
+    .when('maxFeatures', {
+      is: Joi.exist(),
+      then: Joi.number().forbidden(),
+      otherwise: Joi.number().empty('').integer()
+    })
+    .messages({
+      'any.unknown': MINMAX_OR_EXACT_ERROR_MESSAGE,
+      '*': EXACT_FEATURES_ERROR_MESSAGE
+    }),
+  minFeatures: questionDetailsFullSchema.minFeaturesSchema
+    .messages({
+      'number.max':
+        'Minimum number of features cannot be greater than the maximum',
+      '*': MIN_FEATURES_ERROR_MESSAGE
+    })
+    .when('maxFeatures', {
+      is: Joi.exist(),
+      then: Joi.number().max(Joi.ref('maxFeatures'))
+    }),
+  maxFeatures: questionDetailsFullSchema.maxFeaturesSchema.messages({
+    '*': MAX_FEATURES_ERROR_MESSAGE
+  })
 })

--- a/designer/server/src/models/forms/editor-v2/page-fields.js
+++ b/designer/server/src/models/forms/editor-v2/page-fields.js
@@ -28,7 +28,10 @@ const textFieldQuestions = [
   QuestionAdvancedSettings.Suffix,
   QuestionAdvancedSettings.MinChecks,
   QuestionAdvancedSettings.MaxChecks,
-  QuestionAdvancedSettings.ExactChecks
+  QuestionAdvancedSettings.ExactChecks,
+  QuestionAdvancedSettings.MinFeatures,
+  QuestionAdvancedSettings.MaxFeatures,
+  QuestionAdvancedSettings.ExactFeatures
 ]
 
 const multiLineTextFieldQuestions = [

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
@@ -31,7 +31,7 @@ export function addDateFieldProperties(question) {
 }
 
 /**
- * @param { TextFieldComponent | MultilineTextFieldComponent | NumberFieldComponent | FileUploadFieldComponent | CheckboxesFieldComponent } question
+ * @param { TextFieldComponent | MultilineTextFieldComponent | NumberFieldComponent | FileUploadFieldComponent | CheckboxesFieldComponent | GeospatialFieldComponent } question
  */
 export function addMinMaxFieldProperties(question) {
   if (question.type === ComponentType.FileUploadField) {
@@ -46,6 +46,13 @@ export function addMinMaxFieldProperties(question) {
       exactChecks: question.schema?.length,
       minChecks: question.schema?.min,
       maxChecks: question.schema?.max
+    }
+  }
+  if (question.type === ComponentType.GeospatialField) {
+    return {
+      exactFeatures: question.schema?.length,
+      minFeatures: question.schema?.min,
+      maxFeatures: question.schema?.max
     }
   }
   return {
@@ -96,7 +103,8 @@ export function mapToQuestionOptions(question) {
     ComponentType.MultilineTextField,
     ComponentType.NumberField,
     ComponentType.FileUploadField,
-    ComponentType.CheckboxesField
+    ComponentType.CheckboxesField,
+    ComponentType.GeospatialField
   ])
   const isLocationField = isLocationFieldType(question.type)
 

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.test.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.test.js
@@ -206,6 +206,38 @@ describe('editor-v2 - question details advanced settings model', () => {
         exactChecks: 3
       })
     })
+
+    test('should add minFeatures/maxFeatures if geospatial', () => {
+      const res = addMinMaxFieldProperties({
+        type: ComponentType.GeospatialField,
+        name: '',
+        title: '',
+        options: {},
+        schema: {
+          min: 2,
+          max: 4
+        }
+      })
+      expect(res).toEqual({
+        minFeatures: 2,
+        maxFeatures: 4
+      })
+    })
+
+    test('should add exactFeatures if geospatial', () => {
+      const res = addMinMaxFieldProperties({
+        type: ComponentType.GeospatialField,
+        name: '',
+        title: '',
+        options: {},
+        schema: {
+          length: 3
+        }
+      })
+      expect(res).toEqual({
+        exactFeatures: 3
+      })
+    })
   })
 
   describe('addRegexFieldProperties', () => {

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -280,6 +280,11 @@ export interface GeospatialFieldComponent extends FormFieldBase {
     condition?: string
     countries?: GeospatialFieldOptionsCountry[]
   }
+  schema?: {
+    max?: number
+    min?: number
+    length?: number
+  }
 }
 
 // Content Fields

--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -460,6 +460,24 @@ export const countriesSchema = Joi.array()
   .single()
   .description('The country to be included in a geospatial field')
 
+export const exactFeaturesSchema = Joi.number()
+  .empty('')
+  .integer()
+  .min(1)
+  .description('Specifies the exact number of features required to be defined.')
+
+export const minFeaturesSchema = Joi.number()
+  .empty('')
+  .integer()
+  .min(1)
+  .description('Minimum number of features required to be defined.')
+
+export const maxFeaturesSchema = Joi.number()
+  .empty('')
+  .integer()
+  .min(1)
+  .description('Maximum number of features allowed to be defined.')
+
 type GenericRuleOptions<K extends string, T> = Omit<GetRuleOptions, 'args'> & {
   args: Record<K, T>
 }
@@ -652,7 +670,10 @@ export const questionDetailsFullSchema = {
   minChecksSchema,
   maxChecksSchema,
   exactChecksSchema,
-  countriesSchema
+  countriesSchema,
+  minFeaturesSchema,
+  maxFeaturesSchema,
+  exactFeaturesSchema
 }
 
 export const formEditorInputPageKeys = {

--- a/model/src/form/form-editor/types.ts
+++ b/model/src/form/form-editor/types.ts
@@ -373,6 +373,21 @@ export interface FormEditor {
    * The country restriction for geospatial questions
    */
   countries?: (GeospatialFieldOptionsCountry | 'any')[]
+
+  /**
+   * The exact number of features to define for geospatial questions
+   */
+  exactFeatures: string
+
+  /**
+   * The minimum number of features to define for geospatial questions
+   */
+  minFeatures: string
+
+  /**
+   * The maximum number of features to define for geospatial questions
+   */
+  maxFeatures: string
 }
 
 export type FormEditorInputPage = Pick<
@@ -455,6 +470,9 @@ export type FormEditorInputQuestion = Pick<
   | 'conditionalAmount'
   | 'conditionalAmountCondition'
   | 'countries'
+  | 'exactFeatures'
+  | 'minFeatures'
+  | 'maxFeatures'
 >
 
 export type FormEditorInputPageSettings = Pick<


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/DF-1084

<img width="1854" height="3045" alt="image" src="https://github.com/user-attachments/assets/1cb0a67f-8e1f-4a08-8803-fbf11862a783" />
