### PR TITLE
feat/df-1086: Model changes for specific geometry types

### DIFF
--- a/model/src/components/enums.ts
+++ b/model/src/components/enums.ts
@@ -35,6 +35,12 @@ export enum GeospatialFieldOptionsCountryEnum {
   Wales = 'wales'
 }
 
+export enum GeospatialFieldGeometryTypesEnum {
+  Point = 'point',
+  Line = 'line',
+  Shape = 'shape'
+}
+
 export const PreviewTypeEnum = {
   ...ComponentType,
   Question: 'Question',

--- a/model/src/components/index.ts
+++ b/model/src/components/index.ts
@@ -1,6 +1,7 @@
 export { ComponentTypes } from '~/src/components/component-types.js'
 export {
   ComponentType,
+  GeospatialFieldGeometryTypesEnum,
   GeospatialFieldOptionsCountryEnum,
   PreviewTypeEnum
 } from '~/src/components/enums.js'

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -2,6 +2,7 @@ import { type LanguageMessages } from 'joi'
 
 import {
   type ComponentType,
+  type GeospatialFieldGeometryTypesEnum,
   type PreviewTypeEnum
 } from '~/src/components/enums.js'
 import {
@@ -279,7 +280,7 @@ export interface GeospatialFieldComponent extends FormFieldBase {
   options: FormFieldBase['options'] & {
     condition?: string
     countries?: GeospatialFieldOptionsCountry[]
-    geometryTypes?: string[]
+    geometryTypes?: GeospatialFieldGeometryTypesEnum[]
   }
   schema?: {
     max?: number

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -279,6 +279,7 @@ export interface GeospatialFieldComponent extends FormFieldBase {
   options: FormFieldBase['options'] & {
     condition?: string
     countries?: GeospatialFieldOptionsCountry[]
+    geometryTypes?: string[]
   }
   schema?: {
     max?: number

--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -3,6 +3,7 @@ import Joi, { type ArraySchema, type GetRuleOptions } from 'joi'
 import { rtrimOnly } from '~/src/common/rtrim-only.js'
 import {
   ComponentType,
+  GeospatialFieldGeometryTypesEnum,
   GeospatialFieldOptionsCountryEnum
 } from '~/src/components/enums.js'
 import {
@@ -477,6 +478,10 @@ export const maxFeaturesSchema = Joi.number()
   .integer()
   .min(1)
   .description('Maximum number of features allowed to be defined.')
+
+export const geometryTypesSchema = Joi.array()
+  .items(Joi.string().valid(...Object.values(GeospatialFieldGeometryTypesEnum)))
+  .description('The geometry types allowed in a geospatial field')
 
 type GenericRuleOptions<K extends string, T> = Omit<GetRuleOptions, 'args'> & {
   args: Record<K, T>

--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -678,7 +678,8 @@ export const questionDetailsFullSchema = {
   countriesSchema,
   minFeaturesSchema,
   maxFeaturesSchema,
-  exactFeaturesSchema
+  exactFeaturesSchema,
+  geometryTypesSchema
 }
 
 export const formEditorInputPageKeys = {

--- a/model/src/form/form-editor/types.ts
+++ b/model/src/form/form-editor/types.ts
@@ -388,6 +388,11 @@ export interface FormEditor {
    * The maximum number of features to define for geospatial questions
    */
   maxFeatures: string
+
+  /**
+   * The geometry types restriction for geospatial questions
+   */
+  geometryTypes?: string[]
 }
 
 export type FormEditorInputPage = Pick<

--- a/model/src/form/form-editor/types.ts
+++ b/model/src/form/form-editor/types.ts
@@ -1,4 +1,7 @@
-import { type ComponentType } from '~/src/components/enums.js'
+import {
+  type ComponentType,
+  type GeospatialFieldGeometryTypesEnum
+} from '~/src/components/enums.js'
 import {
   type ComponentDef,
   type GeospatialFieldOptionsCountry
@@ -392,7 +395,7 @@ export interface FormEditor {
   /**
    * The geometry types restriction for geospatial questions
    */
-  geometryTypes?: string[]
+  geometryTypes?: GeospatialFieldGeometryTypesEnum[]
 }
 
 export type FormEditorInputPage = Pick<


### PR DESCRIPTION
Add schema and model changes to allow geometry types to be specified (point, line, shape) for the geospatial map component.

This will allow work to commence on the `engine-plugin`.

A further PR will be raised to implement these model changes in the `designer` UI.

Ticket [DF-1086](https://eaflood.atlassian.net/browse/DF-1086)

[DF-1086]: https://eaflood.atlassian.net/browse/DF-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ