### PR TITLE
fix/df-1091: Fixed interactive preview not starting up properly

### DIFF
--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -23,7 +23,7 @@ import { preventUnicodeInEmail } from '~/src/form/utils/prevent-unicode.js'
 
 export const emailAddressNoUnicodeSchema = Joi.string()
   .trim()
-  .email()
+  .email({ tlds: { allow: false } })
   .custom((value, helpers) => preventUnicodeInEmail(value, helpers))
   .description('Email address preventing unicode characters')
 


### PR DESCRIPTION
Ticket [DF-1095](https://eaflood.atlassian.net/browse/DF-1095)

Caused by a TLD rule conflict in Joi

[DF-1095]: https://eaflood.atlassian.net/browse/DF-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ