### PR TITLE
feat/df-1137: Model changes and functionality to use drilldown data in metrics

### DIFF
--- a/designer/client/src/stylesheets/_metrics.scss
+++ b/designer/client/src/stylesheets/_metrics.scss
@@ -29,11 +29,11 @@
 }
 
 // GOV.UK Publishing Components big number styles
-.gem-c-big-number {
+.app-c-big-number {
   margin-bottom: 0;
 }
 
-.gem-c-big-number__value {
+.app-c-big-number__value {
   display: block;
   font-size: 3rem;
   font-weight: 700;
@@ -43,12 +43,12 @@
 }
 
 @media (min-width: 40.0625em) {
-  .gem-c-big-number__value {
+  .app-c-big-number__value {
     font-size: 3.5rem;
   }
 }
 
-.gem-c-big-number__label {
+.app-c-big-number__label {
   display: block;
   font-size: 1rem;
   font-weight: 600;
@@ -103,7 +103,7 @@
 }
 
 // Ensure consistent vertical alignment
-.app-metric-tile .gem-c-big-number {
+.app-metric-tile .app-c-big-number {
   flex: 1 0 auto;
 }
 

--- a/designer/server/src/common/components/metrics-tile/template.njk
+++ b/designer/server/src/common/components/metrics-tile/template.njk
@@ -11,12 +11,12 @@
 <!-- Metrics tile -->
 <div class="{{ tileClasses }}" data-testid="{{ metricTestId }}">
   <div class="app-metric-tile">
-    <div class="gem-c-big-number">
-      <span class="gem-c-big-number__label">{{ params.title }}</span>
+    <div class="app-c-big-number">
+      <span class="app-c-big-number__label">{{ params.title }}</span>
       {% if params.count > 0 and params.drillDown.enabled %}
-        <span class="gem-c-big-number__value"><a href="{{ params.drillDown.url }}" class="govuk-link govuk-link--no-visited-state">{{ params.count | formatNumber }}{{ units | safe }}</a></span>
+        <span class="app-c-big-number__value"><a href="{{ params.drillDown.url }}" class="govuk-link govuk-link--no-visited-state">{{ params.count | formatNumber }}{{ units | safe }}</a></span>
       {% else %}
-        <span class="gem-c-big-number__value">{{ params.count | formatNumber }}{{ units | safe }}</span>
+        <span class="app-c-big-number__value">{{ params.count | formatNumber }}{{ units | safe }}</span>
       {% endif %}
       </span>
     </div>

--- a/designer/server/src/common/components/metrics-tile/template.njk
+++ b/designer/server/src/common/components/metrics-tile/template.njk
@@ -6,18 +6,17 @@
   {% set changeSymbolPercent = '' %}
 {% endif %}
 {% set metricTestId = params.testId or ('headline-column-' + (params.title | lower | replace(' ', '-'))) %}
+{% set tileClasses = params.classes if params.classes else "govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" %}
+{% set units = '<span class="app-big-number-unit"> ' + params.units + '</span>' if params.units else '' %}
 <!-- Metrics tile -->
-<div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="{{ metricTestId }}">
+<div class="{{ tileClasses }}" data-testid="{{ metricTestId }}">
   <div class="app-metric-tile">
     <div class="gem-c-big-number">
       <span class="gem-c-big-number__label">{{ params.title }}</span>
       {% if params.count > 0 and params.drillDown.enabled %}
-        <span class="gem-c-big-number__value"><a href="{{ params.drillDown.url }}" class="govuk-link govuk-link--no-visited-state">{{ params.count | formatNumber }}</a></span>
+        <span class="gem-c-big-number__value"><a href="{{ params.drillDown.url }}" class="govuk-link govuk-link--no-visited-state">{{ params.count | formatNumber }}{{ units | safe }}</a></span>
       {% else %}
-        <span class="gem-c-big-number__value">{{ params.count | formatNumber }}</span>
-      {% endif %}
-      {% if params.units %}
-      <span class="app-big-number-unit">{{ params.units }}</span>
+        <span class="gem-c-big-number__value">{{ params.count | formatNumber }}{{ units | safe }}</span>
       {% endif %}
       </span>
     </div>

--- a/designer/server/src/lib/metrics.js
+++ b/designer/server/src/lib/metrics.js
@@ -47,6 +47,24 @@ export async function getMetrics(filter = {}) {
 }
 
 /**
+ * Get drilldown metrics (details within a tile)
+ * @param {string} period
+ * @param {FormMetricName} metricName
+ */
+export async function getDrilldownMetrics(period, metricName) {
+  const getJsonByType =
+    /** @type {typeof getJson<{ drilldownRows: FormDrilldownMetric[] }>} */ (
+      getJson
+    )
+
+  const requestUrl = new URL(`${period}/${metricName}`, metricsEndpoint)
+
+  const { body } = await getJsonByType(requestUrl)
+
+  return body.drilldownRows
+}
+
+/**
  * Regenerate the full set of metrics afresh (clears the 'mertics' DB and repopulates)
  * @param {string} token
  */
@@ -58,6 +76,6 @@ export async function regenerateMetrics(token) {
 }
 
 /**
- * @import { FormOverviewMetric, FormTotalsMetric } from '@defra/forms-model'
+ * @import { FormDrilldownMetric, FormMetricName, FormOverviewMetric, FormTotalsMetric } from '@defra/forms-model'
  * @import { FilterCriteria } from '~/src/models/admin/metrics-helper.js'
  */

--- a/designer/server/src/lib/metrics.test.js
+++ b/designer/server/src/lib/metrics.test.js
@@ -1,10 +1,16 @@
+import { FormMetricName } from '@defra/forms-model'
+
 import config from '~/src/config.js'
 import {
   createMockResponse,
   mockedGetJson,
   mockedPostJson
 } from '~/src/lib/__stubs__/editor.js'
-import { getMetrics, regenerateMetrics } from '~/src/lib/metrics.js'
+import {
+  getDrilldownMetrics,
+  getMetrics,
+  regenerateMetrics
+} from '~/src/lib/metrics.js'
 
 jest.mock('~/src/lib/fetch.js')
 
@@ -44,6 +50,27 @@ describe('metrics.js', () => {
         org: ['Org1', 'Org2']
       })
       expect(result.overview).toEqual([])
+
+      const calledUrl = mockedGetJson.mock.calls[0][0]
+      expect(calledUrl.href).toBe(expectedUrl.href)
+    })
+  })
+
+  describe('getDrilldownMetrics', () => {
+    it('should call endpoint', async () => {
+      mockedGetJson.mockResolvedValueOnce({
+        response: createMockResponse(),
+        body: { drilldownRows: [] }
+      })
+      const expectedUrl = new URL(
+        '/report/last7Days/NewFormsCreated',
+        auditEndpoint
+      )
+      const result = await getDrilldownMetrics(
+        'last7Days',
+        FormMetricName.NewFormsCreated
+      )
+      expect(result).toEqual([])
 
       const calledUrl = mockedGetJson.mock.calls[0][0]
       expect(calledUrl.href).toBe(expectedUrl.href)

--- a/designer/server/src/models/admin/metrics-helper.js
+++ b/designer/server/src/models/admin/metrics-helper.js
@@ -91,7 +91,7 @@ const formStructureMetricNames =
  * @property {boolean} grouped - true if drill down results are to be grouped per form
  * @property {string} displayName - display name for metric
  * @property {{ text: string, attributes?: Record<string, string> }} [headers] - custom headers for drill down
- * @property {(detail: FormTimelineMetric) => { text: string, attributes?: Record<string, string | number> }} [valueFunc] - function to return custom value
+ * @property {(detail: FormDrilldownMetric) => { text: string, attributes?: Record<string, string | number> }} [valueFunc] - function to return custom value
  */
 
 /**
@@ -603,5 +603,5 @@ export function numberCell(num) {
 }
 
 /**
- * @import { FormOverviewMetric, FormTimelineMetric, FormTotalsMetric } from '@defra/forms-model'
+ * @import { FormDrilldownMetric, FormOverviewMetric, FormTotalsMetric } from '@defra/forms-model'
  */

--- a/designer/server/src/models/admin/metrics.js
+++ b/designer/server/src/models/admin/metrics.js
@@ -49,6 +49,12 @@ const periodSlugs = /** @type {Record<string, string>} */ ({
   'all-time': 'allTime'
 })
 
+const FORM_NOT_FOUND = {
+  name: 'Form not found',
+  slug: 'not-found',
+  organisation: 'Unknown'
+}
+
 /**
  * @param {{ overview: FormOverviewMetric[], totals: FormTotalsMetric }} metrics
  * @param {FilterAndSortCriteria} filterAndSort
@@ -117,25 +123,37 @@ export function sortMetricRows(rows, { sortCol, sortDir }) {
 }
 
 /**
- * @param {{ overview: FormOverviewMetric[], totals: FormTotalsMetric }} metrics
+ * @param {string} periodSlug
+ */
+export function getPeriodNameFromSlug(periodSlug) {
+  return periodSlugs[periodSlug]
+}
+
+/**
+ * @param {{ overview: FormOverviewMetric[], totals: FormTotalsMetric }} tileMetrics
+ * @param {FormDrilldownMetric[]} drilldownMetrics
  * @param {string} period
  * @param {FormMetricName} metricName
  */
-export function metricsDrilldownViewModel(metrics, period, metricName) {
+export function metricsDrilldownViewModel(
+  tileMetrics,
+  drilldownMetrics,
+  period,
+  metricName
+) {
   const overviewMetrics = /** @type {Record<string, any>} */ (
-    mapTotalMetrics(metrics.totals, tilePeriodNames)
+    mapTotalMetrics(tileMetrics.totals, tilePeriodNames)
   )
-  const periodSelector = periodSlugs[period]
+  const periodSelector = getPeriodNameFromSlug(period)
   const periodDetails = overviewMetrics[periodSelector]
-  const totals = /** @type {Record<string, any>} */ (metrics.totals)
-  const details = totals[periodSelector][metricName].details
+
   const table = {
     classes: 'moj-scrollable-pane',
     attributes: {
       'data-module': 'moj-sortable-table'
     },
     firstCellIsHeader: true,
-    ...createDrilldownHeaderAndRows(metrics, metricName, details)
+    ...createDrilldownHeaderAndRows(tileMetrics, metricName, drilldownMetrics)
   }
 
   const tileConfig = MetricsTileConfig[metricName]
@@ -151,7 +169,7 @@ export function metricsDrilldownViewModel(metrics, period, metricName) {
 /**
  * @param {{ overview: FormOverviewMetric[], totals: FormTotalsMetric }} metrics
  * @param {FormMetricName} metricName
- * @param {FormTimelineMetric[]} details
+ * @param {FormDrilldownMetric[]} details
  */
 export function createDrilldownHeaderAndRows(metrics, metricName, details) {
   const formMap = new Map()
@@ -192,22 +210,20 @@ export function createDrilldownHeaderAndRows(metrics, metricName, details) {
       countsMap.set(detail.formId, newTotal)
     })
     countsMap.keys().forEach((formId) => {
-      const formNameInfo = formMap.get(formId)
-      if (formNameInfo) {
-        rows.push([
-          {
-            html: `<a href="/library/${formNameInfo.slug}" class="govuk-link govuk-link--no-visited-state">${formNameInfo.name}</a>`
-          },
-          { text: formNameInfo.organisation },
-          { ...numberCell(countsMap.get(formId) ?? 0) }
-        ])
-      }
+      const formNameInfo = formMap.get(formId) ?? FORM_NOT_FOUND
+      rows.push([
+        {
+          html: `<a href="/library/${formNameInfo.slug}" class="govuk-link govuk-link--no-visited-state">${formNameInfo.name}</a>`
+        },
+        { text: formNameInfo.organisation },
+        { ...numberCell(countsMap.get(formId) ?? 0) }
+      ])
     })
   } else {
     // Not grouped
     details.forEach((detail) => {
-      const formNameInfo = formMap.get(detail.formId)
-      if (formNameInfo && tileConfig.drillDown.valueFunc) {
+      const formNameInfo = formMap.get(detail.formId) ?? FORM_NOT_FOUND
+      if (tileConfig.drillDown.valueFunc) {
         rows.push([
           {
             html: `<a href="/library/${formNameInfo.slug}" class="govuk-link govuk-link--no-visited-state">${formNameInfo.name}</a>`
@@ -315,6 +331,6 @@ export function combineModel(combinedElement, liveElement, typeKeyName) {
 }
 
 /**
- * @import { FormMetricName, FormOverviewMetric, FormTimelineMetric, FormTotalsMetric } from '@defra/forms-model'
+ * @import { FormDrilldownMetric, FormMetricName, FormOverviewMetric, FormTimelineMetric, FormTotalsMetric } from '@defra/forms-model'
  * @import { ComponentUsageQuestionType, ComponentUsageFeature, ComponentUsageFormStructure, FilterAndSortCriteria , FilterCriteria, FormTilesView, SortCriteria, TableRowMetric} from '~/src/models/admin/metrics-helper.js'
  */

--- a/designer/server/src/models/admin/metrics.test.js
+++ b/designer/server/src/models/admin/metrics.test.js
@@ -665,6 +665,11 @@ describe('metrics models', () => {
               slug: 'form-3',
               organisation: 'Org 2'
             }
+          },
+          {
+            formId: 'form-id-1',
+            formStatus: FormStatus.Live,
+            summaryMetrics: {}
           }
         ]
       }
@@ -681,6 +686,10 @@ describe('metrics models', () => {
           {
             formId: 'form-id-1',
             metricValue: 990
+          },
+          {
+            formId: 'form-id-unknown',
+            metricValue: 4
           }
         ]
         const res = createDrilldownHeaderAndRows(
@@ -726,6 +735,20 @@ describe('metrics models', () => {
                   'data-sort-value': 2
                 },
                 text: '2'
+              }
+            ],
+            [
+              {
+                html: '<a href="/library/not-found" class="govuk-link govuk-link--no-visited-state">Form not found</a>'
+              },
+              {
+                text: 'Unknown'
+              },
+              {
+                attributes: {
+                  'data-sort-value': 4
+                },
+                text: '4'
               }
             ]
           ]

--- a/designer/server/src/models/admin/metrics.test.js
+++ b/designer/server/src/models/admin/metrics.test.js
@@ -764,6 +764,10 @@ describe('metrics models', () => {
           {
             formId: 'form-id-3',
             createdAt: new Date('2026-03-02T08:00:00.000Z')
+          },
+          {
+            formId: 'form-id-unknown',
+            createdAt: new Date('2026-03-02T08:00:00.000Z')
           }
         ]
         const res = createDrilldownHeaderAndRows(
@@ -806,6 +810,20 @@ describe('metrics models', () => {
               },
               {
                 text: 'Org 2'
+              },
+              {
+                attributes: {
+                  'data-sort-value': '2026-03-02 08:00:00'
+                },
+                text: '02 Mar 2026 8:00 am'
+              }
+            ],
+            [
+              {
+                html: '<a href="/library/not-found" class="govuk-link govuk-link--no-visited-state">Form not found</a>'
+              },
+              {
+                text: 'Unknown'
               },
               {
                 attributes: {

--- a/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
+++ b/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
@@ -910,9 +910,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-new-forms-created">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">New forms created</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">New forms created</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -930,9 +930,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-forms-first-published">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Forms first published</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Forms first published</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -950,9 +950,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-form-re-published">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Form re-published</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Form re-published</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -970,9 +970,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-form-submissions">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Form submissions</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Form submissions</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -997,9 +997,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-forms-in-draft">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Forms in draft</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Forms in draft</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1017,9 +1017,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-average-time-to-publish">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Average time to publish</span>
-            <span class="gem-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Average time to publish</span>
+            <span class="app-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1048,9 +1048,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-new-forms-created">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">New forms created</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">New forms created</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1068,9 +1068,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-forms-first-published">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Forms first published</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Forms first published</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1088,9 +1088,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-form-re-published">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Form re-published</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Form re-published</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1108,9 +1108,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-form-submissions">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Form submissions</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Form submissions</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1135,9 +1135,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-forms-in-draft">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Forms in draft</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Forms in draft</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1155,9 +1155,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-average-time-to-publish">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Average time to publish</span>
-            <span class="gem-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Average time to publish</span>
+            <span class="app-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1186,9 +1186,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-new-forms-created">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">New forms created</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">New forms created</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1206,9 +1206,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-forms-first-published">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Forms first published</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Forms first published</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1226,9 +1226,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-form-re-published">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Form re-published</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Form re-published</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1246,9 +1246,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-form-submissions">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Form submissions</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Form submissions</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1273,9 +1273,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-forms-in-draft">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Forms in draft</span>
-            <span class="gem-c-big-number__value">0</span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Forms in draft</span>
+            <span class="app-c-big-number__value">0</span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1293,9 +1293,9 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
         <!-- Metrics tile -->
     <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-tablet govuk-grid-column-one-quarter-from-desktop" data-testid="headline-column-average-time-to-publish">
       <div class="app-metric-tile">
-        <div class="gem-c-big-number">
-          <span class="gem-c-big-number__label">Average time to publish</span>
-            <span class="gem-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
+        <div class="app-c-big-number">
+          <span class="app-c-big-number__label">Average time to publish</span>
+            <span class="app-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">

--- a/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
+++ b/designer/server/src/routes/admin/__snapshots__/form-metrics.test.js.snap
@@ -1019,8 +1019,7 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Average time to publish</span>
-            <span class="gem-c-big-number__value">0</span>
-          <span class="app-big-number-unit">days</span>
+            <span class="gem-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1158,8 +1157,7 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Average time to publish</span>
-            <span class="gem-c-big-number__value">0</span>
-          <span class="app-big-number-unit">days</span>
+            <span class="gem-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">
@@ -1297,8 +1295,7 @@ exports[`Form metrics routes form-metrics display and filter form metrics should
       <div class="app-metric-tile">
         <div class="gem-c-big-number">
           <span class="gem-c-big-number__label">Average time to publish</span>
-            <span class="gem-c-big-number__value">0</span>
-          <span class="app-big-number-unit">days</span>
+            <span class="gem-c-big-number__value">0<span class="app-big-number-unit"> days</span></span>
           </span>
         </div>
         <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-2">

--- a/designer/server/src/routes/admin/form-metrics.js
+++ b/designer/server/src/routes/admin/form-metrics.js
@@ -8,12 +8,14 @@ import { logger } from '~/src/common/helpers/logging/logger.js'
 import { buildAdminNavigation } from '~/src/common/nunjucks/context/build-navigation.js'
 import {
   MetricsFilterFields,
+  getDrilldownMetrics,
   getMetrics,
   regenerateMetrics
 } from '~/src/lib/metrics.js'
 import { publishPlatformMetricsDownloadRequestedEvent } from '~/src/messaging/publish.js'
 import { getMetricsAsExcel } from '~/src/models/admin/metrics-excel.js'
 import {
+  getPeriodNameFromSlug,
   metricsComponentUsageViewModel,
   metricsDrilldownViewModel,
   metricsFormActivityViewModel
@@ -251,8 +253,19 @@ export default [
       const { period, metricName } = params
       const navigation = buildAdminNavigation(ADMIN_TOOLS)
 
-      const metrics = await getMetrics()
-      const model = metricsDrilldownViewModel(metrics, period, metricName)
+      const periodName = getPeriodNameFromSlug(period)
+
+      // Get tile metrics, for period ranges and form details lookups
+      const tileMetrics = await getMetrics()
+
+      const drilldownMetrics = await getDrilldownMetrics(periodName, metricName)
+
+      const model = metricsDrilldownViewModel(
+        tileMetrics,
+        drilldownMetrics,
+        period,
+        metricName
+      )
 
       return h.view('admin/form-metrics-drilldown', {
         pageTitle: `${ADMIN_TOOLS} - ${METRICS_TITLE}`,

--- a/designer/server/src/routes/admin/form-metrics.test.js
+++ b/designer/server/src/routes/admin/form-metrics.test.js
@@ -3,7 +3,7 @@ import { format } from 'date-fns'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/createServer.js'
-import { getMetrics } from '~/src/lib/metrics.js'
+import { getDrilldownMetrics, getMetrics } from '~/src/lib/metrics.js'
 import { publishPlatformMetricsDownloadRequestedEvent } from '~/src/messaging/publish.js'
 import { getMetricsAsExcel } from '~/src/models/admin/metrics-excel.js'
 import { buildQueryFromPayload } from '~/src/routes/admin/form-metrics.js'
@@ -131,8 +131,7 @@ describe('Form metrics routes', () => {
           totals: {
             last7Days: {
               Submissions: {
-                count: 0,
-                details: []
+                count: 0
               }
             },
             prev7Days: {},
@@ -149,6 +148,8 @@ describe('Form metrics routes', () => {
         }
         // @ts-expect-error - partial mock of data
         jest.mocked(getMetrics).mockResolvedValueOnce(mockMetrics)
+
+        jest.mocked(getDrilldownMetrics).mockResolvedValueOnce([])
 
         const options = {
           method: 'get',

--- a/model/src/form/form-metrics/enums.ts
+++ b/model/src/form/form-metrics/enums.ts
@@ -1,7 +1,8 @@
 export enum FormMetricType {
   TotalsMetric = 'totals-metric',
   OverviewMetric = 'overview-metric',
-  TimelineMetric = 'timeline-metric'
+  TimelineMetric = 'timeline-metric',
+  DrilldownMetric = 'drilldown-metric'
 }
 
 export enum FormMetricName {

--- a/model/src/form/form-metrics/types.ts
+++ b/model/src/form/form-metrics/types.ts
@@ -49,6 +49,15 @@ export interface FormTimelineMetric {
   createdAt: Date
 }
 
+export interface FormDrilldownMetric {
+  type: FormMetricType.DrilldownMetric
+  formId: string
+  metricName: FormMetricName
+  metricValue: number
+  periodName: string
+  createdAt: Date
+}
+
 export type FormMetric =
   | FormTotalsMetric
   | FormOverviewMetric


### PR DESCRIPTION
Pairs with PR https://github.com/DEFRA/forms-audit-api/pull/159

Drilldown data is now stored separate to the overview record, so as not to risk hitting the mongodb doc limit. This PR reads the data from a new endpoint rather than from the original overview report endpoint.

Also fixes a cosmetic bug where the unit 'days' was being incorrectly styled in the 'Average time to publish' tile