### PR TITLE
fix(payment): remove duplicate paymentConditionalAmounts field

### DIFF
--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.js
@@ -462,8 +462,7 @@ export const paymentFields = /** @type {FormEditorGovukFieldBaseKeys[]} */ ([
   QuestionBaseSettings.PaymentConditionalAmounts,
   QuestionBaseSettings.PaymentDescription,
   QuestionBaseSettings.PaymentTestApiKey,
-  QuestionBaseSettings.PaymentLiveApiKey,
-  QuestionBaseSettings.PaymentConditionalAmounts
+  QuestionBaseSettings.PaymentLiveApiKey
 ])
 
 /**

--- a/designer/server/src/models/forms/editor-v2/base-settings-fields.test.js
+++ b/designer/server/src/models/forms/editor-v2/base-settings-fields.test.js
@@ -1000,6 +1000,20 @@ describe('editor-v2 - advanced settings fields model', () => {
       )
       expect(conditional?.customTemplate).toBe('payment-conditional-amounts')
     })
+
+    it('does not render any base field more than once', () => {
+      // A duplicate entry renders the inline editor twice, which makes the
+      // browser submit conditionalAmount/conditionalAmountCondition as arrays
+      // and breaks the Joi string validator. See PR #1443.
+      const fields = getFieldList(
+        undefined,
+        ComponentType.PaymentField,
+        undefined,
+        buildDefinition()
+      )
+      const names = fields.map((f) => f.name)
+      expect(names).toEqual([...new Set(names)])
+    })
   })
 
   describe('getFileUploadFields', () => {


### PR DESCRIPTION
Removes duplicate `PaymentConditionalAmounts` entry in `paymentFields` (introduced in #1443) that caused the inline editor to render twice, breaking condition validation.