### PR TITLE
feat/df-1086: Advanced options for geometry type

### DIFF
--- a/designer/server/src/common/constants/editor.js
+++ b/designer/server/src/common/constants/editor.js
@@ -84,7 +84,7 @@ export const QuestionTypeDescriptions =
     },
     {
       type: ComponentType.GeospatialField,
-      description: 'Location: An area or points on a map'
+      description: 'Location: An area, a line, or points on a map'
     }
   ])
 
@@ -135,6 +135,7 @@ export const QuestionAdvancedSettings =
     MinChecks: 'minChecks',
     MaxChecks: 'maxChecks',
     ExactChecks: 'exactChecks',
+    GeometryTypes: 'geometryTypes',
     Countries: 'countries',
     MinFeatures: 'minFeatures',
     MaxFeatures: 'maxFeatures',

--- a/designer/server/src/lib/utils.js
+++ b/designer/server/src/lib/utils.js
@@ -50,6 +50,17 @@ export function isCheckboxSelected(checkboxVal) {
 }
 
 /**
+ * @param { string[] | undefined } options
+ * @param { string | undefined } value
+ */
+export function hasCheckedValue(options, value) {
+  if (!value || !options || options.length === 0) {
+    return false
+  }
+  return options.includes(value)
+}
+
+/**
  *
  * @param {string | undefined | null} str
  * @returns {boolean}

--- a/designer/server/src/lib/utils.test.js
+++ b/designer/server/src/lib/utils.test.js
@@ -21,6 +21,7 @@ import {
   getHeaders,
   getListFromComponent,
   handlePrecision,
+  hasCheckedValue,
   mapListToTextareaStr,
   noListToSave
 } from '~/src/lib/utils.js'
@@ -342,6 +343,24 @@ describe('utils', () => {
     })
     it('should accept zero (DF-832: base payment amount allows £0)', () => {
       expect(handlePrecision(0, mockHelpers, 2)).toBe(0)
+    })
+  })
+
+  describe('hasCheckedValue', () => {
+    it('should return false if options are undefined', () => {
+      expect(hasCheckedValue(undefined, 'test')).toBe(false)
+    })
+    it('should return false if no options', () => {
+      expect(hasCheckedValue([], 'test')).toBe(false)
+    })
+    it('should return false if undefined value', () => {
+      expect(hasCheckedValue(['option1'], undefined)).toBe(false)
+    })
+    it('should return false if empty value', () => {
+      expect(hasCheckedValue([''], '')).toBe(false)
+    })
+    it('should return true if value matches', () => {
+      expect(hasCheckedValue(['abc', 'def'], 'abc')).toBe(true)
     })
   })
 })

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
@@ -1,3 +1,6 @@
+import { GeospatialFieldGeometryTypesEnum } from '@defra/forms-model'
+import upperFirst from 'lodash/upperFirst.js'
+
 import { QuestionAdvancedSettings } from '~/src/common/constants/editor.js'
 import {
   GOVUK_INPUT_WIDTH_3,
@@ -82,6 +85,7 @@ export const advancedSettingsPerComponentType =
     ],
     HiddenField: [],
     GeospatialField: [
+      QuestionAdvancedSettings.GeometryTypes,
       QuestionAdvancedSettings.Countries,
       QuestionAdvancedSettings.MinFeatures,
       QuestionAdvancedSettings.MaxFeatures,
@@ -333,6 +337,23 @@ export const allAdvancedSettingsFields =
         text: 'The maximum number of checkboxes a user can select'
       },
       classes: GOVUK_INPUT_WIDTH_3
+    },
+    [QuestionAdvancedSettings.GeometryTypes]: {
+      name: 'geometryTypes',
+      id: 'geometryTypes',
+      classes: 'govuk-checkboxes--small',
+      fieldset: {
+        legend: {
+          text: 'Choose the geometry types you accept',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m'
+        }
+      },
+      formGroup: { classes: 'app-settings-checkboxes' },
+      items: Object.values(GeospatialFieldGeometryTypesEnum).map((typ) => ({
+        value: typ,
+        text: upperFirst(typ)
+      }))
     },
     [QuestionAdvancedSettings.Countries]: {
       name: 'countries',

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.js
@@ -94,6 +94,12 @@ export function getAdditionalOptions(payload) {
       shouldInclude: () => payload.paymentDescription !== undefined
     },
     {
+      key: 'geometryTypes',
+      getValue: () => payload.geometryTypes,
+      shouldInclude: () =>
+        Array.isArray(payload.geometryTypes) && payload.geometryTypes.length
+    },
+    {
       key: 'countries',
       getValue: () => payload.countries,
       shouldInclude: () =>

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-schemas.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-schemas.js
@@ -157,6 +157,16 @@ export const allSpecificSchemas = Joi.object().keys({
     }),
     otherwise: Joi.string().optional().allow('')
   }),
+  geometryTypes: Joi.when('questionType', {
+    is: 'GeospatialField',
+    then: questionDetailsFullSchema.geometryTypesSchema
+      .min(1)
+      .required()
+      .messages({
+        '*': 'Choose at least one geometry type'
+      })
+  }),
+  otherwise: Joi.array().optional(),
   countries: questionDetailsFullSchema.countriesSchema,
   exactFeatures: questionDetailsFullSchema.exactFeaturesSchema
     .when('minFeatures', {

--- a/designer/server/src/models/forms/editor-v2/page-fields.js
+++ b/designer/server/src/models/forms/editor-v2/page-fields.js
@@ -49,7 +49,8 @@ const checkBoxFieldQuestions = [
   QuestionBaseSettings.ImageTypes,
   QuestionBaseSettings.TabularDataTypes,
   QuestionBaseSettings.UsePostcodeLookup,
-  QuestionAdvancedSettings.GiveInstructions
+  QuestionAdvancedSettings.GiveInstructions,
+  QuestionAdvancedSettings.GeometryTypes
 ]
 
 const fileUploadFields = [QuestionBaseSettings.FileTypes]

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
@@ -239,9 +239,11 @@ export function advancedSettingsFields(options, question, validation) {
         ),
         items: fieldSettings.items?.map((item) => ({
           ...item,
-          checked: /** @type {string | undefined} */ (
-            formValues[fieldName]
-          )?.includes(item.value ?? '')
+          checked:
+            item.value &&
+            /** @type {string | undefined} */ (formValues[fieldName])?.includes(
+              item.value
+            )
         }))
       }
     }

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
@@ -1,4 +1,7 @@
-import { ComponentType } from '@defra/forms-model'
+import {
+  ComponentType,
+  GeospatialFieldGeometryTypesEnum
+} from '@defra/forms-model'
 
 import { isLocationFieldType } from '~/src/common/constants/component-types.js'
 import { QuestionAdvancedSettings } from '~/src/common/constants/editor.js'
@@ -6,6 +9,7 @@ import { insertValidationErrors, isCheckboxSelected } from '~/src/lib/utils.js'
 import { allAdvancedSettingsFields } from '~/src/models/forms/editor-v2/advanced-settings-fields.js'
 import { allEnhancedFields } from '~/src/models/forms/editor-v2/enhanced-fields.js'
 import { getDefaultLocationInstructions } from '~/src/models/forms/editor-v2/location-instruction-defaults.js'
+import { getFieldComponentType } from '~/src/models/forms/editor-v2/page-fields.js'
 
 /**
  * @param {NumberFieldComponent} question
@@ -156,7 +160,10 @@ export function mapToQuestionOptions(question) {
     question.type === ComponentType.GeospatialField
       ? {
           countries: /** @type {GeospatialFieldComponent} */ (question).options
-            .countries ?? ['any']
+            .countries ?? ['any'],
+          geometryTypes:
+            /** @type {GeospatialFieldComponent} */ (question).options
+              .geometryTypes ?? Object.values(GeospatialFieldGeometryTypesEnum)
         }
       : {}
 
@@ -217,6 +224,24 @@ export function advancedSettingsFields(options, question, validation) {
           checked: isCheckboxSelected(
             /** @type {string | undefined} */ (formValues[fieldName])
           )
+        }))
+      }
+    }
+
+    if (
+      getFieldComponentType(fieldSettings) === ComponentType.CheckboxesField
+    ) {
+      // Re-apply checkbox values
+      return {
+        ...fieldSettings,
+        ...insertValidationErrors(
+          formErrors ? formErrors[fieldName] : undefined
+        ),
+        items: fieldSettings.items?.map((item) => ({
+          ...item,
+          checked: /** @type {string | undefined} */ (
+            formValues[fieldName]
+          )?.includes(item.value ?? '')
         }))
       }
     }

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
@@ -5,11 +5,14 @@ import {
 
 import { isLocationFieldType } from '~/src/common/constants/component-types.js'
 import { QuestionAdvancedSettings } from '~/src/common/constants/editor.js'
-import { insertValidationErrors, isCheckboxSelected } from '~/src/lib/utils.js'
+import {
+  hasCheckedValue,
+  insertValidationErrors,
+  isCheckboxSelected
+} from '~/src/lib/utils.js'
 import { allAdvancedSettingsFields } from '~/src/models/forms/editor-v2/advanced-settings-fields.js'
 import { allEnhancedFields } from '~/src/models/forms/editor-v2/enhanced-fields.js'
 import { getDefaultLocationInstructions } from '~/src/models/forms/editor-v2/location-instruction-defaults.js'
-import { getFieldComponentType } from '~/src/models/forms/editor-v2/page-fields.js'
 
 /**
  * @param {NumberFieldComponent} question
@@ -31,6 +34,28 @@ export function addDateFieldProperties(question) {
   return {
     maxFuture: question.options.maxDaysInFuture,
     maxPast: question.options.maxDaysInPast
+  }
+}
+
+/**
+ * @param { LocationFieldComponent } question
+ */
+export function addLocationFieldProperties(question) {
+  return {
+    giveInstructions: question.options.instructionText ? 'true' : undefined,
+    instructionText: question.options.instructionText
+  }
+}
+
+/**
+ * @param { GeospatialFieldComponent } question
+ */
+export function addGeospatialFieldProperties(question) {
+  return {
+    countries: question.options.countries ?? ['any'],
+    geometryTypes:
+      question.options.geometryTypes ??
+      Object.values(GeospatialFieldGeometryTypesEnum)
   }
 }
 
@@ -147,24 +172,13 @@ export function mapToQuestionOptions(question) {
       )
     : {}
   const locationExtras = isLocationField
-    ? {
-        giveInstructions: /** @type {LocationFieldComponent} */ (question)
-          .options.instructionText
-          ? 'true'
-          : undefined,
-        instructionText: /** @type {LocationFieldComponent} */ (question)
-          .options.instructionText
-      }
+    ? addLocationFieldProperties(
+        /** @type {LocationFieldComponent} */ (question)
+      )
     : {}
   const geospatialExtras =
     question.type === ComponentType.GeospatialField
-      ? {
-          countries: /** @type {GeospatialFieldComponent} */ (question).options
-            .countries ?? ['any'],
-          geometryTypes:
-            /** @type {GeospatialFieldComponent} */ (question).options
-              .geometryTypes ?? Object.values(GeospatialFieldGeometryTypesEnum)
-        }
+      ? addGeospatialFieldProperties(question)
       : {}
 
   return {
@@ -228,9 +242,7 @@ export function advancedSettingsFields(options, question, validation) {
       }
     }
 
-    if (
-      getFieldComponentType(fieldSettings) === ComponentType.CheckboxesField
-    ) {
+    if (fieldName === QuestionAdvancedSettings.GeometryTypes) {
       // Re-apply checkbox values
       return {
         ...fieldSettings,
@@ -239,11 +251,10 @@ export function advancedSettingsFields(options, question, validation) {
         ),
         items: fieldSettings.items?.map((item) => ({
           ...item,
-          checked:
-            item.value &&
-            /** @type {string | undefined} */ (formValues[fieldName])?.includes(
-              item.value
-            )
+          checked: hasCheckedValue(
+            /** @type {string[] | undefined} */ (formValues[fieldName]),
+            item.value
+          )
         }))
       }
     }

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.test.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.test.js
@@ -456,6 +456,22 @@ describe('editor-v2 - question details advanced settings model', () => {
       expect(result[0].value).toContain('Click to add the location to the map')
     })
 
+    test('should re-apply checkbox values for geospatial fields', () => {
+      const question = /** @type {ComponentDef} */ ({
+        type: ComponentType.GeospatialField,
+        name: 'geospatial',
+        title: 'geospatial title',
+        options: {}
+      })
+      const result = advancedSettingsFields(['geometryTypes'], question)
+      expect(result).toHaveLength(1)
+      expect(result[0].items).toHaveLength(3)
+      const items = result[0]?.items ?? []
+      expect(items[0]).toEqual({ text: 'Point', value: 'point', checked: true })
+      expect(items[1]).toEqual({ text: 'Line', value: 'line', checked: true })
+      expect(items[2]).toEqual({ text: 'Shape', value: 'shape', checked: true })
+    })
+
     test('should use validation value over default for location instruction', () => {
       const question = /** @type {ComponentDef} */ ({
         type: ComponentType.OsGridRefField,

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.test.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.test.js
@@ -385,7 +385,8 @@ describe('editor-v2 - question details advanced settings model', () => {
         }
       })
       expect(res).toEqual({
-        countries: ['wales']
+        countries: ['wales'],
+        geometryTypes: ['point', 'line', 'shape']
       })
     })
   })

--- a/designer/server/src/models/forms/editor-v2/question-type.js
+++ b/designer/server/src/models/forms/editor-v2/question-type.js
@@ -130,7 +130,7 @@ const locationSubItems = [
     value: ComponentType.LatLongField
   },
   {
-    text: 'An area or points on a map',
+    text: 'An area, a line, or points on a map',
     value: ComponentType.GeospatialField
   }
 ]

--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -481,6 +481,7 @@ export const maxFeaturesSchema = Joi.number()
 
 export const geometryTypesSchema = Joi.array()
   .items(Joi.string().valid(...Object.values(GeospatialFieldGeometryTypesEnum)))
+  .single()
   .description('The geometry types allowed in a geospatial field')
 
 type GenericRuleOptions<K extends string, T> = Omit<GetRuleOptions, 'args'> & {

--- a/model/src/form/form-editor/types.ts
+++ b/model/src/form/form-editor/types.ts
@@ -477,6 +477,7 @@ export type FormEditorInputQuestion = Pick<
   | 'paymentLiveApiKey'
   | 'conditionalAmount'
   | 'conditionalAmountCondition'
+  | 'geometryTypes'
   | 'countries'
   | 'exactFeatures'
   | 'minFeatures'


### PR DESCRIPTION
Advanced options for geometry type

Defaults to all of point/line/shape when creating a new GeospatialField question.

Ticket [DF-1086](https://eaflood.atlassian.net/browse/DF-1086)

<img width="850" height="735" alt="image" src="https://github.com/user-attachments/assets/b0c2216f-0afe-4d55-986b-63d31e19e8d5" />

[DF-1086]: https://eaflood.atlassian.net/browse/DF-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ