### PR TITLE
Hotfix: allow exit pages to show inline, not at end

### DIFF
--- a/designer/server/src/models/forms/editor-v2/pages.js
+++ b/designer/server/src/models/forms/editor-v2/pages.js
@@ -251,11 +251,10 @@ export function mapPageData(slug, definition, filterOptions) {
 const DISPLAY_RANK_QUESTION = 0
 const DISPLAY_RANK_SUMMARY = 1
 const DISPLAY_RANK_PAYMENT = 2
-const DISPLAY_RANK_TERMINAL = 3
 
 /**
  * Display-order rank for the form overview listing. Mirrors the runtime flow:
- * question pages → Check your answers (Summary) → Payment → terminal/exit pages.
+ * Question pages → Check your answers (Summary) → Payment pages.
  * `pageNum` continues to come from the original definition.pages index so labels
  * are stable regardless of display order.
  * @param {Page} page
@@ -266,9 +265,6 @@ function pageDisplayRank(page) {
   }
   if (isPaymentPage(page)) {
     return DISPLAY_RANK_PAYMENT
-  }
-  if (page.controller === ControllerType.Terminal) {
-    return DISPLAY_RANK_TERMINAL
   }
   return DISPLAY_RANK_QUESTION
 }

--- a/designer/server/src/models/forms/editor-v2/pages.test.js
+++ b/designer/server/src/models/forms/editor-v2/pages.test.js
@@ -190,7 +190,7 @@ describe('editor-v2 - pages model', () => {
       })
     })
 
-    test('Terminal pages sort after Payment in the display order', () => {
+    test('Terminal pages should remain in the display order', () => {
       const def = structuredClone(testFormDefinitionWithPayment)
       def.pages.push(
         /** @type {*} */ ({
@@ -204,9 +204,8 @@ describe('editor-v2 - pages model', () => {
       )
       const res = mapPageData('slug', def, undefined)
       const titles = res.pages.map((p) => p.title)
-      expect(titles.indexOf('Payment')).toBeLessThan(
-        titles.indexOf('You cannot continue')
-      )
+      expect(titles.indexOf('You cannot continue')).toBe(0)
+      expect(titles.indexOf('Payment')).toBe(2)
     })
   })
 


### PR DESCRIPTION
Allow exit pages to show inline, not at end

Ticket [DF-1111](https://eaflood.atlassian.net/browse/DF-1111)

[DF-1111]: https://eaflood.atlassian.net/browse/DF-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ