### PR TITLE
fix/df-789: Remove 'offline' default value

### DIFF
--- a/model/src/form/form-metadata/index.ts
+++ b/model/src/form/form-metadata/index.ts
@@ -138,7 +138,6 @@ export const notificationEmailAddressSchema =
 
 export const offlineSchema = Joi.boolean()
   .optional()
-  .default(false)
   .description(
     'Whether the form has been taken offline and is unavailable to new sessions'
   )


### PR DESCRIPTION
Fixed an issue where changing metadata (after taking form offline) re-enabled the form.
Forms-manager requires a model bump from this PR for the fix to be implemented.