### PR TITLE
feat/df-1151: Added CYA preview panel

### DIFF
--- a/designer/client/src/javascripts/error-preview/__stubs__/error-preview.js
+++ b/designer/client/src/javascripts/error-preview/__stubs__/error-preview.js
@@ -37,3 +37,28 @@ export const panelHTML = `
           </a>
 </div>
 `
+
+export const panelCheckYourAnswersHTML = `
+<div class="govuk-tabs__panel" id="tab-cya" role="tabpanel" aria-labelledby="tab_tab-cya" tabindex="0">
+  <!-- Check Your Answers Content -->
+  <p class="govuk-body-s govuk-!-margin-bottom-4">
+    Preview of how the short description appears on the check your answers page
+  </p>
+
+  <h2 class="govuk-heading-l">Check your answers before sending your form</h2>
+  <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <span id="cya-short-description-preview1" class="error-preview-shortDescription" data-overrideplaceholder="[Short description]">[Short description]</span>
+      </dt>
+      <dd class="govuk-summary-list__value">Answer goes here</dd>
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link govuk-link--disabled" href="#" aria-disabled="true">
+            Change<span class="govuk-visually-hidden error-preview-shortDescription" id="cya-short-description-preview2" data-overrideplaceholder="[Short description]">[Short description]</span>
+          </a>
+      </dd>
+    </div>
+  </dl>
+  <button type="button" class="govuk-button" data-module="govuk-button" disabled="" data-govuk-button-init="">Accept and send</button>
+</div>
+`

--- a/designer/client/src/javascripts/error-preview/error-preview.js
+++ b/designer/client/src/javascripts/error-preview/error-preview.js
@@ -134,6 +134,11 @@ export class ErrorPreviewDomElements {
           return
         }
 
+        // Override placeholder if needed
+        if (elem.dataset.overrideplaceholder) {
+          placeholder = elem.dataset.overrideplaceholder
+        }
+
         const sourceText = Array.isArray(source)
           ? (source.find((el) => el?.value)?.value ?? '')
           : (source?.value ?? '')

--- a/designer/client/src/javascripts/error-preview/error-preview.js
+++ b/designer/client/src/javascripts/error-preview/error-preview.js
@@ -123,9 +123,9 @@ export class ErrorPreviewDomElements {
   /**
    * @param { HTMLInputElement | null | (HTMLInputElement | null)[] } source
    * @param {HTMLElementOrNull[]} targets
-   * @param {string} placeholder
+   * @param {string} defaultPlaceholder
    */
-  updateText(source, targets, placeholder) {
+  updateText(source, targets, defaultPlaceholder) {
     targets.forEach((elem) => {
       if (elem) {
         // Skip elements marked as fixed (e.g., location field base errors like "Enter easting and northing")
@@ -134,10 +134,9 @@ export class ErrorPreviewDomElements {
           return
         }
 
-        // Override placeholder if needed
-        if (elem.dataset.overrideplaceholder) {
-          placeholder = elem.dataset.overrideplaceholder
-        }
+        // Allows override of default placeholder if needed
+        const placeholder =
+          elem.dataset.overrideplaceholder ?? defaultPlaceholder
 
         const sourceText = Array.isArray(source)
           ? (source.find((el) => el?.value)?.value ?? '')

--- a/designer/client/src/javascripts/error-preview/error-preview.test.js
+++ b/designer/client/src/javascripts/error-preview/error-preview.test.js
@@ -1,6 +1,7 @@
 import { ComponentType } from '@defra/forms-model'
 
 import {
+  panelCheckYourAnswersHTML,
   panelHTML,
   shortDescInputHTML
 } from '~/src/javascripts/error-preview/__stubs__/error-preview'
@@ -93,6 +94,21 @@ describe('error-preview', () => {
       res.updateText(sourceElem, targets, '[placeholder]')
       expect(targets[0].textContent).toBe('[placeholder]')
       expect(targets[targets.length - 1].textContent).toBe('[placeholder]')
+    })
+
+    it('should updateText with override of placeholder if target has override placeholder value', () => {
+      document.body.innerHTML =
+        shortDescInputHTML + panelHTML + panelCheckYourAnswersHTML
+      const advancedFields = fieldMappings[ComponentType.TextField]
+      const res = new ErrorPreviewDomElements(advancedFields)
+      expect(res).toBeDefined()
+      const targets = /** @type {HTMLInputElement[]} */ (
+        Array.from(document.querySelectorAll('.error-preview-shortDescription'))
+      )
+      const sourceElem = document.createElement('input')
+      sourceElem.value = ''
+      res.updateText(sourceElem, targets, '[placeholder]')
+      expect(targets[5].textContent).toBe('[Short description]')
     })
 
     it('should updateText with placeholder if both sources have an empty text value', () => {

--- a/designer/server/src/common/components/preview-panel-tabs/template.njk
+++ b/designer/server/src/common/components/preview-panel-tabs/template.njk
@@ -15,6 +15,11 @@
         <a class="govuk-tabs__tab" href="#tab-errors" id="tab-errors-link" role="tab" aria-controls="tab-errors">Error messages</a>
       </li>
       {% endif %}
+      {% if params.checkYourAnswers %}
+      <li class="govuk-tabs__list-item" role="presentation">
+        <a class="govuk-tabs__tab" href="#tab-cya" id="tab-cya-link" role="tab" aria-controls="tab-errors">Check your answers</a>
+      </li>
+      {% endif %}
     </ul>
 
     <div class="govuk-tabs__panel" id="tab-preview" role="tabpanel" aria-labelledby="tab-preview-link" tabindex="0">
@@ -71,6 +76,42 @@
           }) %}
           {% endcall %}
       </div>
+
+      <div class="govuk-button-group govuk-!-margin-top-3">
+        {{ govukSkipLink({
+          text: "Skip to page overview",
+          href: "#page-overview",
+          attributes: {
+            "data-module": "govuk-skip-link"
+          }
+        }) }}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if params.checkYourAnswers %}
+      <div class="govuk-tabs__panel" id="tab-cya" role="tabpanel" aria-labelledby="tab-cya-link" tabindex="0">
+
+      <!-- Check Your Answers Content -->
+      <p class="govuk-body-s govuk-!-margin-bottom-4">
+        Preview of how the short description appears on the check your answers page
+      </p>
+
+      <h2 class="govuk-heading-l">Check your answers before sending your form</h2>
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <span id="cya-short-description-preview1" class="error-preview-shortDescription" data-overrideplaceholder="[Short description]">{{ params.checkYourAnswers.shortDescription }}</span>
+          </dt>
+          <dd class="govuk-summary-list__value">Answer goes here</dd>
+          <dd class="govuk-summary-list__actions">
+            <a class="govuk-link govuk-link--disabled" href="#" aria-disabled="true">
+                Change<span class="govuk-visually-hidden error-preview-shortDescription" id="cya-short-description-preview2" data-overrideplaceholder="[Short description]">{{ params.checkYourAnswers.shortDescription }}</span>
+              </a>
+          </dd>
+        </div>
+      </dl>
+      <button type="button" class="govuk-button" data-module="govuk-button" disabled="" data-govuk-button-init="">Accept and send</button>
 
       <div class="govuk-button-group govuk-!-margin-top-3">
         {{ govukSkipLink({

--- a/designer/server/src/common/components/preview-panel-tabs/template.njk
+++ b/designer/server/src/common/components/preview-panel-tabs/template.njk
@@ -17,7 +17,7 @@
       {% endif %}
       {% if params.checkYourAnswers %}
       <li class="govuk-tabs__list-item" role="presentation">
-        <a class="govuk-tabs__tab" href="#tab-cya" id="tab-cya-link" role="tab" aria-controls="tab-errors">Check your answers</a>
+        <a class="govuk-tabs__tab" href="#tab-cya" id="tab-cya-link" role="tab" aria-controls="tab-cya">Check your answers</a>
       </li>
       {% endif %}
     </ul>
@@ -90,7 +90,7 @@
     {% endif %}
 
     {% if params.checkYourAnswers %}
-      <div class="govuk-tabs__panel" id="tab-cya" role="tabpanel" aria-labelledby="tab-cya-link" tabindex="0">
+      <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="tab-cya" role="tabpanel" aria-labelledby="tab-cya-link" tabindex="0">
 
       <!-- Check Your Answers Content -->
       <p class="govuk-body-s govuk-!-margin-bottom-4">

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -3,7 +3,10 @@ import { createComponent } from '@defra/forms-engine-plugin/engine/components/he
 import { ComponentType, FormStatus, randomId } from '@defra/forms-model'
 
 import { isLocationFieldType } from '~/src/common/constants/component-types.js'
-import { QuestionTypeDescriptions } from '~/src/common/constants/editor.js'
+import {
+  QuestionBaseSettings,
+  QuestionTypeDescriptions
+} from '~/src/common/constants/editor.js'
 import { buildErrorList } from '~/src/common/helpers/build-error-details.js'
 import { logger } from '~/src/common/helpers/logging/logger.js'
 import { MASKED_KEY, getPaymentSecretsMasked } from '~/src/lib/secrets.js'
@@ -358,6 +361,22 @@ export async function applyPaymentValues(
 }
 
 /**
+ * @param { ComponentType | undefined } questionType
+ * @param {GovukField[]} fields
+ */
+function getCheckYourAnswers(questionType, fields) {
+  if (questionType === ComponentType.PaymentField) {
+    return undefined
+  }
+
+  return {
+    shortDescription:
+      fields.find((x) => x.name === QuestionBaseSettings.ShortDescription)
+        ?.value ?? '[Short description]'
+  }
+}
+
+/**
  * @param {{ metadata: FormMetadata, definition: FormDefinition, pageId: string, questionId: string }} formCriteria
  * @param {string} stateId
  * @param {string} token
@@ -428,6 +447,7 @@ export async function questionDetailsViewModel(
       ? getPaymentConditionalAmountsViewModel({ definition, state })
       : undefined
 
+  const checkYourAnswers = getCheckYourAnswers(questionType, basePageFields)
   return {
     listDetails: getListDetails(state, questionFieldsOverride),
     state,
@@ -441,6 +461,7 @@ export async function questionDetailsViewModel(
     extraFields,
 
     errorTemplates,
+    checkYourAnswers,
     ...getCardHeadings(details),
     navigation: details.navigation,
     errorList,

--- a/designer/server/src/models/forms/editor-v2/question-details.js
+++ b/designer/server/src/models/forms/editor-v2/question-details.js
@@ -364,7 +364,7 @@ export async function applyPaymentValues(
  * @param { ComponentType | undefined } questionType
  * @param {GovukField[]} fields
  */
-function getCheckYourAnswers(questionType, fields) {
+export function getCheckYourAnswers(questionType, fields) {
   if (questionType === ComponentType.PaymentField) {
     return undefined
   }

--- a/designer/server/src/routes/forms/editor-v2/question-details.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.test.js
@@ -44,6 +44,7 @@ import {
   getQuestionSessionState,
   setQuestionSessionState
 } from '~/src/lib/session-helper.js'
+import { getCheckYourAnswers } from '~/src/models/forms/editor-v2/question-details.js'
 import {
   buildListFromDetails,
   saveList
@@ -1692,6 +1693,32 @@ describe('Editor v2 question details routes', () => {
           savedDetails
         ).options?.conditionalAmounts ?? []
       expect(savedAmounts).toEqual([{ amount: 50, condition: 'cond-disk' }])
+    })
+  })
+
+  describe('getCheckYourAnswers', () => {
+    test('should ignore if payment question', () => {
+      expect(
+        getCheckYourAnswers(ComponentType.PaymentField, [])
+      ).toBeUndefined()
+    })
+
+    test('should used default placeholder if no shortDesc field found', () => {
+      expect(getCheckYourAnswers(ComponentType.TextField, [])).toEqual({
+        shortDescription: '[Short description]'
+      })
+    })
+
+    test('should used shortDesc value if exists', () => {
+      const fields = [
+        {
+          name: 'shortDescription',
+          value: 'my short desc value'
+        }
+      ]
+      expect(getCheckYourAnswers(ComponentType.TextField, fields)).toEqual({
+        shortDescription: 'my short desc value'
+      })
     })
   })
 })

--- a/designer/server/src/routes/forms/editor-v2/question-details.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.test.js
@@ -1703,7 +1703,7 @@ describe('Editor v2 question details routes', () => {
       ).toBeUndefined()
     })
 
-    test('should used default placeholder if no shortDesc field found', () => {
+    test('should use default placeholder if no shortDesc field found', () => {
       expect(getCheckYourAnswers(ComponentType.TextField, [])).toEqual({
         shortDescription: '[Short description]'
       })

--- a/designer/server/src/routes/forms/editor-v2/question-details.test.js
+++ b/designer/server/src/routes/forms/editor-v2/question-details.test.js
@@ -184,10 +184,11 @@ describe('Editor v2 question details routes', () => {
     expect($previewHeading).toBeInstanceOf(HTMLLabelElement)
     expect($previewHeading.getAttribute('for')).toContain('inputField')
 
-    expect($actions).toHaveLength(5)
+    expect($actions).toHaveLength(6)
     expect($actions[2]).toHaveTextContent('Preview error messages')
     expect($actions[3]).toHaveTextContent('Preview page')
     expect($actions[4]).toHaveTextContent('Save and continue')
+    expect($actions[5]).toHaveTextContent('Accept and send')
 
     const $fields = container.getAllByRole('textbox')
     expect($fields[0].id).toBe('question')
@@ -237,7 +238,7 @@ describe('Editor v2 question details routes', () => {
     expect($cardTitle).toHaveTextContent('Question 2')
     expect($cardTitle).toHaveClass('editor-card-title')
 
-    expect($actions).toHaveLength(3)
+    expect($actions).toHaveLength(4)
     expect($actions[2]).toHaveTextContent('Save and continue')
 
     const $fields = container.getAllByRole('textbox')
@@ -291,10 +292,11 @@ describe('Editor v2 question details routes', () => {
     expect($cardTitle).toHaveTextContent('Question 1')
     expect($cardTitle).toHaveClass('editor-card-title')
 
-    expect($actions).toHaveLength(5)
+    expect($actions).toHaveLength(6)
     expect($actions[2]).toHaveTextContent('Preview error messages')
     expect($actions[3]).toHaveTextContent('Preview page')
     expect($actions[4]).toHaveTextContent('Save and continue')
+    expect($actions[5]).toHaveTextContent('Accept and send')
 
     const $fields = container.getAllByRole('textbox')
     expect($fields[3].id).toBe('errorDescription')

--- a/designer/server/src/views/forms/editor-v2/partials/question-details-preview-panel.njk
+++ b/designer/server/src/views/forms/editor-v2/partials/question-details-preview-panel.njk
@@ -5,6 +5,7 @@
     previewPageUrl: previewPageUrl,
     previewErrorsUrl: previewErrorsUrl,
     errorTemplates: errorTemplates,
+    checkYourAnswers: checkYourAnswers,
     extraFields: extraFields,
     basePageFields: basePageFields,
     model: model,


### PR DESCRIPTION
Ticket [DF-1151](https://eaflood.atlassian.net/browse/DF-1151)

Re-uses JS preview framework (used for error messages preview), with a placeholder override enhancement.

[DF-1151]: https://eaflood.atlassian.net/browse/DF-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ