### PR TITLE
DF-1031: Add telephone number field format option

### DIFF
--- a/designer/server/src/common/constants/editor.js
+++ b/designer/server/src/common/constants/editor.js
@@ -139,7 +139,8 @@ export const QuestionAdvancedSettings =
     Countries: 'countries',
     MinFeatures: 'minFeatures',
     MaxFeatures: 'maxFeatures',
-    ExactFeatures: 'exactFeatures'
+    ExactFeatures: 'exactFeatures',
+    TelephoneNumberFormat: 'telephoneNumberFormat'
   }
 
 /**

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
@@ -448,11 +448,11 @@ export const allAdvancedSettingsFields =
       items: [
         {
           value: 'uk',
-          text: 'UK'
+          text: 'UK only'
         },
         {
           value: 'international',
-          text: 'International'
+          text: 'International only'
         },
         {
           divider: 'or'

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
@@ -3,6 +3,7 @@ import upperFirst from 'lodash/upperFirst.js'
 
 import { QuestionAdvancedSettings } from '~/src/common/constants/editor.js'
 import {
+  GOVUK_FIELDSET_LEGEND__M,
   GOVUK_INPUT_WIDTH_3,
   GOVUK_LABEL__M
 } from '~/src/models/forms/editor-v2/common.js'
@@ -349,7 +350,7 @@ export const allAdvancedSettingsFields =
         legend: {
           text: 'Choose the geometry types you accept',
           isPageHeading: false,
-          classes: 'govuk-fieldset__legend--m'
+          classes: GOVUK_FIELDSET_LEGEND__M
         }
       },
       formGroup: { classes: 'app-settings-checkboxes' },
@@ -366,7 +367,7 @@ export const allAdvancedSettingsFields =
         legend: {
           text: 'Which country must the features be in?',
           isPageHeading: false,
-          classes: 'govuk-fieldset__legend--m'
+          classes: GOVUK_FIELDSET_LEGEND__M
         }
       },
       formGroup: { classes: 'app-settings-radios' },
@@ -440,7 +441,7 @@ export const allAdvancedSettingsFields =
         legend: {
           text: 'Format of telephone number',
           isPageHeading: false,
-          classes: 'govuk-fieldset__legend--m'
+          classes: GOVUK_FIELDSET_LEGEND__M
         }
       },
       formGroup: { classes: 'app-settings-radios' },

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-config.js
@@ -50,7 +50,10 @@ export const advancedSettingsPerComponentType =
       QuestionAdvancedSettings.Classes
     ],
     UkAddressField: [],
-    TelephoneNumberField: [QuestionAdvancedSettings.Classes],
+    TelephoneNumberField: [
+      QuestionAdvancedSettings.Classes,
+      QuestionAdvancedSettings.TelephoneNumberFormat
+    ],
     EmailAddressField: [QuestionAdvancedSettings.Classes],
     Html: [],
     InsetText: [],
@@ -428,6 +431,36 @@ export const allAdvancedSettingsFields =
         text: 'The maximum number of features a user can define'
       },
       classes: GOVUK_INPUT_WIDTH_3
+    },
+    [QuestionAdvancedSettings.TelephoneNumberFormat]: {
+      name: 'telephoneNumberFormat',
+      id: 'telephoneNumberFormat',
+      classes: 'govuk-radios--small',
+      fieldset: {
+        legend: {
+          text: 'Format of telephone number',
+          isPageHeading: false,
+          classes: 'govuk-fieldset__legend--m'
+        }
+      },
+      formGroup: { classes: 'app-settings-radios' },
+      items: [
+        {
+          value: 'uk',
+          text: 'UK'
+        },
+        {
+          value: 'international',
+          text: 'International'
+        },
+        {
+          divider: 'or'
+        },
+        {
+          value: 'any',
+          text: 'Any'
+        }
+      ]
     }
   })
 

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-fields.test.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-fields.test.js
@@ -58,6 +58,12 @@ describe('editor-v2 - advanced settings fields model', () => {
         ComponentType.RadiosField
       )
     })
+
+    test('should return RadiosField for telephone number format', () => {
+      expect(getFieldComponentType({ name: 'telephoneNumberFormat' })).toBe(
+        ComponentType.RadiosField
+      )
+    })
   })
 
   describe('mapQuestionDetails', () => {

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.js
@@ -106,6 +106,12 @@ export function getAdditionalOptions(payload) {
         Array.isArray(payload.countries) &&
         payload.countries.length === 1 &&
         payload.countries[0] !== 'any'
+    },
+    {
+      key: 'format',
+      getValue: () => payload.telephoneNumberFormat,
+      shouldInclude: () =>
+        payload.telephoneNumberFormat && payload.telephoneNumberFormat !== 'any'
     }
   ]
 

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.test.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.test.js
@@ -35,6 +35,11 @@ describe('advanced-settings-helpers', () => {
       expect(result).toEqual({ suffix: ' per item' })
     })
 
+    it('should include telephoneNumberFormat when provided', () => {
+      const result = getAdditionalOptions({ telephoneNumberFormat: 'uk' })
+      expect(result).toEqual({ telephoneNumberFormat: 'uk' })
+    })
+
     it('should include countries when provided', () => {
       const result = getAdditionalOptions({ countries: ['scotland'] })
       expect(result).toEqual({ countries: ['scotland'] })

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.test.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-helpers.test.js
@@ -37,7 +37,7 @@ describe('advanced-settings-helpers', () => {
 
     it('should include telephoneNumberFormat when provided', () => {
       const result = getAdditionalOptions({ telephoneNumberFormat: 'uk' })
-      expect(result).toEqual({ telephoneNumberFormat: 'uk' })
+      expect(result).toEqual({ format: 'uk' })
     })
 
     it('should include countries when provided', () => {

--- a/designer/server/src/models/forms/editor-v2/advanced-settings-schemas.js
+++ b/designer/server/src/models/forms/editor-v2/advanced-settings-schemas.js
@@ -199,5 +199,6 @@ export const allSpecificSchemas = Joi.object().keys({
     }),
   maxFeatures: questionDetailsFullSchema.maxFeaturesSchema.messages({
     '*': MAX_FEATURES_ERROR_MESSAGE
-  })
+  }),
+  telephoneNumberFormat: questionDetailsFullSchema.telephoneNumberFormatSchema
 })

--- a/designer/server/src/models/forms/editor-v2/common.js
+++ b/designer/server/src/models/forms/editor-v2/common.js
@@ -15,6 +15,7 @@ export const SAVE = 'Save'
 export const GOVUK_LABEL__M = 'govuk-label--m'
 export const GOVUK_INPUT_WIDTH_2 = 'govuk-input--width-2'
 export const GOVUK_INPUT_WIDTH_3 = 'govuk-input--width-3'
+export const GOVUK_FIELDSET_LEGEND__M = 'govuk-fieldset__legend--m'
 export const CHANGES_SAVED_SUCCESSFULLY = 'Changes saved successfully'
 
 /**

--- a/designer/server/src/models/forms/editor-v2/page-fields.js
+++ b/designer/server/src/models/forms/editor-v2/page-fields.js
@@ -55,7 +55,10 @@ const checkBoxFieldQuestions = [
 
 const fileUploadFields = [QuestionBaseSettings.FileTypes]
 
-const radiosFieldQuestions = [QuestionAdvancedSettings.Countries]
+const radiosFieldQuestions = [
+  QuestionAdvancedSettings.Countries,
+  QuestionAdvancedSettings.TelephoneNumberFormat
+]
 
 /**
  * @param {GovukField} field

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.js
@@ -60,6 +60,15 @@ export function addGeospatialFieldProperties(question) {
 }
 
 /**
+ * @param { TelephoneNumberFieldComponent } question
+ */
+export function addTelephoneFieldProperties(question) {
+  return {
+    telephoneNumberFormat: question.options.format ?? 'any'
+  }
+}
+
+/**
  * @param { TextFieldComponent | MultilineTextFieldComponent | NumberFieldComponent | FileUploadFieldComponent | CheckboxesFieldComponent | GeospatialFieldComponent } question
  */
 export function addMinMaxFieldProperties(question) {
@@ -180,6 +189,10 @@ export function mapToQuestionOptions(question) {
     question.type === ComponentType.GeospatialField
       ? addGeospatialFieldProperties(question)
       : {}
+  const telephoneExtras =
+    question.type === ComponentType.TelephoneNumberField
+      ? addTelephoneFieldProperties(question)
+      : {}
 
   return {
     classes: /** @type {FormComponentsDef} */ (question).options.classes,
@@ -189,7 +202,8 @@ export function mapToQuestionOptions(question) {
     ...multilineExtras,
     ...regexExtras,
     ...locationExtras,
-    ...geospatialExtras
+    ...geospatialExtras,
+    ...telephoneExtras
   }
 }
 
@@ -298,6 +312,6 @@ export function enhancedFields(options, question, validation) {
  */
 
 /**
- * @import { ComponentDef, DatePartsFieldComponent, EastingNorthingFieldComponent, FileUploadFieldComponent, CheckboxesFieldComponent, FormComponentsDef, FormEditor, GovukField, LatLongFieldComponent, MonthYearFieldComponent, MultilineTextFieldComponent, NationalGridFieldNumberFieldComponent, NumberFieldComponent, OsGridRefFieldComponent, TextFieldComponent, GeospatialFieldComponent } from '@defra/forms-model'
+ * @import { ComponentDef, DatePartsFieldComponent, EastingNorthingFieldComponent, FileUploadFieldComponent, CheckboxesFieldComponent, FormComponentsDef, FormEditor, GovukField, LatLongFieldComponent, MonthYearFieldComponent, MultilineTextFieldComponent, NationalGridFieldNumberFieldComponent, NumberFieldComponent, OsGridRefFieldComponent, TextFieldComponent, GeospatialFieldComponent, TelephoneNumberFieldComponent } from '@defra/forms-model'
  * @import { ValidationFailure } from '~/src/common/helpers/types.js'
  */

--- a/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.test.js
+++ b/designer/server/src/models/forms/editor-v2/question-details-advanced-settings.test.js
@@ -389,6 +389,20 @@ describe('editor-v2 - question details advanced settings model', () => {
         geometryTypes: ['point', 'line', 'shape']
       })
     })
+
+    test('should map a telephone number field with format', () => {
+      const res = mapToQuestionOptions({
+        type: ComponentType.TelephoneNumberField,
+        name: 'phone',
+        title: 'phone title',
+        options: {
+          format: 'uk'
+        }
+      })
+      expect(res).toEqual({
+        telephoneNumberFormat: 'uk'
+      })
+    })
   })
 
   describe('advancedSettingsFields', () => {

--- a/model/src/components/enums.ts
+++ b/model/src/components/enums.ts
@@ -42,6 +42,11 @@ export enum GeospatialFieldGeometryTypesEnum {
   Shape = 'shape'
 }
 
+export enum TelephoneNumberFieldOptionsFormatEnum {
+  UK = 'uk',
+  International = 'international'
+}
+
 export const PreviewTypeEnum = {
   ...ComponentType,
   Question: 'Question',

--- a/model/src/components/index.ts
+++ b/model/src/components/index.ts
@@ -3,7 +3,8 @@ export {
   ComponentType,
   GeospatialFieldGeometryTypesEnum,
   GeospatialFieldOptionsCountryEnum,
-  PreviewTypeEnum
+  PreviewTypeEnum,
+  TelephoneNumberFieldOptionsFormatEnum
 } from '~/src/components/enums.js'
 export {
   allDocumentTypes,

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -118,10 +118,13 @@ export interface NumberFieldComponent extends FormFieldBase {
   }
 }
 
+export type TelephoneNumberFieldOptionsFormat = 'international' | 'uk'
+
 export interface TelephoneNumberFieldComponent extends FormFieldBase {
   type: ComponentType.TelephoneNumberField
   options: FormFieldBase['options'] & {
     condition?: string
+    format?: TelephoneNumberFieldOptionsFormat
     customValidationMessage?: string
   }
 }

--- a/model/src/form/form-definition/index.ts
+++ b/model/src/form/form-definition/index.ts
@@ -3,7 +3,12 @@ import JoiBase, { type CustomHelpers, type LanguageMessages } from 'joi'
 import { v4 as uuidV4 } from 'uuid'
 
 import { rtrimOnly } from '~/src/common/rtrim-only.js'
-import { ComponentType } from '~/src/components/enums.js'
+import {
+  ComponentType,
+  GeospatialFieldGeometryTypesEnum,
+  GeospatialFieldOptionsCountryEnum,
+  TelephoneNumberFieldOptionsFormatEnum
+} from '~/src/components/enums.js'
 import { isConditionalType } from '~/src/components/helpers.js'
 import {
   type ComponentDef,
@@ -621,7 +626,42 @@ export const componentSchema = Joi.object<ComponentDef>()
           .description(
             'Name of EmailAddressField to prepopulate GOV.UK Pay email'
           )
-      }).description('Email field reference - for PaymentField only')
+      }).description('Email field reference - for PaymentField only'),
+      countries: Joi.when('type', {
+        is: Joi.string().trim().valid(ComponentType.GeospatialField).required(),
+        then: Joi.array()
+          .items(
+            Joi.string().valid(
+              ...Object.values(GeospatialFieldOptionsCountryEnum)
+            )
+          )
+          .description(
+            'Country filters for geospatial data - for GeospatialField only'
+          )
+      }).description('Country filters - for GeospatialField only'),
+      geometryTypes: Joi.when('type', {
+        is: Joi.string().trim().valid(ComponentType.GeospatialField).required(),
+        then: Joi.array()
+          .items(
+            Joi.string().valid(
+              ...Object.values(GeospatialFieldGeometryTypesEnum)
+            )
+          )
+          .description(
+            'Geometry types for geospatial data - for GeospatialField only'
+          )
+      }).description('Geometry types - for GeospatialField only'),
+      format: Joi.when('type', {
+        is: Joi.string()
+          .trim()
+          .valid(ComponentType.TelephoneNumberField)
+          .required(),
+        then: Joi.string()
+          .valid(...Object.values(TelephoneNumberFieldOptionsFormatEnum))
+          .description(
+            'Format for telephone number - for TelephoneNumberField only'
+          )
+      }).description('Format - for TelephoneNumberField only')
     })
       .default({})
       .unknown(true)

--- a/model/src/form/form-editor/index.ts
+++ b/model/src/form/form-editor/index.ts
@@ -4,7 +4,8 @@ import { rtrimOnly } from '~/src/common/rtrim-only.js'
 import {
   ComponentType,
   GeospatialFieldGeometryTypesEnum,
-  GeospatialFieldOptionsCountryEnum
+  GeospatialFieldOptionsCountryEnum,
+  TelephoneNumberFieldOptionsFormatEnum
 } from '~/src/components/enums.js'
 import {
   MAX_NUMBER_OF_REPEAT_ITEMS,
@@ -484,6 +485,10 @@ export const geometryTypesSchema = Joi.array()
   .single()
   .description('The geometry types allowed in a geospatial field')
 
+export const telephoneNumberFormatSchema = Joi.string()
+  .valid(...Object.values(TelephoneNumberFieldOptionsFormatEnum), 'any')
+  .description('The format for the telephone number field')
+
 type GenericRuleOptions<K extends string, T> = Omit<GetRuleOptions, 'args'> & {
   args: Record<K, T>
 }
@@ -680,7 +685,8 @@ export const questionDetailsFullSchema = {
   minFeaturesSchema,
   maxFeaturesSchema,
   exactFeaturesSchema,
-  geometryTypesSchema
+  geometryTypesSchema,
+  telephoneNumberFormatSchema
 }
 
 export const formEditorInputPageKeys = {

--- a/model/src/form/form-editor/types.ts
+++ b/model/src/form/form-editor/types.ts
@@ -4,7 +4,8 @@ import {
 } from '~/src/components/enums.js'
 import {
   type ComponentDef,
-  type GeospatialFieldOptionsCountry
+  type GeospatialFieldOptionsCountry,
+  type TelephoneNumberFieldOptionsFormat
 } from '~/src/components/types.js'
 import { type DateDirections, type DateUnits } from '~/src/conditions/enums.js'
 import {
@@ -396,6 +397,11 @@ export interface FormEditor {
    * The geometry types restriction for geospatial questions
    */
   geometryTypes?: GeospatialFieldGeometryTypesEnum[]
+
+  /**
+   * The format restriction for telephone number questions
+   */
+  telephoneNumberFormat?: TelephoneNumberFieldOptionsFormat | 'any'
 }
 
 export type FormEditorInputPage = Pick<
@@ -482,6 +488,7 @@ export type FormEditorInputQuestion = Pick<
   | 'exactFeatures'
   | 'minFeatures'
   | 'maxFeatures'
+  | 'telephoneNumberFormat'
 >
 
 export type FormEditorInputPageSettings = Pick<


### PR DESCRIPTION
Add types and UI for new `options.format` for the `TelephoneNumberField`

<img width="1854" height="2207" alt="image" src="https://github.com/user-attachments/assets/ceaf566e-256b-4996-b0c8-6afdba97aa24" />
