### PR TITLE
feat/df-1164: Add ref num to submission payload (optional)

### DIFF
--- a/model/src/form/form-submission/index.ts
+++ b/model/src/form/form-submission/index.ts
@@ -73,6 +73,11 @@ export const formSubmitPayloadSchema = Joi.object<SubmitPayload>()
     sessionId: Joi.string()
       .required()
       .description('User session identifier for tracking and security'),
+    referenceNumber: Joi.string()
+      // TODO - make this required in later releases - optional for now to avoid release glitches
+      .optional()
+      .allow('')
+      .description('Reference number for the form submission'),
     main: Joi.array<SubmitRecord>()
       .items(formSubmitRecordSchema)
       .required()

--- a/model/src/form/form-submission/types.ts
+++ b/model/src/form/form-submission/types.ts
@@ -72,7 +72,7 @@ export interface SubmitPayload {
   /**
    * The reference number of the user session
    */
-  referenceNumber: string
+  referenceNumber?: string
 
   /**
    * The main form anwsers

--- a/model/src/form/form-submission/types.ts
+++ b/model/src/form/form-submission/types.ts
@@ -70,6 +70,11 @@ export interface SubmitPayload {
   sessionId: string
 
   /**
+   * The reference number of the user session
+   */
+  referenceNumber: string
+
+  /**
    * The main form anwsers
    */
   main: SubmitRecord[]


### PR DESCRIPTION
Allow 'reference number' to be passed in submission payload, so it can be inserted in the CSV file.
Initially 'optional' to avoid any glitches during deployment. To be made mandatory after initial release.