### PR TITLE
fix/df-987: Retains list items if validation error in main save

### DIFF
--- a/designer/server/src/routes/forms/editor-v2/question-details.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.js
@@ -220,15 +220,15 @@ export function overrideStateIfJsEnabled(request) {
       'questionType' in payload
         ? /** @type {string} */ (payload.questionType)
         : undefined
+    const stateId =
+      'stateId' in params ? /** @type {string} */ (params.stateId) : 'unknown'
+    const existing = getQuestionSessionState(request.yar, stateId) ?? {}
     const listItemsData =
       'listItemsData' in payload
         ? /** @type {string} */ (payload.listItemsData)
-        : undefined
-    const stateId =
-      'stateId' in params ? /** @type {string} */ (params.stateId) : 'unknown'
+        : JSON.stringify(existing.listItems)
 
     if (jsEnabled) {
-      const existing = getQuestionSessionState(request.yar, stateId) ?? {}
       const overriddenState = buildOverriddenState(
         existing,
         questionType,

--- a/designer/server/src/routes/forms/editor-v2/question-details.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.test.js
@@ -958,7 +958,18 @@ describe('Editor v2 question details routes', () => {
         editRow: {
           expanded: false
         },
-        listItems: [],
+        listItems: [
+          {
+            text: 'option 1',
+            hint: { text: 'option 1 hint' },
+            value: 'option 1 val'
+          },
+          {
+            text: 'option 2',
+            hint: { text: 'option 2 hint' },
+            value: 'option 2 val'
+          }
+        ],
         questionType: 'RadiosField'
       }
     )


### PR DESCRIPTION
Retains list items if validation error in main save
e.g. when creating a checkbox, and you have at least one item added, but then save the question (without question name or description), a validation error is shown. However, prior to this fix, the existing list items were disappearing.

Ticket [DF-987](https://eaflood.atlassian.net/browse/DF-987)

[DF-987]: https://eaflood.atlassian.net/browse/DF-987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ