### PR TITLE
404 on Responses Page

### DIFF
--- a/designer/server/src/lib/forms.js
+++ b/designer/server/src/lib/forms.js
@@ -125,6 +125,18 @@ export async function getLiveFormDefinition(id, token) {
 }
 
 /**
+ * Get form definition, preferring draft over live
+ * @param {FormMetadata} metadata
+ * @param {string} token
+ */
+export function getFormDefinition(metadata, token) {
+  if (metadata.draft) {
+    return getDraftFormDefinition(metadata.id, token)
+  }
+  return getLiveFormDefinition(metadata.id, token)
+}
+
+/**
  * Retrieves a form definition version from the form manager for a given id
  * @param {string} id - the id of the form
  * @param {number} versionNumber - the version of the form

--- a/designer/server/src/lib/forms.js
+++ b/designer/server/src/lib/forms.js
@@ -129,7 +129,7 @@ export async function getLiveFormDefinition(id, token) {
  * @param {FormMetadata} metadata
  * @param {string} token
  */
-export function getFormDefinition(metadata, token) {
+export function getDraftFormDefinitionWithLiveFallback(metadata, token) {
   if (metadata.draft) {
     return getDraftFormDefinition(metadata.id, token)
   }

--- a/designer/server/src/lib/forms.test.js
+++ b/designer/server/src/lib/forms.test.js
@@ -696,7 +696,7 @@ describe('Forms library routes', () => {
       })
     })
 
-    describe('getFormDefinition', () => {
+    describe('getDraftFormDefinitionWithLiveFallback', () => {
       const token = auth.credentials.token
 
       beforeEach(() => {
@@ -710,7 +710,10 @@ describe('Forms library routes', () => {
           body: formDefinition
         })
 
-        const result = await forms.getFormDefinition(formMetadata, token)
+        const result = await forms.getDraftFormDefinitionWithLiveFallback(
+          formMetadata,
+          token
+        )
 
         const fetchGetJsonMock = /** @type {jest.Mock} */ (fetch.getJson)
         const calledUrl = /** @type {URL} */ (fetchGetJsonMock.mock.calls[0][0])
@@ -729,7 +732,7 @@ describe('Forms library routes', () => {
         })
 
         const metadataWithoutDraft = { ...formMetadata, draft: undefined }
-        const result = await forms.getFormDefinition(
+        const result = await forms.getDraftFormDefinitionWithLiveFallback(
           metadataWithoutDraft,
           token
         )

--- a/designer/server/src/lib/forms.test.js
+++ b/designer/server/src/lib/forms.test.js
@@ -696,6 +696,54 @@ describe('Forms library routes', () => {
       })
     })
 
+    describe('getFormDefinition', () => {
+      const token = auth.credentials.token
+
+      beforeEach(() => {
+        jest.clearAllMocks()
+      })
+
+      it('should fetch the draft definition when draft exists on metadata', async () => {
+        jest.spyOn(fetch, 'getJson').mockResolvedValueOnce({
+          /** @type {any} */
+          response: {},
+          body: formDefinition
+        })
+
+        const result = await forms.getFormDefinition(formMetadata, token)
+
+        const fetchGetJsonMock = /** @type {jest.Mock} */ (fetch.getJson)
+        const calledUrl = /** @type {URL} */ (fetchGetJsonMock.mock.calls[0][0])
+
+        expect(calledUrl.pathname).toBe(
+          '/forms/661e4ca5039739ef2902b214/definition/draft'
+        )
+        expect(result).toEqual(formDefinition)
+      })
+
+      it('should fetch the live definition when no draft exists on metadata', async () => {
+        jest.spyOn(fetch, 'getJson').mockResolvedValueOnce({
+          /** @type {any} */
+          response: {},
+          body: formDefinition
+        })
+
+        const metadataWithoutDraft = { ...formMetadata, draft: undefined }
+        const result = await forms.getFormDefinition(
+          metadataWithoutDraft,
+          token
+        )
+
+        const fetchGetJsonMock = /** @type {jest.Mock} */ (fetch.getJson)
+        const calledUrl = /** @type {URL} */ (fetchGetJsonMock.mock.calls[0][0])
+
+        expect(calledUrl.pathname).toBe(
+          '/forms/661e4ca5039739ef2902b214/definition'
+        )
+        expect(result).toEqual(formDefinition)
+      })
+    })
+
     describe('getFormDefinitionVersion', () => {
       const token = auth.credentials.token
 

--- a/designer/server/src/routes/forms/editor-v2/responses.js
+++ b/designer/server/src/routes/forms/editor-v2/responses.js
@@ -86,7 +86,7 @@ export default [
       const scopes = getUserScopes(auth)
 
       const metadata = await forms.get(slug, token)
-      const definition = await forms.getDraftFormDefinition(metadata.id, token)
+      const definition = await forms.getFormDefinition(metadata, token)
 
       const formId = metadata.id
 

--- a/designer/server/src/routes/forms/editor-v2/responses.js
+++ b/designer/server/src/routes/forms/editor-v2/responses.js
@@ -86,7 +86,10 @@ export default [
       const scopes = getUserScopes(auth)
 
       const metadata = await forms.get(slug, token)
-      const definition = await forms.getFormDefinition(metadata, token)
+      const definition = await forms.getDraftFormDefinitionWithLiveFallback(
+        metadata,
+        token
+      )
 
       const formId = metadata.id
 

--- a/designer/server/src/routes/forms/editor-v2/responses.test.js
+++ b/designer/server/src/routes/forms/editor-v2/responses.test.js
@@ -157,6 +157,30 @@ describe('Editor v2 responses routes', () => {
       )
       expect($error).toBeInTheDocument()
     })
+
+    test('should render page when form has no draft (live-only form)', async () => {
+      jest.mocked(forms.get).mockResolvedValueOnce({
+        ...testFormMetadata,
+        draft: undefined,
+        notificationEmail: 'test@defra.gov.uk'
+      })
+
+      const options = {
+        method: 'get',
+        url: '/library/my-form-slug/editor-v2/responses',
+        auth
+      }
+
+      const {
+        container,
+        response: { statusCode }
+      } = await renderResponse(server, options)
+
+      expect(statusCode).toBe(StatusCodes.OK)
+      expect(
+        container.getByText('Download responses as an Excel spreadsheet')
+      ).toBeInTheDocument()
+    })
   })
 
   describe('POST', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29937,15 +29937,6 @@
       "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
       "license": "ISC"
     },
-    "node_modules/preact": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.5.3.tgz",
-      "integrity": "sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",


### PR DESCRIPTION
Fixing issue with 'Page not found' on responses page when draft does not exist. This issue was caused by an attempt to build navigation from the draft version of the form which may not exist.