### PR TITLE
feat(DF-830): add paymentConditionalAmounts field to editor and tests

### DIFF
--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.js
@@ -459,9 +459,11 @@ export const hiddenFields = /** @type {FormEditorGovukFieldBaseKeys[]} */ ([
 
 export const paymentFields = /** @type {FormEditorGovukFieldBaseKeys[]} */ ([
   QuestionBaseSettings.PaymentAmount,
+  QuestionBaseSettings.PaymentConditionalAmounts,
   QuestionBaseSettings.PaymentDescription,
   QuestionBaseSettings.PaymentTestApiKey,
-  QuestionBaseSettings.PaymentLiveApiKey
+  QuestionBaseSettings.PaymentLiveApiKey,
+  QuestionBaseSettings.PaymentConditionalAmounts
 ])
 
 /**

--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.test.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.test.js
@@ -972,6 +972,36 @@ describe('editor-v2 - advanced settings fields model', () => {
     })
   })
 
+  describe('PaymentField field list', () => {
+    it('places paymentConditionalAmounts between paymentAmount and paymentDescription', () => {
+      const fields = getFieldList(
+        undefined,
+        ComponentType.PaymentField,
+        undefined,
+        buildDefinition()
+      )
+      const names = fields.map((f) => f.name)
+      const amountIdx = names.indexOf('paymentAmount')
+      const conditionalIdx = names.indexOf('paymentConditionalAmounts')
+      const descriptionIdx = names.indexOf('paymentDescription')
+      expect(conditionalIdx).toBe(amountIdx + 1)
+      expect(descriptionIdx).toBe(conditionalIdx + 1)
+    })
+
+    it('paymentConditionalAmounts field uses the custom template', () => {
+      const fields = getFieldList(
+        undefined,
+        ComponentType.PaymentField,
+        undefined,
+        buildDefinition()
+      )
+      const conditional = fields.find(
+        (f) => f.name === 'paymentConditionalAmounts'
+      )
+      expect(conditional?.customTemplate).toBe('payment-conditional-amounts')
+    })
+  })
+
   describe('getFileUploadFields', () => {
     test('should return file upload fields without validation', () => {
       const questionFields = /** @type {ComponentDef} */ ({


### PR DESCRIPTION
- Introduced paymentConditionalAmounts to the paymentFields array in base-settings-fields.js.
- Added tests to ensure paymentConditionalAmounts is correctly positioned and utilizes the custom template in base-settings-fields.test.js.